### PR TITLE
SQL-2621: Implement COUNT(DISTINCT *)

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -14,8 +14,7 @@ These errors often occur when you use data types in an incorrect or invalid way.
 | ---------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Error 1001](#error-1001)  | A function (e.g., Sin, Abs, Round) has the incorrect number of arguments.                                                                                                               |
 | [Error 1002](#error-1002)  | The specified operation (e.g., Sub, And, Substring) has argument(s) of the incorrect type (e.g., string, int).                                                                                |
-| [Error 1003](#error-1003)  | The argument provided to the aggregation is not of a type that is comparable to itself.                                                                                           |
-| [Error 1004](#error-1004)  | `COUNT(DISTINCT *)` is not supported.                                                                                                                                             |
+| [Error 1003](#error-1003)  | The argument provided to the aggregation is not of a type that is comparable to itself.                                                                                           |                                                                                                                                             |
 | [Error 1005](#error-1005)  | The specified comparison operation (e.g., Lte, Between) could not be done due to incomparable types of their operands (e.g., comparing an int to a string).                                   |
 | [Error 1007](#error-1007)  | Cannot access field, because it cannot be found (and likely doesn't exist).                                                                                                 |
 | [Error 1008](#error-1008)  | The cardinality of a subquery's result set may be greater than 1. The result set MUST have a cardinality of 0 or 1.                                                               |
@@ -104,12 +103,6 @@ The following errors occur when something goes wrong while using the excludeName
 - **Resolution Steps:** Only use AGGREGATE functions on columns of the appropriate type.
   If you want to AGGREGATE on a value within an `array` or `object`, use the UNWIND or FLATTEN data source keywords.
   Corrected example query: `SELECT * FROM myCol GROUP BY a AGGREGATE MIN(a) as min` where `a` is an `int`.
-
-### Error 1004
-
-- **Description:** `COUNT(DISTINCT *)` is not supported.
-- **Common Causes:** Any use of `COUNT(DISTINCT *)` (`SELECT COUNT(DISTINCT *) FROM foo`) is not supported.
-- **Resolution Steps:** Remove any use of `COUNT(DISTINCT *)` from your queries.
 
 ### Error 1005
 

--- a/mongosql/src/air/desugarer/accumulators.rs
+++ b/mongosql/src/air/desugarer/accumulators.rs
@@ -81,7 +81,7 @@ impl AccumulatorsDesugarerVisitor {
     /// each case are applied to the $addToSet or $sum, depending on the value of distinct.
     fn rewrite_count(count_expr: &AccumulatorExpr) -> (AccumulatorExpr, ProjectItem) {
         let new_acc_expr = match count_expr.arg.as_ref() {
-            Variable(v) if v.parent.is_none() && v.name == ROOT_NAME.to_string() => {
+            Variable(v) if v.parent.is_none() && v.name == *ROOT_NAME => {
                 Self::rewrite_count_star(count_expr.distinct, count_expr.alias.clone())
             }
             Document(_doc) => {

--- a/mongosql/src/air/desugarer/accumulators.rs
+++ b/mongosql/src/air/desugarer/accumulators.rs
@@ -16,20 +16,17 @@ macro_rules! make_single_expr_count_conditional {
     ($arg:expr, $then:expr, $else:expr) => {
         Box::new(make_cond_expr!(
             MQLSemanticOperator(MQLSemanticOperator {
-                op: MQLOperator::Not,
-                args: vec![MQLSemanticOperator(MQLSemanticOperator {
-                    op: MQLOperator::In,
-                    args: vec![
-                        MQLSemanticOperator(MQLSemanticOperator {
-                            op: MQLOperator::Type,
-                            args: vec![$arg],
-                        }),
-                        Array(vec![
-                            Literal(LiteralValue::String("missing".to_string())),
-                            Literal(LiteralValue::String("null".to_string())),
-                        ]),
-                    ],
-                })],
+                op: MQLOperator::In,
+                args: vec![
+                    MQLSemanticOperator(MQLSemanticOperator {
+                        op: MQLOperator::Type,
+                        args: vec![$arg],
+                    }),
+                    Array(vec![
+                        Literal(LiteralValue::String("missing".to_string())),
+                        Literal(LiteralValue::String("null".to_string())),
+                    ]),
+                ],
             }),
             $then,
             $else
@@ -134,22 +131,20 @@ impl AccumulatorsDesugarerVisitor {
             (
                 // When distinct, we rewrite to AddToSet.
                 AggregationFunction::AddToSet,
-                // In the case the condition evaluates to true, we include the argument in
-                // the set.
-                arg.clone(),
-                // In the case the condition evaluates to false, we include "$$REMOVE" in
-                // the set, which effectively doesn't add to the set.
+                // In the case the condition evaluates to true, we include "$$REMOVE" in the set,
+                // which effectively doesn't add to the set.
                 REMOVE.clone(),
+                // In the case the condition evaluates to false, we include the argument in the set.
+                arg.clone(),
             )
         } else {
             (
                 // When not distinct, we rewrite to Sum.
                 AggregationFunction::Sum,
-                // In the case the condition evaluates to true, we count this argument.
-                Literal(LiteralValue::Integer(1)),
-                // In the case the condition evaluates to false, we do not count this
-                // argument.
+                // In the case the condition evaluates to true, we do not count this argument.
                 Literal(LiteralValue::Integer(0)),
+                // In the case the condition evaluates to false, we count this argument.
+                Literal(LiteralValue::Integer(1)),
             )
         };
 

--- a/mongosql/src/air/desugarer/accumulators.rs
+++ b/mongosql/src/air/desugarer/accumulators.rs
@@ -4,12 +4,38 @@ use crate::{
         visitor::Visitor,
         AccumulatorExpr, AggregationFunction, Expression,
         Expression::*,
-        Group, LiteralValue, MQLOperator, MQLSemanticOperator, Project, ProjectItem, Reduce, Stage,
+        Group, LiteralValue, MQLOperator, MQLSemanticOperator, Project, ProjectItem, Stage,
         Stage::*,
     },
     make_cond_expr, map,
+    util::{REMOVE, ROOT, ROOT_NAME},
 };
 use linked_hash_map::LinkedHashMap;
+
+macro_rules! make_single_expr_count_conditional {
+    ($arg:expr, $then:expr, $else:expr) => {
+        Box::new(make_cond_expr!(
+            MQLSemanticOperator(MQLSemanticOperator {
+                op: MQLOperator::Not,
+                args: vec![MQLSemanticOperator(MQLSemanticOperator {
+                    op: MQLOperator::In,
+                    args: vec![
+                        MQLSemanticOperator(MQLSemanticOperator {
+                            op: MQLOperator::Type,
+                            args: vec![$arg],
+                        }),
+                        Array(vec![
+                            Literal(LiteralValue::String("missing".to_string())),
+                            Literal(LiteralValue::String("null".to_string())),
+                        ]),
+                    ],
+                })],
+            }),
+            $then,
+            $else
+        ))
+    };
+}
 
 /// Desugars any aggregations in Group stages into appropriate, equivalent
 /// expressions and/or stages. Specifically, aggregations with distinct: true
@@ -31,44 +57,108 @@ impl Pass for AccumulatorsDesugarerPass {
 struct AccumulatorsDesugarerVisitor;
 
 impl AccumulatorsDesugarerVisitor {
-    fn make_count_cond(arg: Expression) -> Expression {
-        let arg_is_missing_or_null_check = MQLSemanticOperator(MQLSemanticOperator {
-            op: MQLOperator::In,
-            args: vec![
-                MQLSemanticOperator(MQLSemanticOperator {
-                    op: MQLOperator::Type,
-                    args: vec![arg],
-                }),
-                Array(vec![
-                    Literal(LiteralValue::String("missing".to_string())),
-                    Literal(LiteralValue::String("null".to_string())),
-                ]),
-            ],
-        });
-        make_cond_expr!(
-            arg_is_missing_or_null_check,
-            Literal(LiteralValue::Integer(0)),
-            Literal(LiteralValue::Integer(1))
-        )
+    /// Rewrites $sqlCount into the appropriate new accumulator expression and project item.
+    /// MongoSQL supports the following cases for COUNT, and each is handled differently.
+    ///     - COUNT(DISTINCT? <col>)
+    ///     - COUNT(DISTINCT? <col1>, <col2>, ...)
+    ///     - COUNT(DISTINCT? *)
+    ///
+    /// For the first case, when counting non-documents, we want to omit missing and null values;
+    /// when counting documents, we want to omit empty documents and documents where all values are
+    /// null.
+    ///
+    /// For the second case, we know with certainty that we are counting documents (a column list is
+    /// represented as a document with those columns as fields). In this case, we want to omit empty
+    /// documents and documents where all values are null.
+    ///
+    /// For the third case, we again know with certainty that we are counting documents (* is
+    /// represented as the "$$ROOT" variable). The * indicates we want to count all documents
+    /// unconditionally.
+    ///
+    /// For all cases, if the count is marked as distinct, we rewrite the accumulator to a $addToSet
+    /// and follow it with a projection assignment that does the counting (via $size). If it is
+    /// non-distinct, we rewrite the accumulator to use $sum. The conditions described above for
+    /// each case are applied to the $addToSet or $sum, depending on the value of distinct.
+    fn rewrite_count(count_expr: AccumulatorExpr) -> (AccumulatorExpr, ProjectItem) {
+        let new_acc_expr = match count_expr.arg.as_ref() {
+            // *
+            Variable(v) if v.parent.is_none() && v.name == ROOT_NAME.to_string() => {
+                let (function, arg) = if count_expr.distinct {
+                    (AggregationFunction::AddToSet, Box::new(ROOT.clone()))
+                } else {
+                    (
+                        AggregationFunction::Sum,
+                        Box::new(Literal(LiteralValue::Integer(1))),
+                    )
+                };
+                AccumulatorExpr {
+                    alias: count_expr.alias.clone(),
+                    function,
+                    distinct: false,
+                    arg,
+                }
+            }
+            // Multi-column
+            Document(doc) => todo!("SQL-2622"),
+            // Single expr
+            arg => {
+                let (agg_func, then, r#else) = if count_expr.distinct {
+                    (
+                        // When distinct, we rewrite to AddToSet.
+                        AggregationFunction::AddToSet,
+                        // In the case the condition evaluates to true, we include the argument in
+                        // the set.
+                        arg.clone(),
+                        // In the case the condition evaluates to false, we include "$$REMOVE" in
+                        // the set, which effectively doesn't add to the set.
+                        REMOVE.clone(),
+                    )
+                } else {
+                    (
+                        // When not distinct, we rewrite to Sum.
+                        AggregationFunction::Sum,
+                        // In the case the condition evaluates to true, we count this argument.
+                        Literal(LiteralValue::Integer(1)),
+                        // In the case the condition evaluates to false, we do not count this
+                        // argument.
+                        Literal(LiteralValue::Integer(0)),
+                    )
+                };
+
+                AccumulatorExpr {
+                    alias: count_expr.alias.clone(),
+                    function: agg_func,
+                    distinct: false,
+                    arg: make_single_expr_count_conditional!(arg.clone(), then, r#else),
+                }
+            }
+        };
+
+        let project_item = if count_expr.distinct {
+            ProjectItem::Assignment(MQLSemanticOperator(MQLSemanticOperator {
+                op: MQLOperator::Size,
+                args: vec![FieldRef(count_expr.alias.into())],
+            }))
+        } else {
+            ProjectItem::Inclusion
+        };
+
+        (new_acc_expr, project_item)
     }
 
-    fn create_distinct_count_project_expression(alias: String) -> Expression {
-        Reduce(Reduce {
-            input: Box::new(FieldRef(alias.into())),
-            init_value: Box::new(Literal(LiteralValue::Integer(0))),
-            inside: Box::new(MQLSemanticOperator(MQLSemanticOperator {
-                op: MQLOperator::Add,
-                args: vec![
-                    Variable("value".to_string().into()),
-                    Self::make_count_cond(Variable("this".to_string().into())),
-                ],
-            })),
-        })
-    }
+    /// Rewrites distinct non-count accumulators into the appropriate new accumulator expression and
+    /// project item. These accumulators are rewritten into AddToSet accumulators which are followed
+    /// by $project assignment expressions that perform the actual accumulator operation on the set.
+    fn rewrite_distinct_non_count(acc_expr: AccumulatorExpr) -> (AccumulatorExpr, ProjectItem) {
+        let new_acc_expr = AccumulatorExpr {
+            alias: acc_expr.alias.clone(),
+            function: AggregationFunction::AddToSet,
+            distinct: false,
+            arg: acc_expr.arg.clone(),
+        };
 
-    fn create_distinct_non_count_project_expression(agg: AccumulatorExpr) -> Expression {
-        MQLSemanticOperator(MQLSemanticOperator {
-            op: match agg.function {
+        let project_item = ProjectItem::Assignment(MQLSemanticOperator(MQLSemanticOperator {
+            op: match acc_expr.function {
                 AggregationFunction::AddToArray => unreachable!(),
                 AggregationFunction::AddToSet => unreachable!(),
                 AggregationFunction::Avg => MQLOperator::Avg,
@@ -82,17 +172,10 @@ impl AccumulatorsDesugarerVisitor {
                 AggregationFunction::StddevSamp => MQLOperator::StddevSamp,
                 AggregationFunction::Sum => MQLOperator::Sum,
             },
-            args: vec![FieldRef(agg.alias.into())],
-        })
-    }
+            args: vec![FieldRef(acc_expr.alias.into())],
+        }));
 
-    fn create_non_distinct_count_aggregation(alias: String, arg: Expression) -> AccumulatorExpr {
-        AccumulatorExpr {
-            alias,
-            function: AggregationFunction::Sum,
-            distinct: false,
-            arg: Box::new(Self::make_count_cond(arg)),
-        }
+        (new_acc_expr, project_item)
     }
 }
 
@@ -101,50 +184,30 @@ impl Visitor for AccumulatorsDesugarerVisitor {
         let node = node.walk(self);
         match node {
             Group(group) => {
-                let mut new_aggregations: Vec<AccumulatorExpr> = Vec::new();
+                let mut new_accumulators: Vec<AccumulatorExpr> = Vec::new();
                 let mut project_specs: LinkedHashMap<String, ProjectItem> = map! {
                     "_id".into() => ProjectItem::Inclusion
                 };
                 let mut needs_project = false;
-                for agg in group.aggregations.clone().into_iter() {
-                    let (new_aggregation, project_item) = if agg.distinct {
-                        needs_project = true;
-                        let new_aggregation = AccumulatorExpr {
-                            alias: agg.alias.clone(),
-                            function: AggregationFunction::AddToSet,
-                            distinct: false,
-                            arg: Box::new(*agg.arg.clone()),
+                for acc_expr in group.aggregations.clone().into_iter() {
+                    needs_project = needs_project || acc_expr.distinct;
+                    let (new_acc_expr, project_item) =
+                        if acc_expr.function == AggregationFunction::Count {
+                            Self::rewrite_count(acc_expr.clone())
+                        } else if acc_expr.distinct {
+                            Self::rewrite_distinct_non_count(acc_expr.clone())
+                        } else {
+                            (acc_expr.clone(), ProjectItem::Inclusion)
                         };
 
-                        let project_item = ProjectItem::Assignment(
-                            if agg.function == AggregationFunction::Count {
-                                // distinct count
-                                Self::create_distinct_count_project_expression(agg.alias.clone())
-                            } else {
-                                // distinct non-count
-                                Self::create_distinct_non_count_project_expression(agg.clone())
-                            },
-                        );
-                        (new_aggregation, project_item)
-                    } else {
-                        let new_aggregation = if agg.function == AggregationFunction::Count {
-                            // non-distinct count
-                            Self::create_non_distinct_count_aggregation(agg.alias.clone(), *agg.arg)
-                        } else {
-                            // non-distinct non-count
-                            agg.clone()
-                        };
-                        let project_item = ProjectItem::Inclusion;
-                        (new_aggregation, project_item)
-                    };
-                    new_aggregations.push(new_aggregation);
-                    project_specs.insert(agg.alias.clone(), project_item);
+                    new_accumulators.push(new_acc_expr);
+                    project_specs.insert(acc_expr.alias.clone(), project_item);
                 }
 
                 let new_group = Group(Group {
                     source: group.source,
                     keys: group.keys,
-                    aggregations: new_aggregations,
+                    aggregations: new_accumulators,
                 });
 
                 if needs_project {
@@ -161,6 +224,10 @@ impl Visitor for AccumulatorsDesugarerVisitor {
     }
 }
 
+/// This visitor rewrites DISTINCT ADD_TO_ARRAY to ADD_TO_SET. This can be done
+/// directly in the $group stage as opposed to how the other distinct operators
+/// are handled (by replacing the accumulator with $addToSet and deferring the
+/// original operation to a follow-up $project stage).
 struct AccumulatorExpressionConverter;
 
 impl Visitor for AccumulatorExpressionConverter {

--- a/mongosql/src/air/desugarer/testdata/desugar_accumulators.yml
+++ b/mongosql/src/air/desugarer/testdata/desugar_accumulators.yml
@@ -50,9 +50,9 @@ tests:
                   {
                     "$cond":
                       [
-                        { "$not": { "$in": [{ "$type": "$a" }, ["missing", "null"]] } },
-                        1,
+                        { "$in": [{ "$type": "$a" }, ["missing", "null"]] },
                         0,
+                        1,
                       ],
                   },
               },
@@ -79,9 +79,9 @@ tests:
                   {
                     "$cond":
                       [
-                        { "$not": { "$in": [{ "$type": "$a" }, ["missing", "null"]] } },
-                        "$a",
+                        { "$in": [{ "$type": "$a" }, ["missing", "null"]] },
                         "$$REMOVE",
+                        "$a",
                       ]
                   }
               }

--- a/mongosql/src/air/desugarer/testdata/desugar_accumulators.yml
+++ b/mongosql/src/air/desugarer/testdata/desugar_accumulators.yml
@@ -30,7 +30,7 @@ tests:
       - { "$group": { "_id": null, "acc": { "$addToSet": "$a" } } }
       - { "$project": { "_id": 1, "acc": { "$avg": "$acc" } } }
 
-  - name: "desugar non-distinct $sqlCount"
+  - name: "desugar non-distinct $sqlCount single column arg"
     input:
       - {
         "$group":
@@ -50,16 +50,16 @@ tests:
                   {
                     "$cond":
                       [
-                        { "$in": [{ "$type": "$a" }, ["missing", "null"]] },
-                        0,
+                        { "$not": { "$in": [{ "$type": "$a" }, ["missing", "null"]] } },
                         1,
+                        0,
                       ],
                   },
               },
           },
       }
 
-  - name: "desugar distinct $sqlCount"
+  - name: "desugar distinct $sqlCount single column arg"
     input:
       - {
         "$group":
@@ -69,40 +69,173 @@ tests:
           },
       }
     expected:
-      - { "$group": { "_id": null, "acc": { "$addToSet": "$a" } } }
+      - {
+        "$group":
+          {
+            "_id": null,
+            "acc":
+              {
+                "$addToSet":
+                  {
+                    "$cond":
+                      [
+                        { "$not": { "$in": [{ "$type": "$a" }, ["missing", "null"]] } },
+                        "$a",
+                        "$$REMOVE",
+                      ]
+                  }
+              }
+          }
+      }
       - {
         "$project":
           {
             "_id": 1,
+            "acc": { "$size": "$acc" },
+          },
+      }
+
+  - name: "desugar non-distinct $sqlCount multi-column arg"
+    skip_reason: "SQL-2622: implement count(multi-col)"
+    input:
+      - {
+        "$group":
+          {
+            "_id": null,
+            "acc": { "$sqlCount": { "var": {"a": "$a", "b": "$b"}, "distinct": false } },
+          },
+      }
+    expected:
+      - {
+        "$group":
+          {
+            "_id": null,
             "acc":
               {
-                "$reduce":
+                "$sum":
                   {
-                    "input": "$acc",
-                    "initialValue": 0,
-                    "in":
-                      {
-                        "$add":
-                          [
-                            "$$value",
-                            {
-                              "$cond":
-                                [
-                                  {
-                                    "$in":
-                                      [
-                                        { "$type": "$$this" },
-                                        ["missing", "null"],
-                                      ],
-                                  },
-                                  0,
-                                  1,
-                                ],
-                            },
-                          ],
-                      },
+                    "$cond":
+                      [
+                        {
+                          "$and":
+                            [
+                              { "$ne": [{"a": "$a", "b": "$b"}, { "$literal": {}}] },
+                              {
+                                "$allElementsTrue":
+                                  [
+                                    {
+                                      "$map":
+                                        {
+                                          "input": { "$objectToArray": {"a": "$a", "b": "$b"} },
+                                          "in": { "$ne": ["$$this.v", null] }
+                                        }
+                                    }
+                                  ]
+                              }
+                            ]
+                        },
+                        1,
+                        0,
+                      ],
                   },
               },
+          },
+      }
+
+  - name: "desugar distinct $sqlCount multi-column arg"
+    skip_reason: "SQL-2622: implement count(multi-col)"
+    input:
+      - {
+        "$group":
+          {
+            "_id": null,
+            "acc": { "$sqlCount": { "var": {"a": "$a", "b": "$b"}, "distinct": true } },
+          },
+      }
+    expected:
+      - {
+        "$group":
+          {
+            "_id": null,
+            "acc":
+              {
+                "$addToSet":
+                  {
+                    "$cond":
+                      [
+                        {
+                          "$and":
+                            [
+                              { "$ne": [{ "a": "$a", "b": "$b" }, { "$literal": {} }] },
+                              {
+                                "$allElementsTrue":
+                                  [
+                                    {
+                                      "$map":
+                                        {
+                                          "input": { "$objectToArray": { "a": "$a", "b": "$b" } },
+                                          "in": { "$ne": ["$$this.v", null] }
+                                        }
+                                    }
+                                  ]
+                              }
+                            ]
+                        },
+                        { "a": "$a", "b": "$b" },
+                        "$$REMOVE",
+                      ]
+                  }
+              }
+          }
+      }
+      - {
+        "$project":
+          {
+            "_id": 1,
+            "acc": { "$size": "$acc" },
+          },
+      }
+
+  - name: "desugar non-distinct $sqlCount * arg (ROOT)"
+    input:
+      - {
+        "$group":
+          {
+            "_id": null,
+            "acc": { "$sqlCount": { "var": "$$ROOT", "distinct": false } },
+          },
+      }
+    expected:
+      - {
+        "$group":
+          {
+            "_id": null,
+            "acc": { "$sum": 1 }
+          },
+      }
+
+  - name: "desugar distinct $sqlCount * arg (ROOT)"
+    input:
+      - {
+        "$group":
+          {
+            "_id": null,
+            "acc": { "$sqlCount": { "var": "$$ROOT", "distinct": true } },
+          },
+      }
+    expected:
+      - {
+        "$group":
+          {
+            "_id": null,
+            "acc": { "$addToSet": "$$ROOT" },
+          }
+      }
+      - {
+        "$project":
+          {
+            "_id": 1,
+            "acc": { "$size": "$acc" },
           },
       }
 

--- a/mongosql/src/algebrizer/test.rs
+++ b/mongosql/src/algebrizer/test.rs
@@ -5159,13 +5159,10 @@ mod aggregation {
             set_quantifier: Some(ast::SetQuantifier::All),
         },
     );
-    test_algebrize_expr_and_schema_check!(
-        count_distinct_star_is_error,
+    test_algebrize!(
+        count_distinct_star,
         method = algebrize_aggregation,
-        expected = Err(Error::SchemaChecking(
-            mir::schema::Error::CountDistinctStarNotSupported
-        )),
-        expected_error_code = 1004,
+        expected = Ok(mir::AggregationExpr::CountStar(true)),
         input = ast::FunctionExpr {
             function: ast::FunctionName::Count,
             args: ast::FunctionArguments::Star,

--- a/mongosql/src/mir/schema/errors.rs
+++ b/mongosql/src/mir/schema/errors.rs
@@ -27,7 +27,6 @@ pub enum Error {
     },
     InvalidBinaryDataType,
     AggregationArgumentMustBeSelfComparable(String, Schema),
-    CountDistinctStarNotSupported,
     InvalidComparison(&'static str, Schema, Schema),
     CannotMergeObjects(Schema, Schema, Satisfaction),
     AccessMissingField(String, Option<Vec<String>>),
@@ -45,7 +44,6 @@ impl UserError for Error {
             Error::IncorrectArgumentCount { .. } => 1001,
             Error::SchemaChecking { .. } => 1002,
             Error::AggregationArgumentMustBeSelfComparable(_, _) => 1003,
-            Error::CountDistinctStarNotSupported => 1004,
             Error::InvalidComparison(_, _, _) => 1005,
             Error::CannotMergeObjects(_, _, _) => 1006,
             Error::AccessMissingField(_, _) => 1007,
@@ -97,7 +95,6 @@ impl UserError for Error {
                     Some(error_msg)
                 }
             }
-            Error::CountDistinctStarNotSupported => None,
             Error::InvalidComparison(func, s1, s2) => {
                 let simplified_s1 = Schema::simplify(s1);
                 let simplified_s2 = Schema::simplify(s2);
@@ -198,7 +195,6 @@ impl UserError for Error {
             Error::IncorrectArgumentCount {name, required, found} => format!("incorrect argument count for {name}: required {required}, found {found}"),
             Error::SchemaChecking {name, required, found } => format!("schema checking failed for {name}: required {required:?}, found {found:?}"),
             Error::AggregationArgumentMustBeSelfComparable(aggs, schema) => format!("cannot have {0:?} aggregations over the schema: {1:?} as it is not comparable to itself", aggs, schema),
-            Error::CountDistinctStarNotSupported => "COUNT(DISTINCT *) is not supported".to_string(),
             Error::InvalidComparison(func, s1, s2) => format!("invalid comparison for {0}: {1:?} cannot be compared to {2:?}", func, s1, s2),
             Error::CannotMergeObjects(s1, s2, sat) => format!("cannot merge objects {0:?} and {1:?} as they {2:?} have overlapping keys", s1, s2, sat),
             Error::AccessMissingField(field, _) => format!("cannot access field {0} because it does not exist", field),

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -859,16 +859,10 @@ impl CachedSchema for Stage {
 impl AggregationExpr {
     pub fn schema(&self, state: &SchemaInferenceState) -> Result<Schema, Error> {
         match self {
-            AggregationExpr::CountStar(distinct) => {
-                if *distinct {
-                    Err(Error::CountDistinctStarNotSupported)
-                } else {
-                    Ok(Schema::AnyOf(set![
-                        Schema::Atomic(Atomic::Integer),
-                        Schema::Atomic(Atomic::Long)
-                    ]))
-                }
-            }
+            AggregationExpr::CountStar(_) => Ok(Schema::AnyOf(set![
+                Schema::Atomic(Atomic::Integer),
+                Schema::Atomic(Atomic::Long)
+            ])),
             AggregationExpr::Function(a) => a.schema(state),
         }
     }

--- a/mongosql/src/translator/stages.rs
+++ b/mongosql/src/translator/stages.rs
@@ -3,11 +3,11 @@ use crate::{
     mapping_registry::{Key, MqlMappingRegistry, MqlMappingRegistryValue, MqlReferenceType},
     mir,
     translator::{Error, MqlTranslator, Result},
-    util::ROOT_NAME,
+    util::{ROOT, ROOT_NAME},
 };
-use mongosql_datastructures::binding_tuple::DatasourceName;
 use mongosql_datastructures::{
-    unique_linked_hash_map, unique_linked_hash_map::UniqueLinkedHashMap,
+    binding_tuple::DatasourceName, unique_linked_hash_map,
+    unique_linked_hash_map::UniqueLinkedHashMap,
 };
 use std::collections::BTreeSet;
 
@@ -585,10 +585,10 @@ impl MqlTranslator {
                 alias.clone()
             };
             let (function, distinct, arg) = match a.agg_expr {
-                mir::AggregationExpr::CountStar(b) => (
+                mir::AggregationExpr::CountStar(distinct) => (
                     air::AggregationFunction::Count,
-                    b,
-                    Box::new(air::Expression::Literal(air::LiteralValue::Integer(1))),
+                    distinct,
+                    Box::new(ROOT.clone()),
                 ),
                 mir::AggregationExpr::Function(afa) => (
                     Self::translate_agg_function(afa.function),

--- a/mongosql/src/translator/test/stages.rs
+++ b/mongosql/src/translator/test/stages.rs
@@ -196,18 +196,18 @@ mod group {
                     expr: ROOT.clone()
                 },],
                 aggregations: vec![
-                    // Count(*) is traslated as Count(1).
+                    // Count(*) is translated as Count(ROOT).
                     air::AccumulatorExpr {
                         alias: "c_distinct".into(),
                         function: air::AggregationFunction::Count,
                         distinct: true,
-                        arg: air::Expression::Literal(air::LiteralValue::Integer(1)).into(),
+                        arg: ROOT.clone().into(),
                     },
                     air::AccumulatorExpr {
                         alias: "c_nondistinct".into(),
                         function: air::AggregationFunction::Count,
                         distinct: false,
-                        arg: air::Expression::Literal(air::LiteralValue::Integer(1)).into(),
+                        arg: ROOT.clone().into(),
                     },
                 ]
             })
@@ -376,7 +376,7 @@ mod group {
                     alias: "__id".into(),
                     function: air::AggregationFunction::Count,
                     distinct: false,
-                    arg: air::Expression::Literal(air::LiteralValue::Integer(1)).into(),
+                    arg: ROOT.clone().into(),
                 },]
             })
             .into(),

--- a/mongosql/src/util/mod.rs
+++ b/mongosql/src/util/mod.rs
@@ -3,11 +3,16 @@ use lazy_static::lazy_static;
 pub use mongosql_datastructures::unique_linked_hash_map;
 
 pub const ROOT_NAME: &str = "ROOT";
+pub const REMOVE_NAME: &str = "REMOVE";
 
 lazy_static! {
     pub static ref ROOT: air::Expression = air::Expression::Variable(air::Variable {
         parent: None,
         name: ROOT_NAME.to_string()
+    });
+    pub static ref REMOVE: air::Expression = air::Expression::Variable(air::Variable {
+        parent: None,
+        name: REMOVE_NAME.to_string()
     });
     // https://www.mongodb.com/docs/manual/reference/operator/query/regex/#mongodb-query-op.-options
     // `s` allows '.' to match all characters including newline characters

--- a/tests/errors/schema.yml
+++ b/tests/errors/schema.yml
@@ -96,12 +96,6 @@ tests:
     should_compile: false
     algebrize_error: 'Error 1003: Cannot perform `Min` aggregation over the type `any type` as it is not comparable to itself. An `any type` schema may indicate that schema is not set for the relevant collection or field. Please verify that the schema is set as expected.'
 
-  - description: Error 1004 CountDistinctStarNotSupported
-    query: "SELECT COUNT(DISTINCT *) FROM foo"
-    current_db: db
-    should_compile: false
-    algebrize_error: 'Error 1004: COUNT(DISTINCT *) is not supported'
-
   - description: Error 1005 InvalidComparison
     query: "SELECT * FROM foo WHERE a <= c"
     current_db: db

--- a/tests/spec_tests/query_tests/group_by.yml
+++ b/tests/spec_tests/query_tests/group_by.yml
@@ -13,6 +13,7 @@ catalog_data:
       - { "_id": 3, "a": 2, "b": 2, "c": 3 }
       - { "_id": 4, "a": 2, "b": 3, "c": 4 }
       - { "_id": 5, "a": 1, "b": 2, "c": 5 }
+      - { "_id": 6, "a": null, "b": null, "c": null}
 
     nullAndMissing:
       - { "_id": 1, "n": null }
@@ -74,9 +75,30 @@ catalog_schema:
             "properties":
               {
                 "_id": { "bsonType": "int" },
-                "a": { "bsonType": "int" },
-                "b": { "bsonType": "int" },
-                "c": { "bsonType": "int" },
+                "a":
+                  {
+                    "anyOf":
+                      [
+                        { "bsonType": "int" },
+                        { "bsonType": !!str "null" },
+                      ]
+                  },
+                "b":
+                  {
+                    "anyOf":
+                      [
+                        { "bsonType": "int" },
+                        { "bsonType": !!str "null" },
+                      ]
+                  },
+                "c":
+                  {
+                    "anyOf":
+                      [
+                        { "bsonType": "int" },
+                        { "bsonType": !!str "null" },
+                      ]
+                  },
               },
           },
         "nullAndMissing":
@@ -364,9 +386,17 @@ tests:
               "sumc": { "$numberInt": "4" },
             },
         }
+      - {
+          "":
+            {
+              "a": null,
+              "b": null,
+              "sumc": 0,
+            },
+        }
 
   - description: multi-item group key with HAVING correctness test
-    query: "SELECT * FROM foo.multi AS multi GROUP BY a AS a, b AS b AGGREGATE SUM(c) AS sumc HAVING a != 1 AND sumc != 4"
+    query: "SELECT * FROM foo.multi AS multi GROUP BY a AS a, b AS b AGGREGATE SUM(c) AS sumc HAVING a IS NOT NULL AND a != 1 AND sumc != 4"
     current_db: foo
     result:
       - {
@@ -508,19 +538,21 @@ tests:
       - { "": { "a": { "$numberInt": "2" }, "gcount": { "$numberInt": "2" } } }
       - { "": { "a": null, "gcount": { "$numberInt": "0" } } }
 
-  - description: COUNT(*) correctness test
+  - description: COUNT(*) correctness test unconditionally count rows
     query: "SELECT * FROM (SELECT a, b FROM foo.multi AS m) AS arr GROUP BY a AS a AGGREGATE COUNT(*) AS gcount"
     current_db: foo
     result:
       - { "": { "a": 1, "gcount": 2 } }
       - { "": { "a": 2, "gcount": 3 } }
+      - { "": { "a": null, "gcount": 1 } }
 
-  - description: COUNT(DISTINCT *) correctness test
+  - description: COUNT(DISTINCT *) correctness test unconditionally count distinct rows
     query: "SELECT * FROM (SELECT a, b FROM foo.multi AS m) AS arr GROUP BY a AS a AGGREGATE COUNT(DISTINCT *) AS gcount"
     current_db: foo
     result:
       - { "": { "a": 1, "gcount": 1 } }
       - { "": { "a": 2, "gcount": 2 } }
+      - { "": { "a": null, "gcount": 1 } }
 
   - description: COUNT(MISSING) and COUNT(NULL) skip MISSING and NULL values
     query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE COUNT(a.a) AS gcounta, COUNT(NULL) AS gcountn"

--- a/tests/spec_tests/query_tests/group_by.yml
+++ b/tests/spec_tests/query_tests/group_by.yml
@@ -1,123 +1,50 @@
 catalog_data:
   foo:
     bar:
-      - {
-          "_id": { "$numberInt": "1" },
-          "a": { "$numberInt": "1" },
-          "b": { "$numberInt": "2" },
-          "c": { "$numberInt": "3" },
-        }
-      - {
-          "_id": { "$numberInt": "2" },
-          "a": { "$numberInt": "1" },
-          "b": { "$numberInt": "12" },
-          "c": { "$numberInt": "3" },
-        }
-      - {
-          "_id": { "$numberInt": "3" },
-          "a": { "$numberInt": "11" },
-          "b": { "$numberInt": "22" },
-          "c": { "$numberInt": "3" },
-        }
-      - {
-          "_id": { "$numberInt": "4" },
-          "a": { "$numberInt": "1" },
-          "b": { "$numberInt": "42" },
-          "c": { "$numberInt": "3" },
-        }
-      - {
-          "_id": { "$numberInt": "5" },
-          "a": { "$numberInt": "111" },
-          "b": { "$numberInt": "142" },
-          "c": { "$numberInt": "13" },
-        }
+      - { "_id": 1, "a": 1, "b": 2, "c": 3 }
+      - { "_id": 2, "a": 1, "b": 12, "c": 3 }
+      - { "_id": 3, "a": 11, "b": 22, "c": 3 }
+      - { "_id": 4, "a": 1, "b": 42, "c": 3 }
+      - { "_id": 5, "a": 111, "b": 142, "c": 13 }
 
     multi:
-      - {
-          "_id": { "$numberInt": "1" },
-          "a": { "$numberInt": "1" },
-          "b": { "$numberInt": "2" },
-          "c": { "$numberInt": "1" },
-        }
-      - {
-          "_id": { "$numberInt": "2" },
-          "a": { "$numberInt": "2" },
-          "b": { "$numberInt": "2" },
-          "c": { "$numberInt": "2" },
-        }
-      - {
-          "_id": { "$numberInt": "3" },
-          "a": { "$numberInt": "2" },
-          "b": { "$numberInt": "2" },
-          "c": { "$numberInt": "3" },
-        }
-      - {
-          "_id": { "$numberInt": "4" },
-          "a": { "$numberInt": "2" },
-          "b": { "$numberInt": "3" },
-          "c": { "$numberInt": "4" },
-        }
-      - {
-          "_id": { "$numberInt": "5" },
-          "a": { "$numberInt": "1" },
-          "b": { "$numberInt": "2" },
-          "c": { "$numberInt": "5" },
-        }
+      - { "_id": 1, "a": 1, "b": 2, "c": 1 }
+      - { "_id": 2, "a": 2, "b": 2, "c": 2 }
+      - { "_id": 3, "a": 2, "b": 2, "c": 3 }
+      - { "_id": 4, "a": 2, "b": 3, "c": 4 }
+      - { "_id": 5, "a": 1, "b": 2, "c": 5 }
 
     nullAndMissing:
-      - { "_id": { "$numberInt": "1" }, "n": null }
-      - { "_id": { "$numberInt": "2" }, "n": null }
-      - { "_id": { "$numberInt": "3" } }
-      - { "_id": { "$numberInt": "4" }, "n": { "$numberInt": "1" } }
+      - { "_id": 1, "n": null }
+      - { "_id": 2, "n": null }
+      - { "_id": 3 }
+      - { "_id": 4, "n": 1 }
 
     baz:
-      - {
-          "_id": { "$numberInt": "1" },
-          "a": { "a": { "$numberInt": "1" }, "b": { "$numberInt": "2" } },
-        }
-      - {
-          "_id": { "$numberInt": "2" },
-          "a": { "a": { "$numberInt": "2" }, "b": { "$numberInt": "2" } },
-        }
-      - {
-          "_id": { "$numberInt": "3" },
-          "a": { "a": { "$numberInt": "2" }, "b": { "$numberInt": "3" } },
-        }
-      - { "_id": { "$numberInt": "4" }, "a": { "a": null, "b": null } }
+      - { "_id": 1, "a": { "a": 1, "b": 2 } }
+      - { "_id": 2, "a": { "a": 2, "b": 2 } }
+      - { "_id": 3, "a": { "a": 2, "b": 3 } }
+      - { "_id": 4, "a": { "a": null, "b": null } }
 
     baz2:
-      - {
-          "_id": { "$numberInt": "1" },
-          "a": { "$numberInt": "1" },
-          "doc": { "a": "a" },
-        }
-      - {
-          "_id": { "$numberInt": "2" },
-          "a": { "$numberInt": "1" },
-          "doc": { "b": "b" },
-        }
-      - {
-          "_id": { "$numberInt": "3" },
-          "a": { "$numberInt": "2" },
-          "doc": { "a": "c" },
-        }
-      - {
-          "_id": { "$numberInt": "4" },
-          "a": { "$numberInt": "2" },
-          "doc": { "a": "d" },
-        }
+      - { "_id": 1, "a": 1, "doc": { "a": "a" } }
+      - { "_id": 2, "a": 1, "doc": { "b": "b" } }
+      - { "_id": 3, "a": 2, "doc": { "a": "c" } }
+      - { "_id": 4, "a": 2, "doc": { "a": "d" } }
 
     numerics:
-      - { "_id": { "$numberInt": "1" }, "a": { "$numberDecimal": "3.0" } }
-      - { "_id": { "$numberInt": "2" }, "a": { "$numberDouble": "3.0" } }
-      - { "_id": { "$numberInt": "3" }, "a": { "$numberInt": "3" } }
+      - { "_id": 1, "a": { "$numberDecimal": "3.0" } }
+      - { "_id": 2, "a": { "$numberDouble": "3.0" } }
+      - { "_id": 3, "a": { "$numberInt": "3" } }
 
     dupes:
-      - { "_id": { "$numberInt": "1" }, "a": { "$numberInt": "1" } }
-      - { "_id": { "$numberInt": "2" }, "a": { "$numberInt": "2" } }
-      - { "_id": { "$numberInt": "3" }, "a": { "$numberInt": "1" } }
+      - { "_id": 1, "a": 1 }
+      - { "_id": 2, "a": 2 }
+      - { "_id": 3, "a": 1 }
+
     arr:
-      - { "_id": { "$numberInt": "1" }, "a": [1, 2] }
+      - { "_id": 1, "a": [1, 2] }
+
     poly:
       - { "_id": 0, a: true }
       - { "_id": 1, a: "yes" }
@@ -582,12 +509,18 @@ tests:
       - { "": { "a": null, "gcount": { "$numberInt": "0" } } }
 
   - description: COUNT(*) correctness test
-    query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE COUNT(*) AS gcount"
+    query: "SELECT * FROM (SELECT a, b FROM foo.multi AS m) AS arr GROUP BY a AS a AGGREGATE COUNT(*) AS gcount"
     current_db: foo
     result:
-      - { "": { "a": { "$numberInt": "1" }, "gcount": { "$numberInt": "1" } } }
-      - { "": { "a": { "$numberInt": "2" }, "gcount": { "$numberInt": "2" } } }
-      - { "": { "a": null, "gcount": { "$numberInt": "0" } } }
+      - { "": { "a": 1, "gcount": 2 } }
+      - { "": { "a": 2, "gcount": 3 } }
+
+  - description: COUNT(DISTINCT *) correctness test
+    query: "SELECT * FROM (SELECT a, b FROM foo.multi AS m) AS arr GROUP BY a AS a AGGREGATE COUNT(DISTINCT *) AS gcount"
+    current_db: foo
+    result:
+      - { "": { "a": 1, "gcount": 1 } }
+      - { "": { "a": 2, "gcount": 2 } }
 
   - description: COUNT(MISSING) and COUNT(NULL) skip MISSING and NULL values
     query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE COUNT(a.a) AS gcounta, COUNT(NULL) AS gcountn"

--- a/tests/spec_tests/query_tests/group_by.yml
+++ b/tests/spec_tests/query_tests/group_by.yml
@@ -581,6 +581,14 @@ tests:
       - { "": { "a": { "$numberInt": "2" }, "gcount": { "$numberInt": "2" } } }
       - { "": { "a": null, "gcount": { "$numberInt": "0" } } }
 
+  - description: COUNT(*) correctness test
+    query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE COUNT(*) AS gcount"
+    current_db: foo
+    result:
+      - { "": { "a": { "$numberInt": "1" }, "gcount": { "$numberInt": "1" } } }
+      - { "": { "a": { "$numberInt": "2" }, "gcount": { "$numberInt": "2" } } }
+      - { "": { "a": null, "gcount": { "$numberInt": "0" } } }
+
   - description: COUNT(MISSING) and COUNT(NULL) skip MISSING and NULL values
     query: "SELECT * FROM foo.baz AS arr GROUP BY a.a AS a AGGREGATE COUNT(a.a) AS gcounta, COUNT(NULL) AS gcountn"
     current_db: foo


### PR DESCRIPTION
This PR implements support for `COUNT(DISTINCT *)`. It also updates the implementation of `COUNT(*)`, `COUNT(<expr>)`, and `COUNT(DISTINCT <expr>)` to be consistent in terms of implementation and behavior.

There's a lot going on in this one:
- I refactored the `desugarer/accumulators.rs` file to better support this accumulator, and I set it up for SQL-2622 (support multi-column `COUNT` aggregations).
- As noted in the ticket, I removed the `CountDistinctStarNotSupported` error from the `mir/schema` errors library, and updated the translation pipeline to support this expression.
- I added spec tests for `COUNT(*)` and `COUNT(DISTINCT *)`. We don't have an explicit `COUNT(DISTINCT <expr>)` test in the spec query tests, but we do have a test that implicitly covers this. **Do you think I should add a spec test for that?**
- We'll need to do some follow-up work to make sure `COUNT(<doc column>)` and `COUNT(DISTINCT <doc column>)` behave consistently with `COUNT(col1, col2, ...)` and `COUNT(DISTINCT col1, col2, ...)`. Specifically, we'll likely want those to follow the same rules (i.e. omit empty docs and docs where all values are null). **Should I add that as a comment to SQL-2622, or should I file a separate ticket to deal with it?**

