### PR TITLE
SQL-2651: Optimize WHERE/ON false queries such that they will always use index scans

### DIFF
--- a/mongosql/src/air/definitions.rs
+++ b/mongosql/src/air/definitions.rs
@@ -703,6 +703,7 @@ pub enum MatchQuery {
     Regex(MatchLanguageRegex),
     ElemMatch(ElemMatch),
     Comparison(MatchLanguageComparison),
+    False,
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -613,6 +613,9 @@ impl<'a> Algebrizer<'a> {
                 cache: SchemaCache::new(),
             }),
         };
+        // We always add the condition as a separate filter to facilitate optimization of constant
+        // join conditions. The stage movement optimization will move the filter back into the join
+        // condition when necessary.
         let stage = if let Some(condition) = condition {
             mir::Stage::Filter(mir::Filter {
                 source: Box::new(stage),

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -589,7 +589,7 @@ impl<'a> Algebrizer<'a> {
                     join_type: mir::JoinType::Left,
                     left: Box::new(left_src),
                     right: Box::new(right_src),
-                    condition,
+                    condition: None,
                     cache: SchemaCache::new(),
                 })
             }
@@ -601,7 +601,7 @@ impl<'a> Algebrizer<'a> {
                     join_type: mir::JoinType::Left,
                     left: Box::new(right_src),
                     right: Box::new(left_src),
-                    condition,
+                    condition: None,
                     cache: SchemaCache::new(),
                 })
             }
@@ -609,9 +609,18 @@ impl<'a> Algebrizer<'a> {
                 join_type: mir::JoinType::Inner,
                 left: Box::new(left_src),
                 right: Box::new(right_src),
-                condition,
+                condition: None,
                 cache: SchemaCache::new(),
             }),
+        };
+        let stage = if let Some(condition) = condition {
+            mir::Stage::Filter(mir::Filter {
+                source: Box::new(stage),
+                condition,
+                cache: SchemaCache::new(),
+            })
+        } else {
+            stage
         };
         stage.schema(&self.schema_inference_state())?;
         Ok(stage)

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -589,7 +589,7 @@ impl<'a> Algebrizer<'a> {
                     join_type: mir::JoinType::Left,
                     left: Box::new(left_src),
                     right: Box::new(right_src),
-                    condition: None,
+                    condition: condition.clone(),
                     cache: SchemaCache::new(),
                 })
             }
@@ -601,29 +601,28 @@ impl<'a> Algebrizer<'a> {
                     join_type: mir::JoinType::Left,
                     left: Box::new(right_src),
                     right: Box::new(left_src),
-                    condition: None,
+                    condition: condition.clone(),
                     cache: SchemaCache::new(),
                 })
             }
-            ast::JoinType::Cross | ast::JoinType::Inner => mir::Stage::Join(mir::Join {
-                join_type: mir::JoinType::Inner,
-                left: Box::new(left_src),
-                right: Box::new(right_src),
-                condition: None,
-                cache: SchemaCache::new(),
-            }),
-        };
-        // We always add the condition as a separate filter to facilitate optimization of constant
-        // join conditions. The stage movement optimization will move the filter back into the join
-        // condition when necessary.
-        let stage = if let Some(condition) = condition {
-            mir::Stage::Filter(mir::Filter {
-                source: Box::new(stage),
-                condition,
-                cache: SchemaCache::new(),
-            })
-        } else {
-            stage
+            ast::JoinType::Cross | ast::JoinType::Inner => {
+                let join = mir::Stage::Join(mir::Join {
+                    join_type: mir::JoinType::Inner,
+                    left: Box::new(left_src),
+                    right: Box::new(right_src),
+                    condition: None,
+                    cache: SchemaCache::new(),
+                });
+                if let Some(condition) = condition {
+                    mir::Stage::Filter(mir::Filter {
+                        source: Box::new(join),
+                        condition,
+                        cache: SchemaCache::new(),
+                    })
+                } else {
+                    join
+                }
+            }
         };
         stage.schema(&self.schema_inference_state())?;
         Ok(stage)

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -589,7 +589,7 @@ impl<'a> Algebrizer<'a> {
                     join_type: mir::JoinType::Left,
                     left: Box::new(left_src),
                     right: Box::new(right_src),
-                    condition: condition.clone(),
+                    condition,
                     cache: SchemaCache::new(),
                 })
             }
