### PR TITLE
SQL-2357: Refine schema derivation for Addition, Subtraction, and Multiplication

### DIFF
--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -865,10 +865,12 @@ impl DeriveSchema for UntaggedOperator {
             // int + int -> int or long; int + long, long + long -> long,
             UntaggedOperatorName::Multiply => {
                 let input_schema = get_input_schema(&args, state)?;
-                if input_schema.satisfies(&Schema::Atomic(Atomic::Integer)) == Satisfaction::Must {
-                    Ok(INTEGRAL.clone())
-                } else if input_schema.satisfies(&INTEGRAL) == Satisfaction::Must {
-                    Ok(Schema::Atomic(Atomic::Long))
+                if input_schema.satisfies(&INTEGER_OR_NULLISH) == Satisfaction::Must {
+                    // If both are (nullable) Ints, the result is (nullable) Int or Long
+                    handle_null_satisfaction(args, state, INTEGRAL.clone())
+                } else if input_schema.satisfies(&INTEGER_LONG_OR_NULLISH) == Satisfaction::Must {
+                    // If both are (nullable) Ints or Longs, the result is (nullable) Long
+                    handle_null_satisfaction(args, state, Schema::Atomic(Atomic::Long))
                 } else {
                     get_decimal_double_or_nullish(args, state)
                 }

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
@@ -514,6 +514,31 @@ mod numeric_ops {
         input = r#"{"$mod": [1, 123]}"#
     );
     test_derive_schema!(
+        add_nullable_int,
+        expected = Ok(Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Long),
+            Schema::Atomic(Atomic::Null),
+        ))),
+        input = r#"{"$add": [1, "$foo"]}"#,
+        ref_schema = Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Null),
+        ))
+    );
+    test_derive_schema!(
+        add_nullable_long,
+        expected = Ok(Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Long),
+            Schema::Atomic(Atomic::Null),
+        ))),
+        input = r#"{"$add": [1, "$foo"]}"#,
+        ref_schema = Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Long),
+            Schema::Atomic(Atomic::Null),
+        ))
+    );
+    test_derive_schema!(
         add_integral,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -554,6 +579,19 @@ mod numeric_ops {
         ref_schema = Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
             Schema::Atomic(Atomic::Null),
+        ))
+    );
+    test_derive_schema!(
+        add_date_or_numeric,
+        expected = Ok(Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Date),
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Long),
+        ))),
+        input = r#"{"$add": [1, "$foo"]}"#,
+        ref_schema = Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Date),
+            Schema::Atomic(Atomic::Integer),
         ))
     );
     test_derive_schema!(

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
@@ -403,6 +403,31 @@ mod numeric_ops {
         ))
     );
     test_derive_schema!(
+        multiply_nullable_int,
+        expected = Ok(Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Long),
+            Schema::Atomic(Atomic::Null),
+        ))),
+        input = r#"{"$multiply": [1, "$foo"]}"#,
+        ref_schema = Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Null),
+        ))
+    );
+    test_derive_schema!(
+        multiply_nullable_long,
+        expected = Ok(Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Long),
+            Schema::Atomic(Atomic::Null),
+        ))),
+        input = r#"{"$multiply": [1, "$foo"]}"#,
+        ref_schema = Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Long),
+            Schema::Atomic(Atomic::Null),
+        ))
+    );
+    test_derive_schema!(
         multiply_integral,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
@@ -631,7 +631,7 @@ mod numeric_ops {
             Schema::Atomic(Atomic::Date),
             Schema::Atomic(Atomic::Null),
         ))),
-        input = r#"{"$subtract": [1, "$foo"]}"#,
+        input = r#"{"$subtract": ["$foo", 1]}"#,
         ref_schema = Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
             Schema::Atomic(Atomic::Null),
@@ -642,6 +642,44 @@ mod numeric_ops {
         expected = Ok(Schema::Atomic(Atomic::Long)),
         input = r#"{"$subtract": ["$foo", "$foo"]}"#,
         ref_schema = Schema::Atomic(Atomic::Date)
+    );
+    test_derive_schema!(
+        subtract_date_or_numeric,
+        expected = Ok(Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Date),
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Long),
+        ))),
+        input = r#"{"$subtract": ["$foo", 1]}"#,
+        ref_schema = Schema::AnyOf(set!(
+            Schema::Atomic(Atomic::Date),
+            Schema::Atomic(Atomic::Integer),
+        ))
+    );
+    test_derive_schema!(
+        subtract_multiple_numeric_pairings,
+        expected = Ok(Schema::AnyOf(set! {
+            Schema::Atomic(Atomic::Null), // since either can be missing
+            Schema::Atomic(Atomic::Long),
+            Schema::Atomic(Atomic::Double),
+        })),
+        input = r#"{"$subtract": ["$foo", "$bar"]}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::AnyOf(set!{
+                    Schema::Atomic(Atomic::Integer),
+                    Schema::Atomic(Atomic::Double),
+                }),
+                "bar".to_string() => Schema::AnyOf(set!{
+                    Schema::Atomic(Atomic::Long),
+                    Schema::Atomic(Atomic::Double),
+                }),
+            },
+            // Nullability implied by lack of requirement
+            required: set! {},
+            additional_properties: false,
+            jaccard_index: None,
+        })
     );
 }
 

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -1600,6 +1600,36 @@ impl Schema {
             _ => Schema::Unsat,
         }
     }
