### PR TITLE
pin-base64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tracing-subscriber = "0"
 glob = "0"
 futures = "0"
 linked-hash-map = "0"
-base64 = "0"
+base64 = "0.22.1"
 bson = "2"
 
 [profile.release]


### PR DESCRIPTION
Only need one review but tagging two, whoever is first wins. This pins base64 to 0.22.1 for mongosql.

So...

I've finally determined the cause of release failure compared to snapshot and patch successes. The main thing we do differently in evergreen on release is use `cargo-edit` to set the package versions. This causes the lockfile to change, resulting in, for reasons unknown, base64 in `mongosql` to downgrade to 0.13.1 from 0.22.1. 

I was able to reproduce the error we're seeing in release locally, exactly as we're seeing it on evergreen. I pinned the version and it cleared the error up even after setting the version to something like 1.6.1