@@ -601,7 +601,7 @@ impl<'a> Algebrizer<'a> {
                     join_type: mir::JoinType::Left,
                     left: Box::new(right_src),
                     right: Box::new(left_src),
-                    condition: condition.clone(),
+                    condition,
                     cache: SchemaCache::new(),
                 })
             }

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -613,6 +613,8 @@ impl<'a> Algebrizer<'a> {
                     condition: None,
                     cache: SchemaCache::new(),
                 });
+                // The stage_movement optimization will place this condition in the Join if it makes sense. Otherwise,
+                // it will move it as early in the pipeline as possible.
                 if let Some(condition) = condition {
                     mir::Stage::Filter(mir::Filter {
                         source: Box::new(join),

--- a/mongosql/src/algebrizer/test.rs
+++ b/mongosql/src/algebrizer/test.rs
@@ -6156,11 +6156,11 @@ mod from_clause {
         left_join,
         method = algebrize_from_clause,
         expected = Ok(mir::Stage::Join(mir::Join {
-                join_type: JoinType::Left,
-                left: Box::new(mir_source_foo()),
-                right: Box::new(mir_source_bar()),
-                condition: Some(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
-                cache: SchemaCache::new(),
+            join_type: JoinType::Left,
+            left: Box::new(mir_source_foo()),
+            right: Box::new(mir_source_bar()),
+            condition: Some(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
+            cache: SchemaCache::new(),
         })),
         input = Some(ast::Datasource::Join(JoinSource {
             join_type: ast::JoinType::Left,
@@ -6174,11 +6174,11 @@ mod from_clause {
         right_join,
         method = algebrize_from_clause,
         expected = Ok(mir::Stage::Join(mir::Join {
-                join_type: JoinType::Left,
-                left: Box::new(mir_source_bar()),
-                right: Box::new(mir_source_foo()),
-                condition: Some(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
-                cache: SchemaCache::new(),
+            join_type: JoinType::Left,
+            left: Box::new(mir_source_bar()),
+            right: Box::new(mir_source_foo()),
+            condition: Some(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
+            cache: SchemaCache::new(),
         })),
         input = Some(ast::Datasource::Join(JoinSource {
             join_type: ast::JoinType::Right,

--- a/mongosql/src/algebrizer/test.rs
+++ b/mongosql/src/algebrizer/test.rs
@@ -6160,7 +6160,7 @@ mod from_clause {
                 join_type: JoinType::Left,
                 left: Box::new(mir_source_foo()),
                 right: Box::new(mir_source_bar()),
-                condition: None,
+                condition: Some(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
                 cache: SchemaCache::new(),
             })),
             condition: mir::Expression::Literal(mir::LiteralValue::Boolean(true)),
@@ -6182,7 +6182,7 @@ mod from_clause {
                 join_type: JoinType::Left,
                 left: Box::new(mir_source_bar()),
                 right: Box::new(mir_source_foo()),
-                condition: None,
+                condition: Some(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
                 cache: SchemaCache::new(),
             })),
             condition: mir::Expression::Literal(mir::LiteralValue::Boolean(true)),
@@ -6582,8 +6582,7 @@ mod from_clause {
                         })
                     ],
                     is_nullable: false,
-                }
-                ),
+                }),
             source:
                 mir::Stage::Join(mir::Join {
                 join_type: mir::JoinType::Left,
@@ -6615,7 +6614,24 @@ mod from_clause {
                     },
                     cache: SchemaCache::new(),
                 })),
-                condition: None,
+                condition: Some(mir::Expression::ScalarFunction(
+                    mir::ScalarFunctionApplication {
+                        function: mir::ScalarFunction::Eq,
+                        args: vec![
+                            mir::Expression::FieldAccess(mir::FieldAccess {
+                                expr: Box::new(mir::Expression::Reference(("foo", 0u16).into())),
+                                field: "a".to_string(),
+                                is_nullable: false,
+                            }),
+                            mir::Expression::FieldAccess(mir::FieldAccess {
+                                expr: Box::new(mir::Expression::Reference(("bar", 0u16).into())),
+                                field: "b".to_string(),
+                                is_nullable: false,
+                            })
+                        ],
+                        is_nullable: false,
+                    })
+                ),
                 cache: SchemaCache::new(),
             }).into(),
             cache: SchemaCache::new(),

--- a/mongosql/src/codegen/match_query.rs
+++ b/mongosql/src/codegen/match_query.rs
@@ -29,6 +29,7 @@ impl MqlCodeGenerator {
             Regex(r) => self.codegen_match_regex(r),
             ElemMatch(em) => self.codegen_match_elem_match(em),
             Comparison(c) => self.codegen_match_comparison(c),
+            False => Ok(bson!({"_id": Bson::MinKey, "$expr": false})),
         }
     }
 

--- a/mongosql/src/codegen/match_query.rs
+++ b/mongosql/src/codegen/match_query.rs
@@ -29,6 +29,9 @@ impl MqlCodeGenerator {
             Regex(r) => self.codegen_match_regex(r),
             ElemMatch(em) => self.codegen_match_elem_match(em),
             Comparison(c) => self.codegen_match_comparison(c),
+            // Some versions of MongoDB do not properly optimize {$match: { $expr: false } } so we codegen it
+            // this way to ensure efficient performance. Otherwise, such a query could result in a needless collection
+            // scan.
             False => Ok(bson!({"_id": Bson::MinKey, "$expr": false})),
         }
     }

--- a/mongosql/src/codegen/test/match_query.rs
+++ b/mongosql/src/codegen/test/match_query.rs
@@ -205,3 +205,11 @@ mod comp {
         })
     );
 }