+
+    /// Turns a Schema into a set of the Schema it matches. Any and AnyOf return the underlying set,
+    /// all other types return singleton sets containing themselves. This is useful for getting the
+    /// cartesian product between two Schemas.
+    fn schema_set(&self) -> BTreeSet<Schema> {
+        match self {
+            Unsat
+            | Schema::Missing
+            | Schema::Atomic(_)
+            | Schema::Array(_)
+            | Schema::Document(_) => set! {self.clone()},
+            AnyOf(ao) => ao.clone(),
+            Schema::Any => UNFOLDED_ANY.schema_set(),
+        }
+    }
+
+    /// Computes the cartesian product of two Schemas. The inputs are simplified as part of this
+    /// process.
+    pub fn cartesian_product(&self, other: &Schema) -> BTreeSet<(Self, Self)> {
+        let self_schema = Schema::simplify(self);
+        let other_schema = Schema::simplify(other);
+
+        let self_set = self_schema.schema_set();
+        let other_set = other_schema.schema_set();
+
+        self_set
+            .into_iter()
+            .flat_map(|l| other_set.clone().into_iter().map(move |r| (l.clone(), r)))
+            .collect()
+    }
 }
 
 impl From<Type> for Schema {

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -1626,8 +1626,9 @@ impl Schema {
         let other_set = other_schema.schema_set();
 
         self_set
-            .into_iter()
-            .flat_map(|l| other_set.clone().into_iter().map(move |r| (l.clone(), r)))
+            .iter()
+            .cloned()
+            .cartesian_product(other_set.iter().cloned())
             .collect()
     }
 }

--- a/mongosql/src/schema/test.rs
+++ b/mongosql/src/schema/test.rs
@@ -3393,42 +3393,6 @@ mod cartesian_product {
     );
 
     test_cartesian_product!(
-        singleton_unsat,
-        expected = {
-            let s: BTreeSet<(Schema, Schema)> = set! {
-                (Unsat, Unsat)
-            };
-            s
-        },
-        schema = Unsat,
-        other = Unsat,
-    );
-
-    test_cartesian_product!(
-        singleton_documents,
-        expected = {
-            let s: BTreeSet<(Schema, Schema)> = set! {
-                (ANY_DOCUMENT.clone(), ANY_DOCUMENT.clone())
-            };
-            s
-        },
-        schema = ANY_DOCUMENT.clone(),
-        other = ANY_DOCUMENT.clone(),
-    );
-
-    test_cartesian_product!(
-        singleton_arrays,
-        expected = {
-            let s: BTreeSet<(Schema, Schema)> = set! {
-                (ANY_ARRAY.clone(), ANY_ARRAY.clone())
-            };
-            s
-        },
-        schema = ANY_ARRAY.clone(),
-        other = ANY_ARRAY.clone(),
-    );
-
-    test_cartesian_product!(
         singleton_with_any_of,
         expected = {
             let s: BTreeSet<(Schema, Schema)> = set! {

--- a/mongosql/src/schema/test.rs
+++ b/mongosql/src/schema/test.rs
@@ -3351,3 +3351,214 @@ mod intersection {
         )),
     );
 }
