### PR TITLE
SQL-2370: implement schema derivation for misc stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,14 +1010,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3122,7 +3122,7 @@ name = "mongosql-cli"
 version = "0.1.0"
 dependencies = [
  "bson",
- "clap 4.5.26",
+ "clap 4.5.28",
  "mongodb",
  "mongosql",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4432,6 +4432,7 @@ version = "0.0.0"
 dependencies = [
  "agg-ast",
  "bson",
+ "linked-hash-map",
  "mongosql",
  "serde_json",
  "thiserror 2.0.11",

--- a/agg-ast/schema_derivation/Cargo.toml
+++ b/agg-ast/schema_derivation/Cargo.toml
@@ -9,5 +9,6 @@ bson = { workspace = true, features = ["chrono-0_4"] }
 mongosql = { path = "../../mongosql" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+linked-hash-map = { workspace = true, features = ["serde_impl"] }
 
 [features]

--- a/agg-ast/schema_derivation/src/lib.rs
+++ b/agg-ast/schema_derivation/src/lib.rs
@@ -140,12 +140,10 @@ pub(crate) fn get_or_create_schema_for_path_mut(
     for field in path {
         schema = match schema {
             Some(Schema::Document(d)) => {
-                if !d.keys.contains_key(&field) {
-                    if !d.additional_properties {
-                        return None;
-                    }
-                    d.keys.insert(field.clone(), Schema::Any);
+                if !d.keys.contains_key(&field) && !d.additional_properties {
+                    return None;
                 }
+                d.insert_if_not_exists(field.clone(), Schema::Any);
                 d.keys.get_mut(&field)
             }
             Some(Schema::Any) => {
@@ -180,11 +178,9 @@ pub(crate) fn get_or_create_schema_for_path_mut(
                         None
                     }
                 })?;
-                if !d.keys.contains_key(&field)
-                    // We can only add keys, if additionalProperties is true.
-                    && d.additional_properties
-                {
-                    d.keys.insert(field.clone(), Schema::Any);
+                // We can only add keys, if additionalProperties is true.
+                if d.additional_properties {
+                    d.insert_if_not_exists(field.clone(), Schema::Any);
                 }
                 // this is a wonky way to do this, putting it in the map and then getting it back
                 // out with this match, but it's what the borrow checker forces (we can't keep the
@@ -210,9 +206,7 @@ fn insert_required_key_into_document_helper(
 ) -> Option<&mut Schema> {
     match schema {
         Some(Schema::Document(d)) => {
-            if !d.keys.contains_key(&field) {
-                d.keys.insert(field.clone(), field_schema);
-            }
+            d.insert_if_not_exists(field.clone(), field_schema);
             // even if the document already included the key, we want to mark it as required.
             // this enables nested field paths to be marked as required down to the required
             // key being inserted.
@@ -231,9 +225,7 @@ fn insert_required_key_into_document_helper(
                     None
                 }
             })?;
-            if !d.keys.contains_key(&field) {
-                d.keys.insert(field.clone(), Schema::Any);
-            }
+            d.insert_if_not_exists(field.clone(), Schema::Any);
             // see comment above for why we require the field even if it existed in the document
             d.required.insert(field.clone());
             **(schema.as_mut()?) = Schema::Document(d);

--- a/agg-ast/schema_derivation/src/lib.rs
+++ b/agg-ast/schema_derivation/src/lib.rs
@@ -143,7 +143,7 @@ pub(crate) fn get_or_create_schema_for_path_mut(
                 if !d.keys.contains_key(&field) && !d.additional_properties {
                     return None;
                 }
-                d.insert_if_not_exists(field.clone(), Schema::Any);
+                d.keys.entry(field.clone()).or_insert(Schema::Any);
                 d.keys.get_mut(&field)
             }
             Some(Schema::Any) => {
@@ -180,7 +180,7 @@ pub(crate) fn get_or_create_schema_for_path_mut(
                 })?;
                 // We can only add keys, if additionalProperties is true.
                 if d.additional_properties {
-                    d.insert_if_not_exists(field.clone(), Schema::Any);
+                    d.keys.entry(field.clone()).or_insert(Schema::Any);
                 }
                 // this is a wonky way to do this, putting it in the map and then getting it back
                 // out with this match, but it's what the borrow checker forces (we can't keep the
@@ -206,7 +206,7 @@ fn insert_required_key_into_document_helper(
 ) -> Option<&mut Schema> {
     match schema {
         Some(Schema::Document(d)) => {
-            d.insert_if_not_exists(field.clone(), field_schema);
+            d.keys.entry(field.clone()).or_insert(field_schema);
             // even if the document already included the key, we want to mark it as required.
             // this enables nested field paths to be marked as required down to the required
             // key being inserted.
@@ -225,7 +225,7 @@ fn insert_required_key_into_document_helper(
                     None
                 }
             })?;
-            d.insert_if_not_exists(field.clone(), Schema::Any);
+            d.keys.entry(field.clone()).or_insert(Schema::Any);
             // see comment above for why we require the field even if it existed in the document
             d.required.insert(field.clone());
             **(schema.as_mut()?) = Schema::Document(d);

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -42,7 +42,7 @@ fn derive_schema_for_pipeline(pipeline: Vec<Stage>, state: &mut ResultSetState) 
         state.result_set_schema = stage.derive_schema(state)?;
         Ok(())
     })?;
-    Ok(state.result_set_schema.clone())
+    Ok(std::mem::take(&mut state.result_set_schema))
 }
 
 impl DeriveSchema for Stage {
@@ -182,7 +182,7 @@ impl DeriveSchema for Stage {
                     // the schema of the field being unwound goes from type Array[X] to type X
                     match s {
                         Schema::Array(a) => {
-                            *s = *a.clone();
+                            *s = std::mem::take(a);
                         }
                         Schema::AnyOf(ao) => {
                             *s = Schema::simplify(&Schema::AnyOf(

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -132,7 +132,7 @@ impl DeriveSchema for Stage {
         ) -> Result<Schema> {
             // facet contains key - value pairs where the key is the name of a field in the output document,
             // and the value is an aggregation pipeline. We can use the same generic helper for aggregating over a whole pipeline
-            // to get the sch ema for each field, cloning the incoming state.
+            // to get the schema for each field, cloning the incoming state.
             let facet_schema = facet
                 .into_iter()
                 .map(|(field, pipeline)| {

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/expression.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/expression.rs
@@ -13,110 +13,110 @@ use std::collections::BTreeMap;
 mod literal {
     use super::*;
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_binary,
         expected = Ok(Schema::Atomic(Atomic::BinData)),
         input = r#"{"$binary" : {"base64" : "", "subType" : "04"}}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_bool,
         expected = Ok(Schema::Atomic(Atomic::Boolean)),
         input = r#"true"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_date,
         expected = Ok(Schema::Atomic(Atomic::Date)),
         input = r#"{ "$date": { "$numberLong": "1655956513000" } }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_dbpointer,
         expected = Ok(Schema::Atomic(Atomic::DbPointer)),
         input =
             r#"{ "$dbPointer": { "$ref": "foo", "$id": { "$oid": "57e193d7a9cc81b4027498b5" } } }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_decimal,
         expected = Ok(Schema::Atomic(Atomic::Decimal)),
         input = r#"{ "$numberDecimal": "3.0" }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_double,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#"{ "$numberDouble": "3.0" }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_int,
         expected = Ok(Schema::Atomic(Atomic::Integer)),
         input = r#"{ "$numberInt": "3" }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_long,
         expected = Ok(Schema::Atomic(Atomic::Long)),
         input = r#"{ "$numberLong": "3" }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_javascript,
         expected = Ok(Schema::Atomic(Atomic::Javascript)),
         input = r#"{ "$code": "function() {}" }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_javascript_with_scope,
         expected = Ok(Schema::Atomic(Atomic::JavascriptWithScope)),
         input = r#"{ "$code": "function() {}", "$scope": { } }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_maxkey,
         expected = Ok(Schema::Atomic(Atomic::MaxKey)),
         input = r#"{ "$maxKey": 1 }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_minkey,
         expected = Ok(Schema::Atomic(Atomic::MinKey)),
         input = r#"{ "$minKey": 1 }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"null"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_oid,
         expected = Ok(Schema::Atomic(Atomic::ObjectId)),
         input = r#"{"$oid": "5d505646cf6d4fe581014ab2"}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_regex,
         expected = Ok(Schema::Atomic(Atomic::Regex)),
         input = r#" { "$regularExpression": { "pattern": "abc*", "options": "ix" } }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_string,
         expected = Ok(Schema::Atomic(Atomic::String)),
         input = r#""foo bar""#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_symbol,
         expected = Ok(Schema::Atomic(Atomic::Symbol)),
         input = r#"{ "$symbol": "sym2" }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         literal_timestamp,
         expected = Ok(Schema::Atomic(Atomic::Timestamp)),
         input = r#"{ "$timestamp": { "t": 42, "i": 1 } }"#
@@ -125,7 +125,7 @@ mod literal {
 mod field_ref {
     use super::*;
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         variable_ref_present,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#""$$foo""#,
@@ -135,7 +135,7 @@ mod field_ref {
         }
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         variable_ref_missing,
         expected = Err(Error::UnknownReference("foo".to_string())),
         input = r#""$$foo""#,
@@ -143,7 +143,7 @@ mod field_ref {
         variables = map!()
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         field_ref,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#""$foo""#,
@@ -151,7 +151,7 @@ mod field_ref {
         variables = map!()
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         nested_field_ref,
         expected = Ok(Schema::AnyOf(
             set! {Schema::Missing, Schema::Atomic(Atomic::Double)}
@@ -166,7 +166,7 @@ mod field_ref {
         variables = map!()
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         field_ref_missing,
         expected = Ok(Schema::Missing),
         input = r#""$foo""#
@@ -176,19 +176,19 @@ mod field_ref {
 mod array {
     use super::*;
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         empty_array,
         expected = Ok(Schema::Array(Box::new(Schema::Unsat))),
         input = r#"[]"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         array_single_type,
         expected = Ok(Schema::Array(Box::new(Schema::Atomic(Atomic::Integer)))),
         input = r#"[1, 2, 3]"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         array_multiple_types,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -197,7 +197,7 @@ mod array {
         input = r#"[1, 2, 3, "foo", "bar"]"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         nested_arrays_not_merged,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Array(Box::new(Schema::AnyOf(set!(
@@ -213,13 +213,13 @@ mod array {
 mod document {
     use super::*;
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         empty_document,
         expected = Ok(Schema::Document(Document::default())),
         input = r#"{}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         document_simple,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -232,7 +232,7 @@ mod document {
         input = r#"{"a": 1, "b": "foo"}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         document_nested,
         expected = Ok(Schema::Document(Document {
             keys: map! {

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
@@ -1,4 +1,32 @@
-macro_rules! test_derive_schema {
+macro_rules! test_derive_stage_schema {
+    // ref_schema and starting_schema are mutually exclusive. ref_schema should be used when only
+    // one reference is needed, while starting_schema should be used when the schema needs multiple
+    // fields.
+    ($func_name:ident, expected = $expected:expr, input = $input:expr$(, starting_schema = $starting_schema:expr)?$(, ref_schema = $ref_schema:expr)?$(, variables = $variables:expr)?) => {
+        #[test]
+        fn $func_name() {
+            let input: Stage = serde_json::from_str($input).unwrap();
+            println!("{:?}", input);
+            #[allow(unused_mut, unused_assignments)]
+            let mut result_set_schema = Schema::Any;
+            $(result_set_schema = Schema::Document(Document { keys: map! {"foo".to_string() => $ref_schema }, required: set! {"foo".to_string()}, ..Default::default()});)?
+            $(result_set_schema = $starting_schema;)?
+            #[allow(unused_mut, unused_assignments)]
+            let mut variables = BTreeMap::new();
+            $(variables = $variables;)?
+            let mut state = ResultSetState {
+                catalog: &BTreeMap::new(),
+                variables,
+                result_set_schema,
+                null_behavior: Satisfaction::Not
+            };
+            let result = input.derive_schema(&mut state);
+            assert_eq!($expected, result);
+        }
+    };
+}
+
+macro_rules! test_derive_expression_schema {
     // ref_schema and starting_schema are mutually exclusive. ref_schema should be used when only
     // one reference is needed, while starting_schema should be used when the schema needs multiple
     // fields.

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
@@ -6,7 +6,6 @@ macro_rules! test_derive_stage_schema {
         #[test]
         fn $func_name() {
             let input: Stage = serde_json::from_str($input).unwrap();
-            println!("{:?}", input);
             #[allow(unused_mut, unused_assignments)]
             let mut result_set_schema = Schema::Any;
             $(result_set_schema = Schema::Document(Document { keys: map! {"foo".to_string() => $ref_schema }, required: set! {"foo".to_string()}, ..Default::default()});)?

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -1,1 +1,445 @@
+use crate::{DeriveSchema, ResultSetState};
+use agg_ast::definitions::Stage;
+use mongosql::{
+    map,
+    schema::{Atomic, Document, Satisfaction, Schema},
+    set,
+};
+use std::collections::BTreeMap;
 
+mod densify {
+    use super::*;
+
+    test_derive_stage_schema!(
+        densify_fully_specified,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::Integer),
+                "bar".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "a".to_string() => Schema::Atomic(Atomic::String),
+                        "b".to_string() => Schema::Document(Document { keys:
+                            map! {
+                                "c".to_string() => Schema::Atomic(Atomic::BinData),
+                                "d".to_string() => Schema::Atomic(Atomic::Boolean)
+                            },
+                            required: set!("c".to_string()),
+                            ..Default::default()
+                        })
+                    },
+                    required: set!("b".to_string()),
+                    ..Default::default()
+                }),
+                "x".to_string() => Schema::Atomic(Atomic::Date),
+                "y".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "z".to_string() => Schema::Atomic(Atomic::Double)
+                    },
+                    required: set!("z".to_string()),
+                    ..Default::default()
+                })
+            },
+            required: set!("bar".to_string(), "x".to_string(), "y".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$densify": {"field": "bar.b.c", "partitionByFields": ["x", "y.z"], "range": { "step": 1, "bounds": "full", "unit": "second" }}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::Integer),
+                "bar".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "a".to_string() => Schema::Atomic(Atomic::String),
+                        "b".to_string() => Schema::Document(Document { keys:
+                            map! {
+                                "c".to_string() => Schema::Atomic(Atomic::BinData),
+                                "d".to_string() => Schema::Atomic(Atomic::Boolean)
+                            },
+                            required: set!("c".to_string(), "d".to_string()),
+                            ..Default::default()
+                        })
+                    },
+                    required: set!("a".to_string()),
+                    ..Default::default()
+                }),
+                "x".to_string() => Schema::Atomic(Atomic::Date),
+                "y".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "z".to_string() => Schema::Atomic(Atomic::Double)
+                    },
+                    ..Default::default()
+                })
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+}
+
+mod documents {
+    use super::*;
+
+    test_derive_stage_schema!(
+        empty,
+        expected = Ok(Schema::Document(Document::default())),
+        input = r#"{"$documents": []}"#
+    );
+
+    test_derive_stage_schema!(
+        singleton,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "a".to_string() => Schema::Atomic(Atomic::Integer)
+            },
+            required: set!("a".to_string()),
+            ..Default::default()
+        })),
+        input = r#" {"$documents": [{"a": 1}]}"#
+    );
+
+    test_derive_stage_schema!(
+        multiple_documents,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "a".to_string() => Schema::AnyOf(set!(
+                    Schema::Atomic(Atomic::Integer),
+                    Schema::Atomic(Atomic::String),
+                    Schema::Document(Document {
+                        keys: map! {
+                            "b".to_string() => Schema::Document(Document {
+                                keys: map!{
+                                    "c".to_string() => Schema::Atomic(Atomic::Boolean)
+                                },
+                                required: set!("c".to_string()),
+                                ..Default::default()
+                            })
+                        },
+                        required: set!("b".to_string()),
+                        ..Default::default()
+                    })
+                )),
+                "b".to_string() => Schema::AnyOf(set!(
+                    Schema::Atomic(Atomic::Null),
+                    Schema::Atomic(Atomic::Integer)
+                ))
+            },
+            required: set!("a".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$documents": [
+                     {"a": 1, "b": 2},
+                     {"a": "yes", "b": null},
+                     {"a": {"b": {"c": true}}}
+        ]}"#
+    );
+}
+
+// mod facet {
+//     use super::*;
+
+//     test_derive_stage_schema!(
+//         empty,
+//         expected = Ok(Schema::Document(Document::default())),
+//         input = r#"stage: {"$facet": {}}"#
+//     );
+
+//     test_derive_stage_schema!(
+//         single,
+//         expected = Ok(Schema::Document(Document {
+//             keys: map! {
+//                 "outputField1".to_string() => Schema::Array(Box::new(
+//                     Schema::Document(Document {
+//                         keys: map! {
+//                             "x".to_string() => Schema::Atomic(Atomic::Integer)
+//                         },
+//                         required: set!("x".to_string()),
+//                         ..Default::default()
+//                     })
+//                 ))
+//             },
+//             required: set!("outputField1".to_string()),
+//             ..Default::default()
+//         })),
+//         input = r#"{"$facet": { "outputField1": [{"$count": "x"}] }}"#
+//     );
+
+//     test_derive_stage_schema!(
+//         multiple,
+//         expected = Ok(Schema::Document(Document {
+//             keys: map! {
+//                 "o1".to_string() => Schema::Array(Box::new(
+//                     Schema::Document(Document {
+//                         keys: map! {
+//                             "x".to_string() => Schema::Atomic(Atomic::String),
+//                         },
+//                         required: set!(),
+//                         ..Default::default()
+//                     })
+//                 )),
+//                 "outputField2".to_string() => Schema::Array(Box::new(
+//                     Schema::Document(Document {
+//                         keys: map! {
+//                             "x".to_string() => Schema::Atomic(Atomic::Integer)
+//                         },
+//                         required: set!(),
+//                         ..Default::default()
+//                     })
+//                 ))
+//             },
+//             required: set!("outputField1".to_string()),
+//             ..Default::default()
+//         })),
+//         input = r#"{"$facet": {
+//             "o1": [{"$limit": 10}, {"$project": {"_id": 0}}],
+//             "outputField2": [{"$count": "x"}],
+//         }}"#,
+//         starting_schema = Schema::Document(Document {
+//             keys: map! {
+//                 "x".to_string() => Schema::Atomic(Atomic::String),
+//                 "_id".to_string() => Schema::Atomic(Atomic::ObjectId)
+//             },
+//             required: set!("_id".to_string()),
+//             ..Default::default()
+//         })
+//     );
+// }
+
+mod geo_near {
+    use super::*;
+
+    test_derive_stage_schema!(
+        geo_near_no_options,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "name".to_string() => Schema::Atomic(Atomic::String),
+                "location".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "type".to_string() => Schema::Atomic(Atomic::String),
+                        "coordinates".to_string() => Schema::Array(Box::new(Schema::Atomic(Atomic::Double)))
+                    },
+                    required: set!("type".to_string(), "coordinates".to_string()),
+                    ..Default::default()
+                }),
+                "category".to_string() => Schema::Atomic(Atomic::String),
+                "f".to_string() => Schema::Atomic(Atomic::Double)
+            },
+            required: set!(
+                "name".to_string(),
+                "location".to_string(),
+                "category".to_string()
+            ),
+            ..Default::default()
+        })),
+        input = r#"{"$geoNear": {
+                   "distanceField": "f",
+                   "near": {
+                       "type": "Point",
+                       "coordinates": [-73.856077, 40.848447],
+                   }
+        }}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "name".to_string() => Schema::Atomic(Atomic::String),
+                "location".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "type".to_string() => Schema::Atomic(Atomic::String),
+                        "coordinates".to_string() => Schema::Array(Box::new(Schema::Atomic(Atomic::Double)))
+                    },
+                    required: set!("type".to_string(), "coordinates".to_string()),
+                    ..Default::default()
+                }),
+                "category".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!(
+                "name".to_string(),
+                "location".to_string(),
+                "category".to_string()
+            ),
+            ..Default::default()
+        })
+    );
+
+    test_derive_stage_schema!(
+        geo_near_include_loc,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "name".to_string() => Schema::Atomic(Atomic::String),
+                "location".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "type".to_string() => Schema::Atomic(Atomic::String),
+                        "coordinates".to_string() => Schema::Array(Box::new(Schema::Atomic(Atomic::Double)))
+                    },
+                    required: set!("type".to_string(), "coordinates".to_string()),
+                    ..Default::default()
+                }),
+                "category".to_string() => Schema::Atomic(Atomic::String),
+                "dist".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "calculated".to_string() => Schema::Atomic(Atomic::Double),
+                        "location".to_string() => Schema::Document(Document {
+                            keys: map! {
+                                "type".to_string() => Schema::Atomic(Atomic::String),
+                                "coordinates".to_string() => Schema::Array(Box::new(Schema::Atomic(Atomic::Double)))
+                            },
+                            required: set!("type".to_string(), "coordinates".to_string()),
+                            ..Default::default()
+                        })
+                    },
+                    required: set!("type".to_string(), "coordinates".to_string()),
+                    ..Default::default()
+                })
+            },
+            required: set!(
+                "name".to_string(),
+                "location".to_string(),
+                "category".to_string()
+            ),
+            ..Default::default()
+        })),
+        input = r#"{"$geoNear": {
+                   "distanceField": "dist.calculated",
+                   "near": {
+                       "type": "Point",
+                       "coordinates": [-73.856077, 40.848447],
+                   },
+                   "includeLocs": "dist.location"
+        }}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "name".to_string() => Schema::Atomic(Atomic::String),
+                "location".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "type".to_string() => Schema::Atomic(Atomic::String),
+                        "coordinates".to_string() => Schema::Array(Box::new(Schema::Atomic(Atomic::Double)))
+                    },
+                    required: set!("type".to_string(), "coordinates".to_string()),
+                    ..Default::default()
+                }),
+                "category".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!(
+                "name".to_string(),
+                "location".to_string(),
+                "category".to_string()
+            ),
+            ..Default::default()
+        })
+    );
+}
+
+mod sort_by_count {
+    use super::*;
+
+    test_derive_stage_schema!(
+        field_ref,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "_id".to_string() => Schema::Atomic(Atomic::Symbol),
+                "count".to_string() => Schema::AnyOf(set!(Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::Long)))
+            },
+            required: set!("_id".to_string(), "count".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{ "$sortByCount": "$foo" }"#,
+        ref_schema = Schema::Atomic(Atomic::Symbol)
+    );
+}
+
+mod unwind {
+    use super::*;
+
+    test_derive_stage_schema!(
+        field_ref,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::Double)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{ "$unwind": "$foo" }"#,
+        ref_schema = Schema::Array(Box::new(Schema::Atomic(Atomic::Double)))
+    );
+
+    test_derive_stage_schema!(
+        field_ref_nested,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "bar".to_string() => Schema::Atomic(Atomic::Double)
+                    },
+                    required: set!("bar".to_string()),
+                    ..Default::default()
+                })
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$unwind": {"path": "$foo.bar"}}"#,
+        ref_schema = Schema::Document(Document {
+            keys: map! {
+                "bar".to_string() => Schema::Array(Box::new(Schema::Atomic(Atomic::Double)))
+            },
+            required: set!("bar".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_stage_schema!(
+        document_no_options,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::Double)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$unwind": {"path": "$foo"}}"#,
+        ref_schema = Schema::Array(Box::new(Schema::Atomic(Atomic::Double)))
+    );
+
+    test_derive_stage_schema!(
+        document_include_array_index_not_null,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::Double),
+                "i".to_string() => Schema::Atomic(Atomic::Integer)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$unwind": {"path": "$foo", "includeArrayIndex": "i"}}"#,
+        ref_schema = Schema::Array(Box::new(Schema::Atomic(Atomic::Double)))
+    );
+
+    test_derive_stage_schema!(
+        document_all_options,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::AnyOf(set!(
+                    Schema::Atomic(Atomic::String),
+                    Schema::Atomic(Atomic::Null)
+                )),
+                "foo".to_string() => Schema::Atomic(Atomic::String),
+                "i".to_string() => Schema::AnyOf(set!(
+                    Schema::Atomic(Atomic::Integer),
+                    Schema::Atomic(Atomic::Null)
+                )),
+            },
+            required: set!("bar".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$unwind": {"path": "$foo", "includeArrayIndex": "i", "preserveNullAndEmptyArrays": true }}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::AnyOf(set!(
+                    Schema::Array(Box::new(Schema::Atomic(Atomic::Double))),
+                    Schema::Atomic(Atomic::Null)
+                )),
+                "bar".to_string() => Schema::Atomic(Atomic::ObjectId)
+            },
+            required: set!("bar".to_string()),
+            ..Default::default()
+        })
+    );
+}

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -130,75 +130,76 @@ mod documents {
     );
 }
 
