### PR TITLE
SQL-2623: Update spec testing for GROUP BY accumulators to demonstrate document and array self-comparability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,14 +1010,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3122,7 +3122,7 @@ name = "mongosql-cli"
 version = "0.1.0"
 dependencies = [
  "bson",
- "clap 4.5.26",
+ "clap 4.5.28",
  "mongodb",
  "mongosql",
  "serde_json",

--- a/mongosql/src/internal_spec_test/mod.rs
+++ b/mongosql/src/internal_spec_test/mod.rs
@@ -23,7 +23,7 @@ const TYPE_CONSTRAINT_DIR: &str = "../tests/spec_tests/type_constraint_tests";
 const TEST_DB: &str = "test";
 lazy_static! {
     static ref TYPE_TO_SCHEMA: BTreeMap<&'static str, Schema> = map! {
-        "ARRAY" => Schema::Array(Box::new(Schema::Any)),
+        "ARRAY" => Schema::Array(Box::new(Schema::Unsat)),
         "BINDATA" => Schema::Atomic(Atomic::BinData),
         "BOOL" => Schema::Atomic(Atomic::Boolean),
         "BSON_DATE" => Schema::Atomic(Atomic::Date),
@@ -44,6 +44,7 @@ lazy_static! {
         "REGEX" => Schema::Atomic(Atomic::Regex),
         "STRING" => Schema::Atomic(Atomic::String),
         "SYMBOL" => Schema::Atomic(Atomic::Symbol),
+        "UNDEFINED" => Schema::Atomic(Atomic::Undefined),
     };
 }
 

--- a/tests/spec_tests/query_tests/group_by.yml
+++ b/tests/spec_tests/query_tests/group_by.yml
@@ -118,6 +118,9 @@ catalog_data:
       - { "_id": { "$numberInt": "3" }, "a": { "$numberInt": "1" } }
     arr:
       - { "_id": { "$numberInt": "1" }, "a": [1, 2] }
+    poly:
+      - { "_id": 0, a: true }
+      - { "_id": 1, a: "yes" }
 
 catalog_schema:
   {
@@ -254,6 +257,20 @@ catalog_schema:
             "additionalProperties": false,
             "properties": { "a": { "bsonType": "array" } },
           },
+        "poly":
+          {
+            "bsonType": "object",
+            "required": ["_id", "a"],
+            "additionalProperties": false,
+            "properties": {
+              "a": {
+                "anyOf": [
+                  { "bsonType": "bool" },
+                  { "bsonType": "string" },
+                ]
+              }
+            },
+          },
       },
   }
 
@@ -289,7 +306,7 @@ tests:
       - { "": { "n": { "$numberInt": "1" } } }
 
   - description: group keys must be mutually comparable types
-    query: "SELECT * FROM foo.baz AS a GROUP BY {'out': a.a} AS doc"
+    query: "SELECT * FROM foo.poly AS a GROUP BY a.a AS p"
     should_compile: false
     algebrize_error: "group key at position 0 is not statically comparable to itself"
 
@@ -527,11 +544,6 @@ tests:
     should_compile: false
     algebrize_error: "* argument only valid in COUNT function"
 
-  - description: ADD_TO_SET requires all elements have statically mutually comparable type
-    query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE ADD_TO_SET(a) AS gset"
-    should_compile: false
-    algebrize_error: 'cannot have "AddToArray DISTINCT" aggregations over the schema: Document(Document { keys: {"a": AnyOf({Atomic(Integer), Atomic(Null)}), "b": AnyOf({Atomic(Integer), Atomic(Null)})}, required: {"a", "b"}, additional_properties: false }) as it is not comparable to itself'
-
   - description: ADD_TO_SET correctness test
     query: "SELECT * FROM (SELECT _id, a FROM foo.baz AS baz ORDER BY _id) AS arr GROUP BY a.a AS a AGGREGATE ADD_TO_SET(a.a) AS gset"
     current_db: foo
@@ -653,11 +665,6 @@ tests:
     should_compile: false
     algebrize_error: "* argument only valid in COUNT function"
 
-  - description: MAX must have statically mutually comparable type
-    query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE MAX(a) AS gmax"
-    should_compile: false
-    algebrize_error: 'cannot have "Max" aggregations over the schema: Document(Document { keys: {"a": AnyOf({Atomic(Integer), Atomic(Null)}), "b": AnyOf({Atomic(Integer), Atomic(Null)})}, required: {"a", "b"}, additional_properties: false }) as it is not comparable to itself'
-
   - description: MERGE_DOCUMENTS correctness test
     query: "SELECT * FROM (SELECT _id, a, doc FROM foo.baz2 AS baz2 ORDER BY _id) AS arr GROUP BY a AS a AGGREGATE MERGE_DOCUMENTS(doc) AS gmerge"
     current_db: foo