+
+mod match_constant_false {
+    test_codegen_match_query!(
+        constant_false,
+        expected = Ok(bson!({"_id": bson::Bson::MinKey, "$expr": false})),
+        input = air::MatchQuery::False
+    );
+}

--- a/mongosql/src/mir/optimizer/rewrite_to_match_language/mod.rs
+++ b/mongosql/src/mir/optimizer/rewrite_to_match_language/mod.rs
@@ -5,6 +5,11 @@
 /// match language (mir::MatchQuery) and the Filter stage replaced with a
 /// MatchFilter stage.
 ///
+/// Also optimizes constant false conditions to a MatchFalse filter. This filter
+/// can be then treated specially in codegen because certain versions of mongodb
+/// require a bit of finesse to ensure that {$match: {$expr: false}} is not
+/// treated as a COLLSCAN.
+///
 /// Note that although comparison operators _can_ be rewritten to use match
 /// language, this optimization does not perform such rewrites. LIKE and IS
 /// ultimately translate to $regexMatch and $eq/$type in aggregation language.
@@ -126,6 +131,8 @@ impl MatchLanguageRewriterVisitor {
                 ScalarFunction::Or => Self::rewrite_logical(MatchLanguageLogicalOp::Or, sf.args),
                 _ => None,
             },
+            // Note this relies on ConstantFolding to ensure that the a constant expression becomes
+            // a LiteralValue.
             Expression::Literal(l) if l.is_falsy() => Some(MatchQuery::False(MatchFalse {
                 cache: SchemaCache::new(),
             })),

--- a/mongosql/src/mir/optimizer/rewrite_to_match_language/mod.rs
+++ b/mongosql/src/mir/optimizer/rewrite_to_match_language/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         optimizer::Optimizer,
         schema::{SchemaCache, SchemaInferenceState},
         visitor::Visitor,
