### PR TITLE
SQL-2618: Enable Document and Array self-comparison

### DIFF
--- a/mongosql/src/algebrizer/test.rs
+++ b/mongosql/src/algebrizer/test.rs
@@ -5146,7 +5146,7 @@ mod aggregation {
     use crate::{
         ast, map, mir, multimap,
         schema::{Atomic, Schema, ANY_DOCUMENT, NUMERIC_OR_NULLISH},
-        unchecked_unique_linked_hash_map,
+        set, unchecked_unique_linked_hash_map,
         usererror::UserError,
     };
     test_algebrize!(
@@ -5214,7 +5214,10 @@ mod aggregation {
         expected = Err(Error::SchemaChecking(
             mir::schema::Error::AggregationArgumentMustBeSelfComparable(
                 "Count DISTINCT".into(),
-                Schema::Any
+                Schema::AnyOf(set! {
+                    Schema::Atomic(Atomic::Integer),
+                    Schema::Atomic(Atomic::String),
+                })
             )
         )),
         expected_error_code = 1003,
@@ -5224,7 +5227,10 @@ mod aggregation {
             set_quantifier: Some(ast::SetQuantifier::Distinct),
         },
         env = map! {
-            ("d", 1u16).into() => ANY_DOCUMENT.clone(),
+            ("d", 1u16).into() => Schema::AnyOf(set! {
+                Schema::Atomic(Atomic::Integer),
+                Schema::Atomic(Atomic::String),
+            }),
         },
     );
     test_algebrize!(

--- a/mongosql/src/algebrizer/test.rs
+++ b/mongosql/src/algebrizer/test.rs
@@ -5146,7 +5146,7 @@ mod aggregation {
     use crate::{
         ast, map, mir, multimap,
         schema::{Atomic, Schema, ANY_DOCUMENT, NUMERIC_OR_NULLISH},
-        set, unchecked_unique_linked_hash_map,
+        unchecked_unique_linked_hash_map,
         usererror::UserError,
     };
     test_algebrize!(
@@ -5214,10 +5214,7 @@ mod aggregation {
         expected = Err(Error::SchemaChecking(
             mir::schema::Error::AggregationArgumentMustBeSelfComparable(
                 "Count DISTINCT".into(),
-                Schema::AnyOf(set! {
-                    Schema::Atomic(Atomic::Integer),
-                    Schema::Atomic(Atomic::String),
-                })
+                Schema::Any
             )
         )),
         expected_error_code = 1003,
@@ -5227,10 +5224,7 @@ mod aggregation {
             set_quantifier: Some(ast::SetQuantifier::Distinct),
         },
         env = map! {
-            ("d", 1u16).into() => Schema::AnyOf(set! {
-                Schema::Atomic(Atomic::Integer),
-                Schema::Atomic(Atomic::String),
-            }),
+            ("d", 1u16).into() => ANY_DOCUMENT.clone(),
         },
     );
     test_algebrize!(

--- a/mongosql/src/internal_spec_test/mod.rs
+++ b/mongosql/src/internal_spec_test/mod.rs
@@ -73,10 +73,10 @@ pub enum Error {
     RewritesFailed(String),
     #[error("rewrite should have failed with error: {0}")]
     RewriteDidNotFail(String),
-    #[error("unexpected algebrize error: {0}")]
-    AlgebrizationFailed(String),
-    #[error("algebrization should have failed, but it didn't")]
-    AlgebrizationDidNotFail,
+    #[error("unexpected algebrize error for test '{0}': {1}")]
+    AlgebrizationFailed(String, String),
+    #[error("algebrization should have failed, but it didn't for test '{0}'")]
+    AlgebrizationDidNotFail(String),
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -246,7 +246,7 @@ pub fn create_catalog(schemas: Vec<Schema>) -> Result<Catalog, Error> {
 ///
 /// This function assumes that [`types[i]`] describes the type of the i`th
 /// argument in the query.
-fn validate_algebrization(types: Vec<String>, ast: Query, is_valid: bool) -> Result<(), Error> {
+fn validate_algebrization(types: Vec<String>, ast: Query, is_valid: bool, test_name: String) -> Result<(), Error> {
     let schemas = types
         .clone()
         .into_iter()
@@ -266,7 +266,7 @@ fn validate_algebrization(types: Vec<String>, ast: Query, is_valid: bool) -> Res
     );
     let plan = algebrizer
         .algebrize_query(ast.clone())
-        .map_err(|e| Error::AlgebrizationFailed(format!("{e:?}")));
+        .map_err(|e| Error::AlgebrizationFailed(test_name.clone(), format!("{e:?}")));
     match plan {
         Ok(_) => {
             if !is_valid {
@@ -274,7 +274,7 @@ fn validate_algebrization(types: Vec<String>, ast: Query, is_valid: bool) -> Res
                 // here
                 dbg!(&types);
                 dbg!(&ast);
-                Err(Error::AlgebrizationDidNotFail)
+                Err(Error::AlgebrizationDidNotFail(test_name))
             } else {
                 Ok(())
             }
@@ -334,7 +334,7 @@ pub fn run_type_constraint_tests() -> Result<(), Error> {
                             .cloned()
                             .collect::<BTreeSet<Vec<String>>>();
                         cross_product.into_iter().try_for_each(|types| {
-                            validate_algebrization(types, ast.clone(), true)
+                            validate_algebrization(types, ast.clone(), true, test.description.clone())
                         })?;
                     }
                     // Ensure that algebrization fails for all invalid type combinations
@@ -343,7 +343,7 @@ pub fn run_type_constraint_tests() -> Result<(), Error> {
                         .unwrap()
                         .difference(&all_valid_permutations)
                         .try_for_each(|types| {
-                            validate_algebrization(types.clone(), ast.clone(), false)
+                            validate_algebrization(types.clone(), ast.clone(), false, test.description.clone())
                         })?;
                 }
             }

--- a/mongosql/src/internal_spec_test/mod.rs
+++ b/mongosql/src/internal_spec_test/mod.rs
@@ -246,7 +246,12 @@ pub fn create_catalog(schemas: Vec<Schema>) -> Result<Catalog, Error> {
 ///
 /// This function assumes that [`types[i]`] describes the type of the i`th
 /// argument in the query.
-fn validate_algebrization(types: Vec<String>, ast: Query, is_valid: bool, test_name: String) -> Result<(), Error> {
+fn validate_algebrization(
+    types: Vec<String>,
+    ast: Query,
+    is_valid: bool,
+    test_name: String,
+) -> Result<(), Error> {
     let schemas = types
         .clone()
         .into_iter()
@@ -334,7 +339,12 @@ pub fn run_type_constraint_tests() -> Result<(), Error> {
                             .cloned()
                             .collect::<BTreeSet<Vec<String>>>();
                         cross_product.into_iter().try_for_each(|types| {
-                            validate_algebrization(types, ast.clone(), true, test.description.clone())
+                            validate_algebrization(
+                                types,
+                                ast.clone(),
+                                true,
+                                test.description.clone(),
+                            )
                         })?;
                     }
                     // Ensure that algebrization fails for all invalid type combinations
@@ -343,7 +353,12 @@ pub fn run_type_constraint_tests() -> Result<(), Error> {
                         .unwrap()
                         .difference(&all_valid_permutations)
                         .try_for_each(|types| {
-                            validate_algebrization(types.clone(), ast.clone(), false, test.description.clone())
+                            validate_algebrization(
+                                types.clone(),
+                                ast.clone(),
+                                false,
+                                test.description.clone(),
+                            )
                         })?;
                 }
             }

--- a/mongosql/src/mir/schema/test/expressions/aggregate.rs
+++ b/mongosql/src/mir/schema/test/expressions/aggregate.rs
@@ -4,6 +4,14 @@ use crate::{
     schema::{Atomic, Document, Schema, ANY_DOCUMENT, NUMERIC_OR_NULLISH},
     set, test_schema,
 };
+use std::sync::LazyLock;
+
+static NON_SELF_COMPARABLE_SCHEMA: LazyLock<Schema> = LazyLock::new(|| {
+    Schema::AnyOf(set! {
+        Schema::Atomic(Atomic::Integer),
+        Schema::Atomic(Atomic::String),
+    })
+});
 
 mod add_to_array {
     use super::*;
@@ -183,20 +191,21 @@ mod avg {
 
 mod count {
     use super::*;
+    // todo: use AnyOf to force non-self-comparability
 
     test_schema!(
         distinct_count_args_must_be_comparable,
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "Count DISTINCT".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::Count,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: true,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(
@@ -234,14 +243,14 @@ mod first {
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "First DISTINCT".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::First,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: true,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(
@@ -270,14 +279,14 @@ mod last {
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "Last DISTINCT".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::Last,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: true,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(
@@ -306,14 +315,14 @@ mod max {
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "Max".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::Max,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: false,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(
@@ -321,14 +330,14 @@ mod max {
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "Max DISTINCT".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::Max,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: true,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(
@@ -404,14 +413,14 @@ mod min {
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "Min".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::Min,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: false,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(
@@ -419,14 +428,14 @@ mod min {
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "Min DISTINCT".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::Min,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: true,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(
@@ -455,14 +464,14 @@ mod stddev_pop {
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "StddevPop DISTINCT".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::StddevPop,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: true,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(
@@ -540,14 +549,14 @@ mod stddev_samp {
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "StddevSamp DISTINCT".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::StddevSamp,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: true,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(
@@ -625,14 +634,14 @@ mod sum {
         expected_error_code = 1003,
         expected = Err(mir_error::AggregationArgumentMustBeSelfComparable(
             "Sum DISTINCT".into(),
-            ANY_DOCUMENT.clone()
+            NON_SELF_COMPARABLE_SCHEMA.clone()
         )),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::Sum,
             arg: Box::new(Expression::Reference(("bar", 0u16).into())),
             distinct: true,
         }),
-        schema_env = map! {("bar", 0u16).into() => ANY_DOCUMENT.clone()},
+        schema_env = map! {("bar", 0u16).into() => NON_SELF_COMPARABLE_SCHEMA.clone()},
     );
 
     test_schema!(

--- a/mongosql/src/mir/schema/test/usererror.rs
+++ b/mongosql/src/mir/schema/test/usererror.rs
@@ -155,24 +155,33 @@ mod cannot_merge_objects {
 }
 
 mod aggregation_argument_must_be_self_comparable {
-    use crate::schema::{Schema, ANY_DOCUMENT};
+    use crate::{
+        schema::{Atomic, Schema},
+        set,
+    };
 
     test_user_error_messages! {
         max,
         input = Error::AggregationArgumentMustBeSelfComparable(
             "Max".into(),
-            ANY_DOCUMENT.clone()
+            Schema::AnyOf(set! {
+                Schema::Atomic(Atomic::Integer),
+                Schema::Atomic(Atomic::String),
+            }),
         ),
-        expected = "Cannot perform `Max` aggregation over the type `object type` as it is not comparable to itself."
+        expected = "Cannot perform `Max` aggregation over the type `polymorphic type` as it is not comparable to itself."
     }
 
     test_user_error_messages! {
         max_distinct,
         input = Error::AggregationArgumentMustBeSelfComparable(
             "Max DISTINCT".into(),
-            ANY_DOCUMENT.clone()
+            Schema::AnyOf(set! {
+                Schema::Atomic(Atomic::Integer),
+                Schema::Atomic(Atomic::String),
+            }),
         ),
-        expected = "Cannot perform `Max DISTINCT` aggregation over the type `object type` as it is not comparable to itself."
+        expected = "Cannot perform `Max DISTINCT` aggregation over the type `polymorphic type` as it is not comparable to itself."
     }
 
     test_user_error_messages! {

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -1113,29 +1113,40 @@ impl Schema {
         use Schema::*;
 
         match (&self, &other) {
-            // We currently disallow arrays and documents in comparisons.
-            (Array(_), _) | (_, Array(_)) => Not,
-            (Document(_), _) | (_, Document(_)) => Not,
-
             // Comparing with an Any schema will always result in a May.
             (Any, _) | (_, Any) => May,
+
+            // Any type is comparable to null
+            (Atomic(crate::schema::Atomic::Null), _) | (_, Atomic(crate::schema::Atomic::Null)) => {
+                Must
+            }
 
             // Missing behaves like null, in that any type is comparable to it.
             (Missing, _) | (_, Missing) => Must,
 
             // Unsat behaves like null, in that any type is comparable to it.
             // However, this likely does not matter at the moment given that Unsat
-            // can only be found in arrays, for which we currently disallow comparisons.
+            // can only be found in arrays, and we allow array-self-comparison.
             (Unsat, _) | (_, Unsat) => Must,
-
-            // Atomics have their own criteria for comparability involving numerics and null.
-            (Atomic(a1), Atomic(a2)) => a1.is_comparable_with(a2),
 
             // Use the meet logic if we have an AnyOf regardless of which side the AnyOf is on,
             // since comparison is a commutative operation that type satisfaction must reflect.
             (AnyOf(anyof_vs), v) | (v, AnyOf(anyof_vs)) => {
                 Schema::schema_predicate_meet(anyof_vs, &|s: &Schema| s.is_comparable_with(v))
             }
+
+            // Atomics have their own criteria for comparability involving numerics and null.
+            (Atomic(a1), Atomic(a2)) => a1.is_comparable_with(a2),
+
+            // Arrays can be compared to other arrays if their elements
+            // are comparable.
+            (Array(l), Array(r)) => l.is_comparable_with(r),
+
+            // Documents can be compared to other documents.
+            (Document(_), Document(_)) => Must,
+
+            // Documents and arrays cannot be compared to any other remaining types
+            (Array(_), _) | (_, Array(_)) | (Document(_), _) | (_, Document(_)) => Not,
         }
     }
 

--- a/mongosql/src/schema/test.rs
+++ b/mongosql/src/schema/test.rs
@@ -1652,18 +1652,24 @@ mod is_comparable_with {
             }
         };
     }
-    // Disallowed comparability tests (arrays and documents).
+    // Array comparability
     test_is_comparable_with!(
-        array_not_comparable_with_another_array,
-        expected = Not,
+        array_is_comparable_with_array_based_on_inner_type,
+        expected = Must,
+        _self = Array(Box::new(Atomic(Integer))),
+        other = Array(Box::new(Atomic(Integer))),
+    );
+    test_is_comparable_with!(
+        array_maybe_comparable_with_array_based_on_inner_type,
+        expected = May,
         _self = ANY_ARRAY,
         other = ANY_ARRAY,
     );
     test_is_comparable_with!(
-        document_not_comparable_with_another_document,
+        array_not_comparable_with_array_based_on_inner_type,
         expected = Not,
-        _self = ANY_DOCUMENT,
-        other = ANY_DOCUMENT,
+        _self = Array(Box::new(Atomic(Integer))),
+        other = Array(Box::new(Atomic(String))),
     );
     test_is_comparable_with!(
         array_not_comparable_with_document,
@@ -1671,12 +1677,29 @@ mod is_comparable_with {
         _self = ANY_ARRAY,
         other = ANY_DOCUMENT,
     );
-
     test_is_comparable_with!(
-        array_not_comparable_with_any,
-        expected = Not,
+        array_maybe_comparable_with_any,
+        expected = May,
         _self = ANY_ARRAY,
         other = Any,
+    );
+    test_is_comparable_with!(
+        array_is_comparable_with_null,
+        expected = Must,
+        _self = ANY_ARRAY,
+        other = Atomic(Null),
+    );
+    test_is_comparable_with!(
+        array_is_comparable_with_missing,
+        expected = Must,
+        _self = ANY_ARRAY,
+        other = Missing,
+    );
+    test_is_comparable_with!(
+        array_is_comparable_with_unsat,
+        expected = Must,
+        _self = ANY_ARRAY,
+        other = Unsat,
     );
     test_is_comparable_with!(
         array_not_comparable_with_another_type,
@@ -1684,54 +1707,43 @@ mod is_comparable_with {
         _self = ANY_ARRAY,
         other = Atomic(Integer),
     );
+
+    // Document comparability
     test_is_comparable_with!(
-        array_not_comparable_with_null,
-        expected = Not,
-        _self = ANY_ARRAY,
+        document_is_comparable_with_another_document,
+        expected = Must,
+        _self = ANY_DOCUMENT,
+        other = ANY_DOCUMENT,
+    );
+    test_is_comparable_with!(
+        document_maybe_comparable_with_any_type,
+        expected = May,
+        _self = ANY_DOCUMENT,
+        other = Any,
+    );
+    test_is_comparable_with!(
+        document_is_comparable_with_null,
+        expected = Must,
+        _self = ANY_DOCUMENT,
         other = Atomic(Null),
     );
     test_is_comparable_with!(
-        array_not_comparable_with_missing,
-        expected = Not,
-        _self = ANY_ARRAY,
+        document_is_comparable_with_missing,
+        expected = Must,
+        _self = ANY_DOCUMENT,
         other = Missing,
     );
     test_is_comparable_with!(
-        array_not_comparable_with_unsat,
-        expected = Not,
-        _self = ANY_ARRAY,
-        other = Unsat,
-    );
-
-    test_is_comparable_with!(
-        document_not_comparable_with_any_type,
-        expected = Not,
+        document_is_comparable_with_unsat,
+        expected = Must,
         _self = ANY_DOCUMENT,
-        other = Any,
+        other = Unsat,
     );
     test_is_comparable_with!(
         document_not_comparable_with_a_type,
         expected = Not,
         _self = ANY_DOCUMENT,
         other = Atomic(Integer),
-    );
-    test_is_comparable_with!(
-        document_not_comparable_with_null,
-        expected = Not,
-        _self = ANY_DOCUMENT,
-        other = Atomic(Null),
-    );
-    test_is_comparable_with!(
-        document_not_comparable_with_missing,
-        expected = Not,
-        _self = ANY_DOCUMENT,
-        other = Missing,
-    );
-    test_is_comparable_with!(
-        document_not_comparable_with_unsat,
-        expected = Not,
-        _self = ANY_DOCUMENT,
-        other = Unsat,
     );
 
     // Any comparison tests.
@@ -1959,6 +1971,18 @@ mod is_comparable_with {
         expected = Not,
         _self = AnyOf(set![Atomic(String), Atomic(Boolean)]),
         other = AnyOf(set![Atomic(Date), Atomic(Integer)]),
+    );
+    test_is_comparable_with!(
+        a_set_containing_array_maybe_comparable_with_set_containing_array,
+        expected = May,
+        _self = AnyOf(set![ANY_ARRAY.clone(), Atomic(Boolean)]),
+        other = AnyOf(set![ANY_ARRAY.clone(), Atomic(Integer)]),
+    );
+    test_is_comparable_with!(
+        a_set_containing_document_maybe_comparable_with_set_containing_document,
+        expected = May,
+        _self = AnyOf(set![ANY_DOCUMENT.clone(), Atomic(Boolean)]),
+        other = AnyOf(set![ANY_DOCUMENT.clone(), Atomic(Integer)]),
     );
 }
 

--- a/tests/errors/schema.yml
+++ b/tests/errors/schema.yml
@@ -1,7 +1,7 @@
 catalog_data:
   db:
     foo:
-      - { '_id': 0, 'a': 1, 'b': 2, 'c': "foo", 'd': { 'a': 1 } }
+      - { '_id': 0, 'a': 1, 'b': 2, 'c': "foo", 'd': { 'a': 1 }, p: true }
     bar:
       - { '_id': 0, 'a': 1, 'b': 2, 'c': "bar", 'd': { 'a': 2 } }
 
@@ -10,7 +10,7 @@ catalog_schema:
     'db': {
       'foo': {
         'bsonType': 'object',
-        "required": [ "_id", "a", "b", "c", "d" ],
+        "required": [ "_id", "a", "b", "c", "d", "p" ],
         "additionalProperties": false,
         "properties":
           {
@@ -26,6 +26,14 @@ catalog_schema:
                   "a": { "bsonType": "int" }
                 }
               },
+            "p":
+              {
+                "anyOf":
+                  [
+                    { "bsonType": "string" },
+                    { "bsonType": "bool" },
+                  ]
+              }
           },
       },
       'bar': {
@@ -77,10 +85,10 @@ tests:
     algebrize_error: 'Error 1002: Incorrect argument type for `Round`. Required: nullable numeric type. Found: any type. An `any type` schema may indicate that schema is not set for the relevant collection or field. Please verify that the schema is set as expected.'
 
   - description: Error 1003 AggregationArgumentMustBeSelfComparable
-    query: "SELECT * FROM foo GROUP BY a AGGREGATE min(d) AS min"
+    query: "SELECT * FROM foo GROUP BY a AGGREGATE min(p) AS min"
     current_db: db
     should_compile: false
-    algebrize_error: 'Error 1003: Cannot perform `Min` aggregation over the type `object type` as it is not comparable to itself.'
+    algebrize_error: 'Error 1003: Cannot perform `Min` aggregation over the type `polymorphic type` as it is not comparable to itself.'
 
   - description: Error 1003 AggregationArgumentMustBeSelfComparable with Any value
     query: "SELECT * FROM any_sch GROUP BY _id AGGREGATE min(d) AS min"
@@ -119,10 +127,10 @@ tests:
     algebrize_error: "Error 1008: cardinality of the subquery's result set may be greater than 1"
 
   - description: Error 1010 SortKeyNotSelfComparable
-    query: "SELECT * FROM foo ORDER BY d"
+    query: "SELECT * FROM foo ORDER BY p"
     current_db: db
     should_compile: false
-    algebrize_error: "Error 1010: Cannot sort by key because `object type` can't be compared against itself."
+    algebrize_error: "Error 1010: Cannot sort by key because `polymorphic type` can't be compared against itself."
 
   - description: Error 1010 SortKeyNotSelfComparable with Any value
     query: "SELECT * FROM any_sch ORDER BY d"
@@ -131,10 +139,10 @@ tests:
     algebrize_error: "Error 1010: Cannot sort by key because `any type` can't be compared against itself. An `any type` schema may indicate that schema is not set for the relevant collection or field. Please verify that the schema is set as expected."
 
   - description: Error 1011 GroupKeyNotSelfComparable
-    query: "SELECT * FROM foo GROUP BY d"
+    query: "SELECT * FROM foo GROUP BY p"
     current_db: db
     should_compile: false
-    algebrize_error: "Error 1011: Cannot group by key because `object type` can't be compared against itself."
+    algebrize_error: "Error 1011: Cannot group by key because `polymorphic type` can't be compared against itself."
 
   - description: Error 1011 GroupKeyNotSelfComparable with Any value
     query: "SELECT * FROM any_sch GROUP BY d"

--- a/tests/spec_tests/query_tests/group_by.yml
+++ b/tests/spec_tests/query_tests/group_by.yml
@@ -289,6 +289,7 @@ tests:
       - { "": { "n": { "$numberInt": "1" } } }
 
   - description: group keys must be mutually comparable types
+    skip_reason: "SQL-2623: update GROUP BY spec tests (this one should removed since all types are now self-comparable)"
     query: "SELECT * FROM foo.baz AS a GROUP BY {'out': a.a} AS doc"
     should_compile: false
     algebrize_error: "group key at position 0 is not statically comparable to itself"
@@ -528,6 +529,7 @@ tests:
     algebrize_error: "* argument only valid in COUNT function"
 
   - description: ADD_TO_SET requires all elements have statically mutually comparable type
+    skip_reason: "SQL-2623: update GROUP BY spec tests (this one should removed since all types are now self-comparable)"
     query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE ADD_TO_SET(a) AS gset"
     should_compile: false
     algebrize_error: 'cannot have "AddToArray DISTINCT" aggregations over the schema: Document(Document { keys: {"a": AnyOf({Atomic(Integer), Atomic(Null)}), "b": AnyOf({Atomic(Integer), Atomic(Null)})}, required: {"a", "b"}, additional_properties: false }) as it is not comparable to itself'
@@ -654,6 +656,7 @@ tests:
     algebrize_error: "* argument only valid in COUNT function"
 
   - description: MAX must have statically mutually comparable type
+    skip_reason: "SQL-2623: update GROUP BY spec tests (this one should removed since all types are now self-comparable)"
     query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE MAX(a) AS gmax"
     should_compile: false
     algebrize_error: 'cannot have "Max" aggregations over the schema: Document(Document { keys: {"a": AnyOf({Atomic(Integer), Atomic(Null)}), "b": AnyOf({Atomic(Integer), Atomic(Null)})}, required: {"a", "b"}, additional_properties: false }) as it is not comparable to itself'
@@ -691,6 +694,7 @@ tests:
     algebrize_error: "* argument only valid in COUNT function"
 
   - description: MIN must have statically mutually comparable type
+    skip_reason: "SQL-2623: update GROUP BY spec tests (this one should removed since all types are now self-comparable)"
     query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE MIN(a) AS gmin"
     should_compile: false
     algebrize_error: 'cannot have "Min" aggregations over the schema: Document(Document { keys: {"a": AnyOf({Atomic(Integer), Atomic(Null)}), "b": AnyOf({Atomic(Integer), Atomic(Null)})}, required: {"a", "b"}, additional_properties: false }) as it is not comparable to itself'

--- a/tests/spec_tests/type_constraint_tests/operators.yml
+++ b/tests/spec_tests/type_constraint_tests/operators.yml
@@ -85,28 +85,35 @@ tests:
 
   - description: "< operands must have comparable types (NULL and MISSING are always allowed)"
     query: "SELECT arg1 < arg2 FROM foo"
+    skip_reason: "SQL-2624: Update spec tests for binary comparison operators (comparisonValidTypes needs to be updated to include document and array)"
     valid_types: *comparisonValidTypes
 
   - description: "<= operands must have comparable types (NULL and MISSING are always allowed)"
     query: "SELECT arg1 <= arg2 FROM foo"
+    skip_reason: "SQL-2624: Update spec tests for binary comparison operators (comparisonValidTypes needs to be updated to include document and array)"
     valid_types: *comparisonValidTypes
 
   - description: "<> operands must have comparable types (NULL and MISSING are always allowed)"
     query: "SELECT arg1 <> arg2 FROM foo"
+    skip_reason: "SQL-2624: Update spec tests for binary comparison operators (comparisonValidTypes needs to be updated to include document and array)"
     valid_types: *comparisonValidTypes
 
   - description: = operands must have comparable types (NULL and MISSING are always allowed)
     query: "SELECT arg1 = arg2 FROM foo"
+    skip_reason: "SQL-2624: Update spec tests for binary comparison operators (comparisonValidTypes needs to be updated to include document and array)"
     valid_types: *comparisonValidTypes
 
   - description: "> operands must have comparable types (NULL and MISSING are always allowed)"
     query: "SELECT arg1 > arg2 FROM foo"
+    skip_reason: "SQL-2624: Update spec tests for binary comparison operators (comparisonValidTypes needs to be updated to include document and array)"
     valid_types: *comparisonValidTypes
 
   - description: ">= operands must have comparable types (NULL and MISSING are always allowed)"
     query: "SELECT arg1 >= arg2 FROM foo"
+    skip_reason: "SQL-2624: Update spec tests for binary comparison operators (comparisonValidTypes needs to be updated to include document and array)"
     valid_types: *comparisonValidTypes
 
   - description: Simple CASE expression WHEN operands must have comparable type to CASE operand
     query: "SELECT CASE arg1 WHEN arg2 THEN 1 ELSE NULL END FROM foo"
+    skip_reason: "SQL-2625: Update spec tests for CASE operator (comparisonValidTypes needs to be updated to include document and array)"
     valid_types: *comparisonValidTypes

--- a/tests/spec_tests/type_constraint_tests/scalar_functions.yml
+++ b/tests/spec_tests/type_constraint_tests/scalar_functions.yml
@@ -27,6 +27,7 @@ variables:
 tests:
   - description: NULLIF operands must have comparable types (NULL and MISSING are always allowed)
     query: "SELECT NULLIF(arg1, arg2) FROM foo"
+    skip_reason: "SQL-2625: Update spec tests for NULLIF (comparisonValidTypes needs to be updated to include document and array)"
     valid_types: *comparisonValidTypes
 
   - description: SIZE operand must have type ARRAY or NULL, or be MISSING


### PR DESCRIPTION
This PR implements `Array` and `Document` self-comparison by updating the `is_comparable_with` method as described in the design doc. I had to make a few more changes than what we initially documented since I wanted to make `Document` and `Array` comparison match all other types (i.e. comparison to `null`/`missing`/`unsat`/`any` works the same for them as for everything else). Unit tests are updated to reflect these new semantics.

For now, I decided to _skip_ now-failing spec tests because we have dedicated tickets in the epic to audit them and decide if they should be updated or removed. Let me know if you prefer I do any of those updates as part of this PR. I think deferring to the follow-up spec test tickets is totally fine. I want to schedule and pick those up next anyway so those changes will happen soon!