@@ -689,11 +696,6 @@ tests:
     query: "SELECT * FROM foo.baz AS arr GROUP BY a AS a AGGREGATE MIN(*) AS gmin"
     should_compile: false
     algebrize_error: "* argument only valid in COUNT function"
-
-  - description: MIN must have statically mutually comparable type
-    query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE MIN(a) AS gmin"
-    should_compile: false
-    algebrize_error: 'cannot have "Min" aggregations over the schema: Document(Document { keys: {"a": AnyOf({Atomic(Integer), Atomic(Null)}), "b": AnyOf({Atomic(Integer), Atomic(Null)})}, required: {"a", "b"}, additional_properties: false }) as it is not comparable to itself'
 
   - description: STDDEV_POP correctness test
     query: "SELECT * FROM foo.bar AS arr GROUP BY a AS a AGGREGATE STDDEV_POP(b) AS gstdp"

--- a/tests/spec_tests/type_constraint_tests/group_by.yml
+++ b/tests/spec_tests/type_constraint_tests/group_by.yml
@@ -22,6 +22,7 @@ variables:
 tests:
   # Note: Non-distinct ADD_TO_ARRAY has no type constraints
   - description: Distinct ADD_TO_ARRAY argument must be self-comparable
+    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE ADD_TO_ARRAY(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
@@ -37,21 +38,25 @@ tests:
 
   # Note: Non-distinct COUNT has no type constraints
   - description: Distinct COUNT argument must be self-comparable
+    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE COUNT(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
   # Note: Non-distinct FIRST has no type constraints
   - description: Distinct FIRST argument must be self-comparable
+    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE FIRST(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
   # Note: Non-distinct LAST has no type constraints
   - description: Distinct LAST argument must be self-comparable
+    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE LAST(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
   # Note: Non-distinct MAX has no type constraints
   - description: Distinct MAX argument must be self-comparable
+    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MAX(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
@@ -69,6 +74,7 @@ tests:
 
   # Note: Non-distinct MIN has no type constraints
   - description: Distinct MIN argument must be self-comparable
+    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MIN(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 

--- a/tests/spec_tests/type_constraint_tests/group_by.yml
+++ b/tests/spec_tests/type_constraint_tests/group_by.yml
@@ -11,18 +11,17 @@ variables:
     - { "arg1": [ "UNDEFINED", "NULL", "MISSING" ] }
     - { "arg1": [ "OBJECTID", "NULL", "MISSING" ] }
     - { "arg1": *bool }
-    - { "arg1": [ "DATE", "NULL", "MISSING" ] }
+    - { "arg1": [ "BSON_DATE", "NULL", "MISSING" ] }
     - { "arg1": [ "NULL", "MISSING" ] }
     - { "arg1": [ "REGEX", "NULL", "MISSING" ] }
     - { "arg1": [ "SYMBOL", "NULL", "MISSING" ] }
-    - { "arg1": [ "TIMESTAMP", "NULL", "MISSING" ] }
+    - { "arg1": [ "BSON_TIMESTAMP", "NULL", "MISSING" ] }
     - { "arg1": [ "MINKEY", "NULL", "MISSING" ] }
     - { "arg1": [ "MAXKEY", "NULL", "MISSING" ] }
 
 tests:
   # Note: Non-distinct ADD_TO_ARRAY has no type constraints
   - description: Distinct ADD_TO_ARRAY argument must be self-comparable
-    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE ADD_TO_ARRAY(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
@@ -38,25 +37,21 @@ tests:
 
   # Note: Non-distinct COUNT has no type constraints
   - description: Distinct COUNT argument must be self-comparable
-    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE COUNT(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
   # Note: Non-distinct FIRST has no type constraints
   - description: Distinct FIRST argument must be self-comparable
-    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE FIRST(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
   # Note: Non-distinct LAST has no type constraints
   - description: Distinct LAST argument must be self-comparable
-    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE LAST(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
   # Note: Non-distinct MAX has no type constraints
   - description: Distinct MAX argument must be self-comparable
-    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MAX(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 
@@ -74,7 +69,6 @@ tests:
 
   # Note: Non-distinct MIN has no type constraints
   - description: Distinct MIN argument must be self-comparable
-    skip_reason: "SQL-2618: enable document and array self-comparison"
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MIN(DISTINCT arg1) AS agg"
     valid_types: *selfComparisonValidTypes
 

--- a/tests/spec_tests/type_constraint_tests/group_by.yml
+++ b/tests/spec_tests/type_constraint_tests/group_by.yml
@@ -2,13 +2,58 @@ variables:
   bool: &bool ["BOOL", "NULL", "MISSING"]
   document: &document ["DOCUMENT", "NULL", "MISSING"]
   numerics: &numerics ["INT", "LONG", "DOUBLE", "DECIMAL", "NULL", "MISSING"]
-
+  selfComparisonValidTypes: &selfComparisonValidTypes
+    - { "arg1": *numerics }
+    - { "arg1": [ "STRING", "NULL", "MISSING" ] }
+    - { "arg1": *document }
+    - { "arg1": [ "ARRAY", "NULL", "MISSING" ] }
+    - { "arg1": [ "BINDATA", "NULL", "MISSING" ] }
+    - { "arg1": [ "UNDEFINED", "NULL", "MISSING" ] }
+    - { "arg1": [ "OBJECTID", "NULL", "MISSING" ] }
+    - { "arg1": *bool }
+    - { "arg1": [ "DATE", "NULL", "MISSING" ] }
+    - { "arg1": [ "NULL", "MISSING" ] }
+    - { "arg1": [ "REGEX", "NULL", "MISSING" ] }
+    - { "arg1": [ "SYMBOL", "NULL", "MISSING" ] }
+    - { "arg1": [ "TIMESTAMP", "NULL", "MISSING" ] }
+    - { "arg1": [ "MINKEY", "NULL", "MISSING" ] }
+    - { "arg1": [ "MAXKEY", "NULL", "MISSING" ] }
 
 tests:
+  # Note: Non-distinct ADD_TO_ARRAY has no type constraints
+  - description: Distinct ADD_TO_ARRAY argument must be self-comparable
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE ADD_TO_ARRAY(DISTINCT arg1) AS agg"
+    valid_types: *selfComparisonValidTypes
+
   - description: AVG argument must be numeric
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE AVG(arg1) AS avg"
     valid_types:
       - {"arg1": *numerics}
+
+  - description: Distinct AVG argument must be numeric
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE AVG(DISTINCT arg1) AS avg"
+    valid_types:
+      - {"arg1": *numerics}
+
+  # Note: Non-distinct COUNT has no type constraints
+  - description: Distinct COUNT argument must be self-comparable
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE COUNT(DISTINCT arg1) AS agg"
+    valid_types: *selfComparisonValidTypes
+
+  # Note: Non-distinct FIRST has no type constraints
+  - description: Distinct FIRST argument must be self-comparable
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE FIRST(DISTINCT arg1) AS agg"
+    valid_types: *selfComparisonValidTypes
+
+  # Note: Non-distinct LAST has no type constraints
+  - description: Distinct LAST argument must be self-comparable
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE LAST(DISTINCT arg1) AS agg"
+    valid_types: *selfComparisonValidTypes
+
+  # Note: Non-distinct MAX has no type constraints
+  - description: Distinct MAX argument must be self-comparable
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MAX(DISTINCT arg1) AS agg"
+    valid_types: *selfComparisonValidTypes
 
   - description: MERGE_DOCUMENTS argument must be document
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MERGE_DOCUMENTS(arg1) AS merge"
@@ -16,8 +61,24 @@ tests:
     valid_types:
       - {"arg1": *document}
 
+  - description: Distinct MERGE_DOCUMENTS argument must be document
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MERGE_DOCUMENTS(DISTINCT arg1) AS merge"
+    skip_reason: "SQL-590: Support nullish document arguments"
+    valid_types:
+      - {"arg1": *document}
+
+  # Note: Non-distinct MIN has no type constraints
+  - description: Distinct MIN argument must be self-comparable
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MIN(DISTINCT arg1) AS agg"
+    valid_types: *selfComparisonValidTypes
+
   - description: STDDEV_POP argument must be numeric
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE STDDEV_POP(arg1) AS pop"
+    valid_types:
+      - {"arg1": *numerics}
+
+  - description: Distinct STDDEV_POP argument must be numeric
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE STDDEV_POP(DISTINCT arg1) AS pop"
     valid_types:
       - {"arg1": *numerics}
 
@@ -26,8 +87,18 @@ tests:
     valid_types:
       - {"arg1": *numerics}
 
+  - description: Distinct STDDEV_SAMP argument must be numeric
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE STDDEV_SAMP(DISTINCT arg1) AS samp"
+    valid_types:
+      - {"arg1": *numerics}
+
   - description: SUM argument must be numeric
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE SUM(arg1) AS sum"
+    valid_types:
+      - {"arg1": *numerics}
+
+  - description: DISTINCT SUM argument must be numeric
+    query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE SUM(DISTINCT arg1) AS sum"
     valid_types:
       - {"arg1": *numerics}
 


### PR DESCRIPTION
This PR updates the `group_by.yml` spec query and type constraint tests. For the query tests, I removed the accumulator type-checking tests in favor of the more robust type constraint test suite; I updated the group key test to use an `AnyOf` schema instead of `Document` (since `Document` is now valid). For the type constraint tests, I added tests for distinct versions of all accumulators, including those that already had non-distinct tests. This covers everything described in the design doc for this ticket.

Note that `COUNT(DISTINCT *)` and `COUNT(DISTINCT col1, col2, ...)` will be spec tested as part of their respective implementation tickets.