-        Expression, FieldPath, IsExpr, LikeExpr, LiteralValue, MQLStage, MatchFilter,
+        Expression, FieldPath, IsExpr, LikeExpr, LiteralValue, MQLStage, MatchFalse, MatchFilter,
         MatchLanguageComparison, MatchLanguageComparisonOp, MatchLanguageLogical,
         MatchLanguageLogicalOp, MatchLanguageRegex, MatchLanguageType, MatchQuery, ScalarFunction,
         Stage, Type, TypeOrMissing,
@@ -126,6 +126,9 @@ impl MatchLanguageRewriterVisitor {
                 ScalarFunction::Or => Self::rewrite_logical(MatchLanguageLogicalOp::Or, sf.args),
                 _ => None,
             },
+            Expression::Literal(l) if l.is_falsy() => Some(MatchQuery::False(MatchFalse {
+                cache: SchemaCache::new(),
+            })),
             _ => None,
         }
     }

--- a/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
+++ b/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::{
     catalog::{Catalog, Namespace},
     map,
@@ -305,5 +307,97 @@ test_rewrite_to_match_language!(
     input = filter_stage(Expression::ScalarFunction(ScalarFunctionApplication::new(
         ScalarFunction::Or,
         vec![valid_like(), valid_is()],
+    )))
+);
+
+test_rewrite_to_match_language!(
+    rewrite_null,
+    expected = match_filter_stage(MatchQuery::False(MatchFalse {
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::Literal(LiteralValue::Null))
+);
+
+test_rewrite_to_match_language!(
+    rewrite_undefined,
+    expected = match_filter_stage(MatchQuery::False(MatchFalse {
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::Literal(LiteralValue::Undefined))
+);
+
+test_rewrite_to_match_language!(
+    rewrite_false_bool,
+    expected = match_filter_stage(MatchQuery::False(MatchFalse {
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::Literal(LiteralValue::Boolean(false)))
+);
+
+test_rewrite_to_match_language_no_op!(
+    rewrite_true_bool_is_noop,
+    filter_stage(Expression::Literal(LiteralValue::Boolean(true)))
+);
+
+test_rewrite_to_match_language!(
+    rewrite_0_int,
+    expected = match_filter_stage(MatchQuery::False(MatchFalse {
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::Literal(LiteralValue::Integer(0)))
+);
+
+test_rewrite_to_match_language_no_op!(
+    rewrite_1_int_is_noop,
+    filter_stage(Expression::Literal(LiteralValue::Integer(1)))
+);
+
+test_rewrite_to_match_language!(
+    rewrite_0_long,
+    expected = match_filter_stage(MatchQuery::False(MatchFalse {
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::Literal(LiteralValue::Long(0)))
+);
+
+test_rewrite_to_match_language_no_op!(
+    rewrite_1_long_is_noop,
+    filter_stage(Expression::Literal(LiteralValue::Long(1)))
+);
+
+test_rewrite_to_match_language!(
+    rewrite_0_double,
+    expected = match_filter_stage(MatchQuery::False(MatchFalse {
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::Literal(LiteralValue::Double(0.0)))
+);
+
+test_rewrite_to_match_language_no_op!(
+    rewrite_1_double_is_noop,
+    filter_stage(Expression::Literal(LiteralValue::Double(1.0)))
+);
+
+test_rewrite_to_match_language!(
+    rewrite_0_decimal,
+    expected = match_filter_stage(MatchQuery::False(MatchFalse {
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::Literal(LiteralValue::Decimal128(
+        bson::Decimal128::from_str("0.0").unwrap()
+    )))
+);
+
+test_rewrite_to_match_language_no_op!(
+    rewrite_1_decimal_is_noop,
+    filter_stage(Expression::Literal(LiteralValue::Decimal128(
+        bson::Decimal128::from_str("1.0").unwrap()
     )))
 );

--- a/mongosql/src/mir/optimizer/stage_movement/mod.rs
+++ b/mongosql/src/mir/optimizer/stage_movement/mod.rs
@@ -483,7 +483,6 @@ impl StageMovementVisitor<'_> {
 
         // unfortunately, due to the borrow checker, we compute uses we may not need.
         let (field_uses, node) = node.field_uses();
-        println!("node: {:?}, field_uses: {:?}", node, field_uses);
         let (datasource_uses, node) = node.datasource_uses();
         let source = match node {
             Stage::Sort(ref n) => &n.source,
@@ -688,7 +687,6 @@ impl StageMovementVisitor<'_> {
                         // This case is when we have a TRUE or FALSE filter, we want this to bubble
                         // up both sides.
                         (false, false) => {
-                            println!("!!!!!!!!!!!!!!!");
                             side = BubbleUpSide::Both;
                         }
                     }

--- a/mongosql/src/mir/optimizer/stage_movement/mod.rs
+++ b/mongosql/src/mir/optimizer/stage_movement/mod.rs
@@ -483,6 +483,7 @@ impl StageMovementVisitor<'_> {
 
         // unfortunately, due to the borrow checker, we compute uses we may not need.
         let (field_uses, node) = node.field_uses();
+        println!("node: {:?}, field_uses: {:?}", node, field_uses);
         let (datasource_uses, node) = node.datasource_uses();
         let source = match node {
             Stage::Sort(ref n) => &n.source,
@@ -684,8 +685,12 @@ impl StageMovementVisitor<'_> {
                         (_, true) => {
                             side = BubbleUpSide::Right;
                         }
-                        // This case should be impossible, but best to be safe
-                        (false, false) => return (node, false),
+                        // This case is when we have a TRUE or FALSE filter, we want this to bubble
+                        // up both sides.
+                        (false, false) => {
+                            println!("!!!!!!!!!!!!!!!");
+                            side = BubbleUpSide::Both;
+                        }
                     }
                 }
             }

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -2068,6 +2068,7 @@ impl CachedSchema for MatchQuery {
             MatchQuery::Regex(s) => &s.cache,
             MatchQuery::ElemMatch(s) => &s.cache,
             MatchQuery::Comparison(s) => &s.cache,
+            MatchQuery::False(f) => &f.cache,
         }
     }
 

--- a/mongosql/src/translator/match_query.rs
+++ b/mongosql/src/translator/match_query.rs
@@ -24,6 +24,7 @@ impl MqlTranslator {
             Regex(r) => self.translate_match_regex(r),
             ElemMatch(em) => self.translate_elem_match(em),
             Comparison(c) => self.translate_match_comparison(c),
+            False(_) => Ok(air::MatchQuery::False),
         }
     }
 

--- a/mongosql/src/translator/test/stages.rs
+++ b/mongosql/src/translator/test/stages.rs
@@ -1231,6 +1231,23 @@ mod mql_intrinsic {
                 cache: mir::schema::SchemaCache::new(),
             }))
         );
+
+        test_translate_stage!(
+            false_stage,
+            expected = Ok(air::Stage::Match(air::Match::MatchLanguage(
+                air::MatchLanguage {
+                    source: util::air_project_collection(None, "foo", Some("f")),
+                    expr: Box::new(air::MatchQuery::False),
+                }
+            ))),
+            input = mir::Stage::MQLIntrinsic(mir::MQLStage::MatchFilter(mir::MatchFilter {
+                source: util::mir_project_collection(None, "foo", Some("f"), None),
+                condition: mir::MatchQuery::False(mir::MatchFalse {
+                    cache: mir::schema::SchemaCache::new(),
+                }),
+                cache: mir::schema::SchemaCache::new(),
+            }))
+        );
     }
 }
 


### PR DESCRIPTION
This PR ended up doing two things:
* Change {$match: {$expr: false}} to {$match: {_id: MinKey, $expr: false}}
* Change Join algebrization to always use a separate Filter instead of the Condition
  * This is fine because Stage Movement will still move them into the condition, if it makes sense, but will move it above the join now when it can! (if the condition constant)