-// mod facet {
-//     use super::*;
+mod facet {
+    // SQL-2369: implement schema derivation for bucketing stages
+    //     use super::*;
 
-//     test_derive_stage_schema!(
-//         empty,
-//         expected = Ok(Schema::Document(Document::default())),
-//         input = r#"stage: {"$facet": {}}"#
-//     );
+    //     test_derive_stage_schema!(
+    //         empty,
+    //         expected = Ok(Schema::Document(Document::default())),
+    //         input = r#"stage: {"$facet": {}}"#
+    //     );
 
-//     test_derive_stage_schema!(
-//         single,
-//         expected = Ok(Schema::Document(Document {
-//             keys: map! {
-//                 "outputField1".to_string() => Schema::Array(Box::new(
-//                     Schema::Document(Document {
-//                         keys: map! {
-//                             "x".to_string() => Schema::Atomic(Atomic::Integer)
-//                         },
-//                         required: set!("x".to_string()),
-//                         ..Default::default()
-//                     })
-//                 ))
-//             },
-//             required: set!("outputField1".to_string()),
-//             ..Default::default()
-//         })),
-//         input = r#"{"$facet": { "outputField1": [{"$count": "x"}] }}"#
-//     );
+    //     test_derive_stage_schema!(
+    //         single,
+    //         expected = Ok(Schema::Document(Document {
+    //             keys: map! {
+    //                 "outputField1".to_string() => Schema::Array(Box::new(
+    //                     Schema::Document(Document {
+    //                         keys: map! {
+    //                             "x".to_string() => Schema::Atomic(Atomic::Integer)
+    //                         },
+    //                         required: set!("x".to_string()),
+    //                         ..Default::default()
+    //                     })
+    //                 ))
+    //             },
+    //             required: set!("outputField1".to_string()),
+    //             ..Default::default()
+    //         })),
+    //         input = r#"{"$facet": { "outputField1": [{"$count": "x"}] }}"#
+    //     );
 
-//     test_derive_stage_schema!(
-//         multiple,
-//         expected = Ok(Schema::Document(Document {
-//             keys: map! {
-//                 "o1".to_string() => Schema::Array(Box::new(
-//                     Schema::Document(Document {
-//                         keys: map! {
-//                             "x".to_string() => Schema::Atomic(Atomic::String),
-//                         },
-//                         required: set!(),
-//                         ..Default::default()
-//                     })
-//                 )),
-//                 "outputField2".to_string() => Schema::Array(Box::new(
-//                     Schema::Document(Document {
-//                         keys: map! {
-//                             "x".to_string() => Schema::Atomic(Atomic::Integer)
-//                         },
-//                         required: set!(),
-//                         ..Default::default()
-//                     })
-//                 ))
-//             },
-//             required: set!("outputField1".to_string()),
-//             ..Default::default()
-//         })),
-//         input = r#"{"$facet": {
-//             "o1": [{"$limit": 10}, {"$project": {"_id": 0}}],
-//             "outputField2": [{"$count": "x"}],
-//         }}"#,
-//         starting_schema = Schema::Document(Document {
-//             keys: map! {
-//                 "x".to_string() => Schema::Atomic(Atomic::String),
-//                 "_id".to_string() => Schema::Atomic(Atomic::ObjectId)
-//             },
-//             required: set!("_id".to_string()),
-//             ..Default::default()
-//         })
-//     );
-// }
+    //     test_derive_stage_schema!(
+    //         multiple,
+    //         expected = Ok(Schema::Document(Document {
+    //             keys: map! {
+    //                 "o1".to_string() => Schema::Array(Box::new(
+    //                     Schema::Document(Document {
+    //                         keys: map! {
+    //                             "x".to_string() => Schema::Atomic(Atomic::String),
+    //                         },
+    //                         required: set!(),
+    //                         ..Default::default()
+    //                     })
+    //                 )),
+    //                 "outputField2".to_string() => Schema::Array(Box::new(
+    //                     Schema::Document(Document {
+    //                         keys: map! {
+    //                             "x".to_string() => Schema::Atomic(Atomic::Integer)
+    //                         },
+    //                         required: set!(),
+    //                         ..Default::default()
+    //                     })
+    //                 ))
+    //             },
+    //             required: set!("outputField1".to_string()),
+    //             ..Default::default()
+    //         })),
+    //         input = r#"{"$facet": {
+    //             "o1": [{"$limit": 10}, {"$project": {"_id": 0}}],
+    //             "outputField2": [{"$count": "x"}],
+    //         }}"#,
+    //         starting_schema = Schema::Document(Document {
+    //             keys: map! {
+    //                 "x".to_string() => Schema::Atomic(Atomic::String),
+    //                 "_id".to_string() => Schema::Atomic(Atomic::ObjectId)
+    //             },
+    //             required: set!("_id".to_string()),
+    //             ..Default::default()
+    //         })
+    //     );
+}
 
 mod sort_by_count {
     use super::*;

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/tagged_ops.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/tagged_ops.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 mod misc_ops {
     use super::*;
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         constant_integral,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -20,7 +20,7 @@ mod misc_ops {
     );
 
     // $cond
-    test_derive_schema!(
+    test_derive_expression_schema!(
         cond,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -32,7 +32,7 @@ mod misc_ops {
 
 mod window_ops {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         window_func_decimal,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Decimal),
@@ -42,7 +42,7 @@ mod window_ops {
         ref_schema = Schema::Atomic(Atomic::Decimal)
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         window_func_double_by_default,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Double),
@@ -51,13 +51,13 @@ mod window_ops {
         input = r#"{ "$derivative": { "input": 123, "unit": "hour" } }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         window_func_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{ "$derivative": { "input": null, "unit": "hour" } }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         window_func_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Double),
@@ -67,7 +67,7 @@ mod window_ops {
         ref_schema = Schema::AnyOf(set!(Schema::Missing, Schema::Atomic(Atomic::Integer)))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         locf,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -80,7 +80,7 @@ mod window_ops {
 
 mod array_ops {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         zip_no_defaults,
         expected = Ok(Schema::Array(Box::new(Schema::Array(Box::new(
             Schema::AnyOf(set!(
@@ -94,7 +94,7 @@ mod array_ops {
             Schema::Atomic(Atomic::String),
         ))))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         zip_defaults,
         expected = Ok(Schema::Array(Box::new(Schema::Array(Box::new(
             Schema::AnyOf(set!(
@@ -105,7 +105,7 @@ mod array_ops {
         input = r#"{"$zip": {"inputs": ["$foo", [1,2,3]], "defaults": ["hello"]}}"#,
         ref_schema = Schema::Array(Box::new(Schema::Atomic(Atomic::Integer)))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         zip_error,
         expected = Err(crate::Error::InvalidExpressionForField(
             "Literal(String(\"hello\"))".to_string(),
@@ -113,7 +113,7 @@ mod array_ops {
         )),
         input = r#"{"$zip": {"inputs": "hello"}}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         map_this,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -125,7 +125,7 @@ mod array_ops {
             Schema::Atomic(Atomic::Double),
         ))))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         map_as,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -137,7 +137,7 @@ mod array_ops {
             Schema::Atomic(Atomic::Double),
         ))))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         map_error,
         expected = Err(crate::Error::InvalidExpressionForField(
             "Literal(String(\"hello\"))".to_string(),
@@ -145,7 +145,7 @@ mod array_ops {
         )),
         input = r#"{"$map": {"input": "hello", "in": "foo"}}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         reduce,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -157,7 +157,7 @@ mod array_ops {
             Schema::Atomic(Atomic::Double),
         ))))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         reduce_error,
         expected = Err(crate::Error::InvalidExpressionForField(
             "Literal(String(\"hello\"))".to_string(),
@@ -169,7 +169,7 @@ mod array_ops {
 
 mod group_ops {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         top_expression,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(
             set! {Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::String)}
@@ -180,7 +180,7 @@ mod group_ops {
                    }}"#,
         ref_schema = Schema::Atomic(Atomic::Integer)
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         top_n_expression,
         expected = Ok(Schema::Array(Box::new(Schema::Array(Box::new(
             Schema::AnyOf(set! {Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::String)})
@@ -192,7 +192,7 @@ mod group_ops {
                    }}"#,
         ref_schema = Schema::Atomic(Atomic::Integer)
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         bottom_expression,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(
             set! {Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::String)}
@@ -203,7 +203,7 @@ mod group_ops {
                    }}"#,
         ref_schema = Schema::Atomic(Atomic::Integer)
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         bottom_n_expression,
         expected = Ok(Schema::Array(Box::new(Schema::Array(Box::new(
             Schema::AnyOf(set! {Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::String)})
@@ -215,7 +215,7 @@ mod group_ops {
                    }}"#,
         ref_schema = Schema::Atomic(Atomic::Integer)
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         max_n,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set! {
             Schema::Atomic(Atomic::Integer),
@@ -237,7 +237,7 @@ mod group_ops {
             Schema::Atomic(Atomic::MaxKey),
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         min_n,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set! {
             Schema::Atomic(Atomic::Integer),
@@ -259,7 +259,7 @@ mod group_ops {
             Schema::Atomic(Atomic::MaxKey),
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         push,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -273,7 +273,7 @@ mod group_ops {
             Schema::Atomic(Atomic::Null),
         ))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         add_to_set,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -292,13 +292,13 @@ mod group_ops {
 mod numeric_ops {
     use super::*;
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         median_double,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#"{ "$median": { "input": 123, "method": "approximate" } }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         median_double_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Double),
@@ -311,7 +311,7 @@ mod numeric_ops {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         median_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Double),
@@ -321,7 +321,7 @@ mod numeric_ops {
         ref_schema = Schema::AnyOf(set!(Schema::Atomic(Atomic::Integer), Schema::Missing))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         median_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{ "$median": { "input": null, "method": "approximate" } }"#
@@ -330,7 +330,7 @@ mod numeric_ops {
 
 mod string_ops {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         regex_find,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Null),
@@ -347,7 +347,7 @@ mod string_ops {
         input = r#"{ "$regexFind": { "input": "$category", "regex": "/cafe/" }  }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         regex_find_all,
         expected = Ok(Schema::Array(Box::new(Schema::Document(Document {
             keys: map! {
@@ -361,25 +361,25 @@ mod string_ops {
         input = r#"{ "$regexFindAll": { "input": "$category", "regex": "/cafe/" }  }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         trim_string,
         expected = Ok(Schema::Atomic(Atomic::String)),
         input = r#"{ "$trim": { "input": "hi friend", "chars": "hi" }  }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         trim_input_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{ "$trim": { "input": null, "chars": "hi" }  }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         trim_chars_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{ "$trim": { "input": "hi", "chars": null } }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         trim_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::String),
@@ -392,7 +392,7 @@ mod string_ops {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         trim_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::String),
@@ -405,19 +405,19 @@ mod string_ops {
 
 mod date_operators {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{ "$hour": null }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_integer,
         expected = Ok(Schema::Atomic(Atomic::Integer)),
         input = r#"{ "$hour": {"$date": {"$numberLong": "123"}} }"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Null),
@@ -430,7 +430,7 @@ mod date_operators {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Null),
@@ -440,31 +440,31 @@ mod date_operators {
         ref_schema = Schema::AnyOf(set!(Schema::Missing, Schema::Atomic(Atomic::Date),))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_timezone_specified_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{ "$hour": {"date": {"$date": {"$numberLong": "123"}}, "timezone": null }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_string_simple,
         expected = Ok(Schema::Atomic(Atomic::Date)),
         input = r#"{ "$dateFromString": {"dateString": "hello" }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_string_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{ "$dateFromString": {"dateString": null }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_string_null_with_on_null,
         expected = Ok(Schema::Atomic(Atomic::Integer)),
         input = r#"{ "$dateFromString": {"dateString": null, "onNull": 1 }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_string_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -477,7 +477,7 @@ mod date_operators {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_string_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -487,13 +487,13 @@ mod date_operators {
         ref_schema = Schema::AnyOf(set!(Schema::Atomic(Atomic::String), Schema::Missing))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_parts_simple,
         expected = Ok(Schema::Atomic(Atomic::Date)),
         input = r#"{ "$dateFromParts": {"year": 2022, "month": 1, "day": 1 }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_parts_one_arg_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -506,7 +506,7 @@ mod date_operators {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_parts_one_arg_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -516,13 +516,13 @@ mod date_operators {
         ref_schema = Schema::AnyOf(set!(Schema::Atomic(Atomic::Integer), Schema::Missing))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_parts_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{ "$dateFromParts": {"year": 2022, "month": 1, "day": 3, "hour": null, "minute": 2, "second": 4}}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_string_with_on_error,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -531,13 +531,13 @@ mod date_operators {
         input = r#"{ "$dateFromString": {"dateString": "hello", "onError": 1 }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_string_not_null_ignores_on_null,
         expected = Ok(Schema::Atomic(Atomic::Date)),
         input = r#"{ "$dateFromString": {"dateString": "hello", "onNull": 1 }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_from_string_nullish_fully_specified,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -551,7 +551,7 @@ mod date_operators {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_to_parts_standard,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -577,7 +577,7 @@ mod date_operators {
         input = r#"{ "$dateToParts": {"date": {"$date": {"$numberLong": "123"}} }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_to_parts_iso8601,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -603,20 +603,20 @@ mod date_operators {
         input = r#"{"$dateToParts": {"date":{"$date": {"$numberLong": "123"}}, "iso8601": true }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_to_parts_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{"$dateToParts": {"date": null, "iso8601": true }}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_to_string,
         expected = Ok(Schema::Atomic(Atomic::String)),
         input = r#"{"$dateToString": {"date": "$foo"}}"#,
         ref_schema = Schema::Atomic(Atomic::Date)
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_to_string_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::String),
@@ -629,7 +629,7 @@ mod date_operators {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_to_string_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::String),
@@ -639,14 +639,14 @@ mod date_operators {
         ref_schema = Schema::AnyOf(set!(Schema::Atomic(Atomic::Date), Schema::Missing))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_to_string_not_null_ignores_on_null,
         expected = Ok(Schema::Atomic(Atomic::String)),
         input = r#"{"$dateToString": {"date": "$foo", "onNull": 1}}"#,
         ref_schema = Schema::Atomic(Atomic::Date)
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_to_string_nullish_fully_specified,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::String),
@@ -659,19 +659,19 @@ mod date_operators {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_addition_all_args,
         expected = Ok(Schema::Atomic(Atomic::Date)),
         input = r#"{"$dateAdd": {"startDate": {"$date": {"$numberLong": "123"}}, "unit": "hour", "amount": "1", "timezone": "America/New_York"}}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_addition_one_arg_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{"$dateAdd": {"startDate": null, "unit": "hour", "amount": "1", "timezone": "America/New_York"}}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_addition_one_arg_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -684,7 +684,7 @@ mod date_operators {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_addition_one_arg_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -694,7 +694,7 @@ mod date_operators {
         ref_schema = Schema::AnyOf(set!(Schema::Atomic(Atomic::Date), Schema::Missing))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_trunc_one_arg_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -707,7 +707,7 @@ mod date_operators {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_trunc_one_arg_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -717,19 +717,19 @@ mod date_operators {
         ref_schema = Schema::AnyOf(set!(Schema::Atomic(Atomic::Date), Schema::Missing))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_trunc_all_args,
         expected = Ok(Schema::Atomic(Atomic::Date)),
         input = r#"{"$dateTrunc": {"date": {"$date": {"$numberLong": "123"}}, "unit": "hour", "binSize": "1", "startOfWeek": "mon", "timezone": "America/New_York"}}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_trunc_one_arg_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{"$dateTrunc": {"date": null, "unit": "hour", "binSize": "1", "startOfWeek": "mon", "timezone": "America/New_York"}}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_diff_one_arg_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -742,7 +742,7 @@ mod date_operators {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_diff_one_arg_possibly_missing,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -752,13 +752,13 @@ mod date_operators {
         ref_schema = Schema::AnyOf(set!(Schema::Atomic(Atomic::Date), Schema::Missing))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_diff_all_args,
         expected = Ok(Schema::Atomic(Atomic::Date)),
         input = r#"{"$dateDiff": {"startDate": {"$date": {"$numberLong": "121"}}, "endDate": {"$date": {"$numberLong": "123"}}, "unit": "hour", "startOfWeek": "mon", "timezone": "America/New_York"}}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         date_diff_one_arg_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{"$dateDiff": {"startDate": {"$date": {"$numberLong": "123"}}, "endDate": null, "unit": "hour", "startOfWeek": "mon", "timezone": "America/New_York"}}"#
@@ -768,7 +768,7 @@ mod date_operators {
 mod field_setter_ops {
     use super::*;
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         get_field,
         expected = Ok(Schema::Atomic(Atomic::String)),
         input = r#"{ "$getField": { "input": "$foo", "field": "x" } }"#,
@@ -782,7 +782,7 @@ mod field_setter_ops {
         })
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         get_field_missing,
         expected = Ok(Schema::Missing),
         input = r#"{ "$getField": { "input": "$foo", "field": "z" } }"#,
@@ -796,7 +796,7 @@ mod field_setter_ops {
         })
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_field,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -817,7 +817,7 @@ mod field_setter_ops {
         })
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_field_root,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -831,7 +831,7 @@ mod field_setter_ops {
         ref_schema = Schema::Atomic(Atomic::Integer)
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_field_new_field,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -853,7 +853,7 @@ mod field_setter_ops {
         })
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_field_remove,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -873,7 +873,7 @@ mod field_setter_ops {
         })
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_field_remove_non_existing_field,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -894,7 +894,7 @@ mod field_setter_ops {
         })
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         unset_field,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -914,7 +914,7 @@ mod field_setter_ops {
         })
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         unset_field_non_exising_field,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -935,14 +935,14 @@ mod field_setter_ops {
         })
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         let_simple,
         expected = Ok(Schema::Atomic(Atomic::Decimal)),
         input = r#"{ "$let": { "vars": {"x": {"$numberDecimal": "1"}}, "in": {"$multiply": ["$$x", "$foo"]}} }"#,
         ref_schema = Schema::Atomic(Atomic::Integer)
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         let_accesses_existing_variables,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Decimal),
@@ -958,7 +958,7 @@ mod field_setter_ops {
         }
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         let_overwrites_existing_variables,
         expected = Ok(Schema::Atomic(Atomic::Decimal)),
         input = r#"{ "$let": { "vars": {"x": {"$numberDecimal": "1"}}, "in": {"$multiply": ["$$x", "$foo"]}} }"#,

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
@@ -46,35 +46,35 @@ macro_rules! test_type_conversion_op {
 
 mod array_ops {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         array_elem_at_missing_field,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{"$arrayElemAt": ["$food", 0]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         array_elem_at_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{"$arrayElemAt": [null, 0]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         array_elem_at_array_field,
         expected = Ok(Schema::Atomic(Atomic::Integer)),
         input = r#"{"$arrayElemAt": ["$foo", 0]}"#,
         ref_schema = Schema::Array(Box::new(Schema::Atomic(Atomic::Integer)))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         array_elem_at_literal_array,
         expected = Ok(Schema::AnyOf(
             set! {Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::String)}
         )),
         input = r#"{"$arrayElemAt": [[1, "hello", 3], 0]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         array_to_object,
         expected = Ok(Schema::Document(Document::any())),
         input = r#"{"$arrayToObject": [["foo", 1], ["bar", "hello"]]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         concat_arrays,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -87,7 +87,7 @@ mod array_ops {
             Schema::Atomic(Atomic::Double)
         ))))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_union,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -100,7 +100,7 @@ mod array_ops {
             Schema::Atomic(Atomic::Double)
         ))))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_intersection_multi,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -112,7 +112,7 @@ mod array_ops {
             Schema::Atomic(Atomic::Double)
         ))))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_intersection_multi_int_only,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -124,12 +124,12 @@ mod array_ops {
             Schema::Atomic(Atomic::Double)
         ))))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_intersection_empty,
         expected = Ok(Schema::Array(Box::new(Schema::Atomic(Atomic::Null),))),
         input = r#"{"$setIntersection": ["$foo", []]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_intersection_empty_set,
         expected = Ok(Schema::Array(Box::new(Schema::Unsat))),
         input = r#"{"$setIntersection": ["$foo", ["hello", "world"]]}"#,
@@ -138,7 +138,7 @@ mod array_ops {
             Schema::Atomic(Atomic::Double)
         ))))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         set_difference,
         expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -154,7 +154,7 @@ mod array_ops {
 
 mod group_ops {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         max,
         expected = Ok(Schema::Atomic(Atomic::MaxKey)),
         input = r#"{"$max": "$foo"}"#,
@@ -168,7 +168,7 @@ mod group_ops {
             Schema::Atomic(Atomic::MaxKey),
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         min,
         expected = Ok(Schema::AnyOf(set! {
             Schema::Atomic(Atomic::Double),
@@ -190,7 +190,7 @@ mod group_ops {
 
 mod constant_ops {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         no_ops,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -203,19 +203,19 @@ mod constant_ops {
         ))
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         constant_boolean,
         expected = Ok(Schema::Atomic(Atomic::Boolean)),
         input = r#"{"$eq": ["foo", "$bar"]}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         constant_int,
         expected = Ok(Schema::Atomic(Atomic::Integer)),
         input = r#"{"$strLenBytes": "hello world"}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         constant_integral,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -224,25 +224,25 @@ mod constant_ops {
         input = r#"{"$count": {}}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         constant_double,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#"{"$rand": {}}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         constant_array_int,
         expected = Ok(Schema::Array(Box::new(Schema::Atomic(Atomic::Integer)))),
         input = r#"{"$range": [ 0, "$distance", 25 ]}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         constant_string,
         expected = Ok(Schema::Atomic(Atomic::String)),
         input = r#"{"$substr": [ "$quarter", 2, -1 ]}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         constant_long,
         expected = Ok(Schema::Atomic(Atomic::Long)),
         input = r#"{"$toHashedIndexKey": "$val"}"#
@@ -301,17 +301,17 @@ mod conversion_ops {
 mod bit_ops {
     use super::*;
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         bitwise_op_long,
         expected = Ok(Schema::Atomic(Atomic::Long)),
         input = r#"{"$bitAnd": [1, {"$numberLong": "1"}]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         bitwise_op_int,
         expected = Ok(Schema::Atomic(Atomic::Integer)),
         input = r#"{"$bitAnd": [1, 1]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         bitwise_op_integral,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -327,7 +327,7 @@ mod bit_ops {
 }
 mod window_ops {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         window_func_decimal_or_null,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Decimal),
@@ -341,7 +341,7 @@ mod window_ops {
             Schema::Atomic(Atomic::Null),
         ))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         window_func_double_or_null,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Double),
@@ -357,38 +357,38 @@ mod window_ops {
 mod numeric_ops {
     use super::*;
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         math_op_decimal,
         expected = Ok(Schema::Atomic(Atomic::Decimal)),
         input = r#"{"$log": "$foo"}"#,
         ref_schema = Schema::Atomic(Atomic::Decimal)
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         math_op_double,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#"{"$log": [1, 2.1]}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         math_op_long,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#"{"$log": [1, {"$numberLong": "1"}]}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         math_op_int,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#"{"$log": [1, 2]}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         math_op_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{"$log": [null, 1]}"#
     );
 
-    test_derive_schema!(
+    test_derive_expression_schema!(
         math_op_nullish,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Decimal),
@@ -402,7 +402,7 @@ mod numeric_ops {
             Schema::Atomic(Atomic::Null),
         ))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         multiply_integral,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -410,18 +410,18 @@ mod numeric_ops {
         ))),
         input = r#"{"$multiply": [1, 1]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         multiply_long,
         expected = Ok(Schema::Atomic(Atomic::Long)),
         input = r#"{"$multiply": [1, {"$numberLong": "1"}]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         multiply_decimal,
         expected = Ok(Schema::Atomic(Atomic::Decimal)),
         input = r#"{"$multiply": [1, "$foo"]}"#,
         ref_schema = Schema::Atomic(Atomic::Decimal)
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         multiply_double_or_null,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Double),
@@ -433,28 +433,28 @@ mod numeric_ops {
             Schema::Atomic(Atomic::Null),
         ))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         pow_decimal,
         expected = Ok(Schema::Atomic(Atomic::Decimal)),
         input = r#"{"$pow": [1, "$foo"]}"#,
         ref_schema = Schema::Atomic(Atomic::Decimal)
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         pow_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{"$pow": [1, null]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         pow_double,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#"{"$pow": [1, 2.0]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         pow_long,
         expected = Ok(Schema::Atomic(Atomic::Long),),
         input = r#"{"$pow": [1, {"$numberLong": "1"}]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         pow_integers,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -462,33 +462,33 @@ mod numeric_ops {
         ))),
         input = r#"{"$pow": [1, 123]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         mod_decimal,
         expected = Ok(Schema::Atomic(Atomic::Decimal)),
         input = r#"{"$mod": [1, "$foo"]}"#,
         ref_schema = Schema::Atomic(Atomic::Decimal)
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         mod_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = r#"{"$mod": [1, null]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         mod_double,
         expected = Ok(Schema::Atomic(Atomic::Double)),
         input = r#"{"$mod": [1, 2.1]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         mod_long,
         expected = Ok(Schema::Atomic(Atomic::Long)),
         input = r#"{"$mod": [3, {"$numberLong": "2"}]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         mod_int,
         expected = Ok(Schema::Atomic(Atomic::Integer)),
         input = r#"{"$mod": [1, 123]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         add_integral,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -496,18 +496,18 @@ mod numeric_ops {
         ))),
         input = r#"{"$add": [1, 1]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         add_long,
         expected = Ok(Schema::Atomic(Atomic::Long)),
         input = r#"{"$add": [1, {"$numberLong": "1"}]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         add_decimal,
         expected = Ok(Schema::Atomic(Atomic::Decimal)),
         input = r#"{"$add": [1, "$foo"]}"#,
         ref_schema = Schema::Atomic(Atomic::Decimal)
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         add_double_or_null,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Double),
@@ -519,7 +519,7 @@ mod numeric_ops {
             Schema::Atomic(Atomic::Null),
         ))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         add_date_or_null,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -531,7 +531,7 @@ mod numeric_ops {
             Schema::Atomic(Atomic::Null),
         ))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         subtract_integral,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),
@@ -539,18 +539,18 @@ mod numeric_ops {
         ))),
         input = r#"{"$subtract": [1, 1]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         subtract_long,
         expected = Ok(Schema::Atomic(Atomic::Long)),
         input = r#"{"$subtract": [1, {"$numberLong": "1"}]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         subtract_decimal,
         expected = Ok(Schema::Atomic(Atomic::Decimal)),
         input = r#"{"$subtract": [1, "$foo"]}"#,
         ref_schema = Schema::Atomic(Atomic::Decimal)
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         subtract_double_or_null,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Double),
@@ -562,7 +562,7 @@ mod numeric_ops {
             Schema::Atomic(Atomic::Null),
         ))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         subtract_date_or_null,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Date),
@@ -574,7 +574,7 @@ mod numeric_ops {
             Schema::Atomic(Atomic::Null),
         ))
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         subtract_both_dates,
         expected = Ok(Schema::Atomic(Atomic::Long)),
         input = r#"{"$subtract": ["$foo", "$foo"]}"#,
@@ -584,7 +584,7 @@ mod numeric_ops {
 
 mod supremum_ops {
     use super::*;
-    test_derive_schema!(
+    test_derive_expression_schema!(
         max,
         expected = Ok(Schema::Atomic(Atomic::String)),
         input = r#"{"$max": ["$foo", 1, "hello"]}"#,
@@ -593,7 +593,7 @@ mod supremum_ops {
             Schema::Atomic(Atomic::String),
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         min,
         expected = Ok(Schema::Atomic(Atomic::Integer)),
         input = r#"{"$min": ["$foo", 1, "hello"]}"#,
@@ -608,7 +608,7 @@ mod misc_ops {
     use super::*;
 
     // $ifNull
-    test_derive_schema!(
+    test_derive_expression_schema!(
         if_null_single_nullable,
         expected = Ok(Schema::AnyOf(
             set! {Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::String)}
@@ -619,7 +619,7 @@ mod misc_ops {
             Schema::Atomic(Atomic::Null),
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         if_null_single_nonnullable,
         expected = Ok(Schema::Atomic(Atomic::Integer)),
         input = r#"{"$ifNull": ["$foo", "yes"]}"#,
@@ -627,7 +627,7 @@ mod misc_ops {
             Schema::Atomic(Atomic::Integer),
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         if_null_multiple_nullable,
         expected = Ok(Schema::AnyOf(set! {
             Schema::Atomic(Atomic::Integer),
@@ -646,7 +646,7 @@ mod misc_ops {
             jaccard_index: None,
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         if_null_multiple_only_include_up_to_first_nonnullable_type,
         expected = Ok(Schema::AnyOf(
             set! {Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::Long)}
@@ -663,7 +663,7 @@ mod misc_ops {
             jaccard_index: None,
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         if_null_final_arg_possibly_null_or_missing,
         expected = Ok(Schema::AnyOf(set! {
             Schema::Atomic(Atomic::Integer),
@@ -688,7 +688,7 @@ mod misc_ops {
             jaccard_index: None,
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         if_null_final_arg_only_possibly_null,
         expected = Ok(Schema::AnyOf(set! {
             Schema::Atomic(Atomic::Integer),
@@ -712,7 +712,7 @@ mod misc_ops {
             jaccard_index: None,
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         if_null_final_arg_only_possibly_missing,
         expected = Ok(Schema::AnyOf(set! {
             Schema::Atomic(Atomic::Integer),
@@ -735,7 +735,7 @@ mod misc_ops {
     );
 
     // $mergeObjects
-    test_derive_schema!(
+    test_derive_expression_schema!(
         merge_objects,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -748,7 +748,7 @@ mod misc_ops {
         })),
         input = r#"{"$mergeObjects": [{"a": 1}, {"b": "yes"}]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         merge_objects_overlapping_keys_same_type,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -760,7 +760,7 @@ mod misc_ops {
         })),
         input = r#"{"$mergeObjects": [{"a": 1}, {"a": 2}]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         merge_objects_overlapping_keys_diff_types,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -772,7 +772,7 @@ mod misc_ops {
         })),
         input = r#"{"$mergeObjects": [{"a": 1}, {"a": true}]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         merge_objects_ignores_nullish_args,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -785,7 +785,7 @@ mod misc_ops {
         })),
         input = r#"{"$mergeObjects": [{"a": 1}, null, {"b": "yes"}, "$missing"]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         merge_objects_all_nullish_args,
         expected = Ok(Schema::Document(Document {
             keys: map! {},
@@ -795,7 +795,7 @@ mod misc_ops {
         })),
         input = r#"{"$mergeObjects": [null, null, "$missing"]}"#
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         merge_objects_possibly_nullish_args,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -835,7 +835,7 @@ mod misc_ops {
             jaccard_index: None,
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         merge_objects_any_of_only_docs,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -875,7 +875,7 @@ mod misc_ops {
             jaccard_index: None,
         })
     );
-    test_derive_schema!(
+    test_derive_expression_schema!(
         merge_objects_duplicate_field_not_required_in_later_doc,
         expected = Ok(Schema::Document(Document {
             keys: map! {

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -299,7 +299,7 @@ impl ResultSet {
     }
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Default)]
 pub enum Schema {
     Unsat,
     Missing,
@@ -307,6 +307,7 @@ pub enum Schema {
     Array(Box<Schema>),
     Document(Document),
     AnyOf(BTreeSet<Schema>),
+    #[default]
     Any,
 }
 
@@ -554,6 +555,15 @@ impl Document {
             false => Some(self.keys.len()),
         };
         (min, max)
+    }
+
+    /// this function is just used for ergonomics in cases where we want to create
+    /// a key with a given schema only if it doesn't exist. This comes up largely in
+    /// schema derivation, where we are regularly mutating documents.
+    pub fn insert_if_not_exists(&mut self, key: String, schema: Schema) {
+        if !self.keys.contains_key(&key) {
+            self.keys.insert(key, schema);
+        }
     }
 }
 

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -556,15 +556,6 @@ impl Document {
         };
         (min, max)
     }
-
-    /// this function is just used for ergonomics in cases where we want to create
-    /// a key with a given schema only if it doesn't exist. This comes up largely in
-    /// schema derivation, where we are regularly mutating documents.
-    pub fn insert_if_not_exists(&mut self, key: String, schema: Schema) {
-        if !self.keys.contains_key(&key) {
-            self.keys.insert(key, schema);
-        }
-    }
 }
 
 impl std::fmt::Debug for Document {


### PR DESCRIPTION
This pr is much shorter than it looks -- I split the macro for testing derive_schema into two so that it can easily deserialize stages and expressions (could perhaps make it one, if we wanted to get fancy, but it was easier this way).

Two stages of the original seven in this ticket were skipped: $redact (that will be hard and annoying -- certainly worth its own ticket) and $geoNear (it was not going to be possible to construct a meaningfully accurate result_set_schema because the information needed to get the type of the coordinates being used would be imbedded in the index, not in the schema).