+
+mod cartesian_product {
+    use crate::{
+        schema::{Atomic, Schema, Schema::*, ANY_ARRAY, ANY_DOCUMENT},
+        set,
+    };
+    use std::collections::BTreeSet;
+
+    macro_rules! test_cartesian_product {
+        ($func_name:ident, expected = $expected:expr, schema = $schema:expr, other = $other:expr,) => {
+            #[test]
+            fn $func_name() {
+                assert_eq!($expected, $schema.cartesian_product(&$other));
+            }
+        };
+    }
+
+    test_cartesian_product!(
+        singleton_atomics,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (Atomic(Atomic::Integer), Atomic(Atomic::String))
+            };
+            s
+        },
+        schema = Atomic(Atomic::Integer),
+        other = Atomic(Atomic::String),
+    );
+
+    test_cartesian_product!(
+        singleton_missing,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (Missing, Missing)
+            };
+            s
+        },
+        schema = Missing,
+        other = Missing,
+    );
+
+    test_cartesian_product!(
+        singleton_unsat,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (Unsat, Unsat)
+            };
+            s
+        },
+        schema = Unsat,
+        other = Unsat,
+    );
+
+    test_cartesian_product!(
+        singleton_documents,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (ANY_DOCUMENT.clone(), ANY_DOCUMENT.clone())
+            };
+            s
+        },
+        schema = ANY_DOCUMENT.clone(),
+        other = ANY_DOCUMENT.clone(),
+    );
+
+    test_cartesian_product!(
+        singleton_arrays,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (ANY_ARRAY.clone(), ANY_ARRAY.clone())
+            };
+            s
+        },
+        schema = ANY_ARRAY.clone(),
+        other = ANY_ARRAY.clone(),
+    );
+
+    test_cartesian_product!(
+        singleton_with_any_of,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (Atomic(Atomic::Integer), Atomic(Atomic::String)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Null)),
+            };
+            s
+        },
+        schema = Atomic(Atomic::Integer),
+        other = AnyOf(set! {Atomic(Atomic::String), Atomic(Atomic::Null)}),
+    );
+
+    test_cartesian_product!(
+        any_of_with_singleton,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (Atomic(Atomic::String), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Null), Atomic(Atomic::Integer)),
+            };
+            s
+        },
+        schema = AnyOf(set! {Atomic(Atomic::String), Atomic(Atomic::Null)}),
+        other = Atomic(Atomic::Integer),
+    );
+
+    test_cartesian_product!(
+        any_ofs,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (Atomic(Atomic::String), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::String), Missing),
+                (Atomic(Atomic::Null), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Null), Missing),
+            };
+            s
+        },
+        schema = AnyOf(set! {Atomic(Atomic::String), Atomic(Atomic::Null)}),
+        other = AnyOf(set! {Atomic(Atomic::Integer), Missing}),
+    );
+
+    test_cartesian_product!(
+        nested_any_ofs,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (Atomic(Atomic::String), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::String), Missing),
+                (Atomic(Atomic::String), Atomic(Atomic::Double)),
+                (Atomic(Atomic::Date), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Date), Missing),
+                (Atomic(Atomic::Date), Atomic(Atomic::Double)),
+                (Missing, Atomic(Atomic::Integer)),
+                (Missing, Missing),
+                (Missing, Atomic(Atomic::Double)),
+                (Atomic(Atomic::Null), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Null), Missing),
+                (Atomic(Atomic::Null), Atomic(Atomic::Double)),
+            };
+            s
+        },
+        schema = AnyOf(
+            set! {Atomic(Atomic::String), AnyOf(set!{Atomic(Atomic::Date), Missing}), Atomic(Atomic::Null)}
+        ),
+        other = AnyOf(
+            set! {Atomic(Atomic::Integer), Missing, AnyOf(set!{Atomic(Atomic::Double), Missing})}
+        ),
+    );
+
+    test_cartesian_product!(
+        any_with_singleton,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (Atomic(Atomic::MinKey), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Null), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Long), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Double), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Decimal), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Symbol), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::String), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::BinData), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Undefined), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::ObjectId), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Boolean), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Date), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Timestamp), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Regex), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::DbPointer), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Javascript), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::JavascriptWithScope), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::MaxKey), Atomic(Atomic::Integer)),
+                (Missing, Atomic(Atomic::Integer)),
+                (ANY_ARRAY.clone(), Atomic(Atomic::Integer)),
+                (ANY_DOCUMENT.clone(), Atomic(Atomic::Integer)),
+            };
+            s
+        },
+        schema = Any,
+        other = Atomic(Atomic::Integer),
+    );
+
+    test_cartesian_product!(
+        singleton_with_any,
+        expected = {
+            let s: BTreeSet<(Schema, Schema)> = set! {
+                (Atomic(Atomic::Integer), Atomic(Atomic::MinKey)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Null)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Integer)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Long)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Double)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Decimal)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Symbol)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::String)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::BinData)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Undefined)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::ObjectId)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Boolean)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Date)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Timestamp)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Regex)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::DbPointer)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::Javascript)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::JavascriptWithScope)),
+                (Atomic(Atomic::Integer), Atomic(Atomic::MaxKey)),
+                (Atomic(Atomic::Integer), Missing),
+                (Atomic(Atomic::Integer), ANY_ARRAY.clone()),
+                (Atomic(Atomic::Integer), ANY_DOCUMENT.clone()),
+            };
+            s
+        },
+        schema = Atomic(Atomic::Integer),
+        other = Any,
+    );
+}


### PR DESCRIPTION
Migrated from the old private repo.

This PR updates schema derivation for addition, subtraction, and multiplication. It is still technically incomplete but I think at this point I'll file a follow-up ticket for remaining work.

My main goals were:
1. Fix multiplication to properly account for nullability. It previously did not acknowledge when it was possibly nullable and now it does.
2. Fix addition and subtraction with respect to Date arguments. The first implementation I merged under this ticket number too strictly assumed the result type would be Date in certain circumstances. Now, it returns the full set of possible types when an operand MAY or MUST be Date.

The things left to do are more precise numeric handling for Addition and Multiplication. Specifically, if you have `AnyOf(Int, Double)` and `AnyOf(Int, Double)` as operands to addition, the result is `AnyOf(Int, Long, Double)` since there could be `Int-Int`, `Int-Double`, and `Double-Double` pairings. Currently, we'd just say this is `Double`. That's not the end of the world but it is imprecise.

I _could_ address that in this ticket using the new cartesian product stuff I added for subtraction, _but_ it's not as easy for n-ary operators like addition and multiplication as it is for a binary operator like subtraction. I think a follow-up ticket that just sits in the backlog until someone has a week to properly hammer this out is the best course of action.