### PR TITLE
SQL-2365: Add schema derivation for Lookup, GraphLookup, and UnionWith

### DIFF
--- a/agg-ast/ast/src/definitions.rs
+++ b/agg-ast/ast/src/definitions.rs
@@ -708,7 +708,8 @@ pub struct GraphLookup {
     pub start_with: Box<Expression>,
     pub connect_from_field: String,
     pub connect_to_field: String,
-    pub r#as: String,
+    #[serde(rename = "as")]
+    pub as_var: String,
     pub max_depth: Option<i32>,
     pub depth_field: Option<String>,
     pub restrict_search_with_match: Option<Box<Expression>>,

--- a/agg-ast/ast/src/serde_test.rs
+++ b/agg-ast/ast/src/serde_test.rs
@@ -1921,7 +1921,7 @@ mod stage_test {
                 start_with: Box::new(Expression::Ref(Ref::FieldRef("start".to_string()))),
                 connect_from_field: "start".to_string(),
                 connect_to_field: "end".to_string(),
-                r#as: "path".to_string(),
+                as_var: "path".to_string(),
                 max_depth: Some(5),
                 depth_field: Some("depth".to_string()),
                 restrict_search_with_match: Some(Box::new(Expression::Document(

--- a/agg-ast/schema_derivation/src/lib.rs
+++ b/agg-ast/schema_derivation/src/lib.rs
@@ -207,10 +207,15 @@ fn insert_required_key_into_document_helper(
     mut schema: Option<&mut Schema>,
     field_schema: Schema,
     field: String,
+    overwrite: bool,
 ) -> Option<&mut Schema> {
     match schema {
         Some(Schema::Document(d)) => {
-            d.keys.entry(field.clone()).or_insert(field_schema);
+            if overwrite {
+                d.keys.insert(field.clone(), field_schema);
+            } else {
+                d.keys.entry(field.clone()).or_insert(field_schema);
+            }
             // even if the document already included the key, we want to mark it as required.
             // this enables nested field paths to be marked as required down to the required
             // key being inserted.
@@ -229,7 +234,11 @@ fn insert_required_key_into_document_helper(
                     None
                 }
             })?;
-            d.keys.entry(field.clone()).or_insert(Schema::Any);
+            if overwrite {
+                d.keys.insert(field.clone(), field_schema);
+            } else {
+                d.keys.entry(field.clone()).or_insert(field_schema);
+            }
             // see comment above for why we require the field even if it existed in the document
             d.required.insert(field.clone());
             **(schema.as_mut()?) = Schema::Document(d);
@@ -247,6 +256,7 @@ pub(crate) fn insert_required_key_into_document(
     schema: &mut Schema,
     field_schema: Schema,
     path: Vec<String>,
+    overwrite: bool,
 ) {
     let mut schema = Some(schema);
     // create a required nested path of document schemas to the field we are trying to insert. For any field
@@ -256,10 +266,16 @@ pub(crate) fn insert_required_key_into_document(
             schema,
             Schema::Document(schema::Document::default()),
             field.clone(),
+            overwrite,
         );
     }
     // with a reference to the nested document that the field exists in, finally, insert the field with its type.
-    insert_required_key_into_document_helper(schema, field_schema, path.last().unwrap().clone());
+    insert_required_key_into_document_helper(
+        schema,
+        field_schema,
+        path.last().unwrap().clone(),
+        overwrite,
+    );
 }
 
 /// remove field is a helper based on get_schema_for_path_mut which removes a field given a field path.

--- a/agg-ast/schema_derivation/src/lib.rs
+++ b/agg-ast/schema_derivation/src/lib.rs
@@ -38,6 +38,8 @@ pub enum Error {
     UnknownReference(String),
     #[error("Not enough arguments for expression: {0}")]
     NotEnoughArguments(String),
+    #[error("Missing from field in lookup")]
+    MissingFromField,
 }
 
 #[macro_export]

--- a/agg-ast/schema_derivation/src/lib.rs
+++ b/agg-ast/schema_derivation/src/lib.rs
@@ -266,7 +266,7 @@ pub(crate) fn insert_required_key_into_document(
             schema,
             Schema::Document(schema::Document::default()),
             field.clone(),
-            overwrite,
+            false,
         );
     }
     // with a reference to the nested document that the field exists in, finally, insert the field with its type.

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -106,6 +106,7 @@ impl DeriveSchema for Stage {
                         &mut required_doc,
                         field_schema.clone(),
                         path.clone(),
+                        false,
                     );
                 }
             });
@@ -182,15 +183,15 @@ impl DeriveSchema for Stage {
                 .ok_or_else(|| Error::UnknownReference(from_field.to_string()))?
                 .clone();
             if let Some(ref depth_field) = graph_lookup.depth_field {
-                let depth_field_schema = Schema::Atomic(Atomic::Long);
                 insert_required_key_into_document(
                     &mut from_schema,
-                    depth_field_schema,
+                    Schema::Atomic(Atomic::Long),
                     depth_field
                         .as_str()
                         .split('.')
                         .map(|s| s.to_string())
                         .collect(),
+                    true,
                 );
             }
             insert_required_key_into_document(
@@ -202,6 +203,7 @@ impl DeriveSchema for Stage {
                     .split('.')
                     .map(|s| s.to_string())
                     .collect(),
+                true,
             );
             Ok(state.result_set_schema.to_owned())
         }
@@ -292,6 +294,7 @@ impl DeriveSchema for Stage {
                     .split('.')
                     .map(|s| s.to_string())
                     .collect(),
+                true,
             );
             Ok(state.result_set_schema.to_owned())
         }
@@ -357,6 +360,7 @@ impl DeriveSchema for Stage {
                 &mut state.result_set_schema,
                 Schema::Array(Box::new(lookup_schema.clone())),
                 as_var.split('.').map(|s| s.to_string()).collect(),
+                true,
             );
             Ok(state.result_set_schema.to_owned())
         }
@@ -461,12 +465,14 @@ impl DeriveSchema for Stage {
                                         Schema::Atomic(Atomic::Null)
                                     )),
                                     path,
+                                    true,
                                 );
                             } else {
                                 insert_required_key_into_document(
                                     &mut state.result_set_schema,
                                     Schema::Atomic(Atomic::Integer),
                                     path,
+                                    true,
                                 );
                             }
                         }

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -342,14 +342,15 @@ impl DeriveSchema for Stage {
                         .catalog
                         .get(&from_name)
                         .ok_or_else(|| Error::UnknownReference(from_name))?;
-                    let state = &mut ResultSetState {
+                    let pipeline_state = &mut ResultSetState {
                         catalog: state.catalog,
                         variables: state.variables.clone(),
                         result_set_schema: from_schema.clone(),
                         current_db: state.current_db.clone(),
                         null_behavior: state.null_behavior,
                     };
-                    let pipeline_schema = derive_schema_for_pipeline(p.pipeline.clone(), state)?;
+                    let pipeline_schema =
+                        derive_schema_for_pipeline(p.pipeline.clone(), pipeline_state)?;
                     state.result_set_schema = state.result_set_schema.union(&pipeline_schema);
                     Ok(state.result_set_schema.to_owned())
                 }

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -186,7 +186,7 @@ impl DeriveSchema for Stage {
                 insert_required_key_into_document(
                     &mut from_schema,
                     depth_field_schema,
-                    vec![depth_field.clone()],
+                    depth_field.as_str().split('.').map(|s| s.to_string()).collect(),
                 );
             }
             insert_required_key_into_document(

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -106,7 +106,7 @@ impl DeriveSchema for Stage {
                         &mut required_doc,
                         field_schema.clone(),
                         path.clone(),
-                        true,
+                        false,
                     );
                 }
             });

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -123,8 +123,8 @@ impl DeriveSchema for Stage {
             let schema = documents.iter().try_fold(
                 None,
                 |schema: Option<Schema>, document: &LinkedHashMap<String, Expression>| {
-                    // here we convert the map of field field - expression to a resulting map of
-                    // field field - field schema. We collect in such a way that we can get the error from any derivation.
+                    // here we convert the map of field namespace - expression to a resulting map of
+                    // field namespace - field schema. We collect in such a way that we can get the error from any derivation.
                     let doc_fields = document
                         .into_iter()
                         .map(|(field, expr)| {
@@ -214,7 +214,7 @@ impl DeriveSchema for Stage {
                 .items
                 .iter()
                 .all(|(k, p)| k != "_id" || !matches!(p, ProjectItem::Exclusion));
-            // project is a map of field field to expression. We can derive the schema for each expression
+            // project is a map of field namespace to expression. We can derive the schema for each expression
             // and then union them together to get the resulting schema.
             let mut keys = project
                 .items

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -300,7 +300,7 @@ impl DeriveSchema for Stage {
             // internal helper function.
             let_body: &Option<LinkedHashMap<String, Expression>>,
             from: &Option<LookupFrom>,
-            pipeline: &Vec<Stage>,
+            pipeline: &[Stage],
             as_var: &str,
             state: &mut ResultSetState,
         ) -> Result<Schema> {
@@ -325,7 +325,7 @@ impl DeriveSchema for Stage {
                 current_db: state.current_db.clone(),
                 null_behavior: Satisfaction::Not,
             };
-            let lookup_schema = derive_schema_for_pipeline(pipeline.clone(), &mut lookup_state)?;
+            let lookup_schema = derive_schema_for_pipeline(pipeline.to_owned(), &mut lookup_state)?;
             insert_required_key_into_document(
                 &mut state.result_set_schema,
                 Schema::Array(Box::new(lookup_schema.clone())),

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -106,7 +106,7 @@ impl DeriveSchema for Stage {
                         &mut required_doc,
                         field_schema.clone(),
                         path.clone(),
-                        false,
+                        true,
                     );
                 }
             });

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -186,13 +186,22 @@ impl DeriveSchema for Stage {
                 insert_required_key_into_document(
                     &mut from_schema,
                     depth_field_schema,
-                    depth_field.as_str().split('.').map(|s| s.to_string()).collect(),
+                    depth_field
+                        .as_str()
+                        .split('.')
+                        .map(|s| s.to_string())
+                        .collect(),
                 );
             }
             insert_required_key_into_document(
                 &mut state.result_set_schema,
                 Schema::Array(Box::new(from_schema.clone())),
-                vec![graph_lookup.r#as.to_string()],
+                graph_lookup
+                    .r#as
+                    .as_str()
+                    .split('.')
+                    .map(|s| s.to_string())
+                    .collect(),
             );
             Ok(state.result_set_schema.to_owned())
         }
@@ -277,7 +286,12 @@ impl DeriveSchema for Stage {
             insert_required_key_into_document(
                 &mut state.result_set_schema,
                 Schema::Array(Box::new(from_schema.clone())),
-                vec![lookup.as_var.to_string()],
+                lookup
+                    .as_var
+                    .as_str()
+                    .split('.')
+                    .map(|s| s.to_string())
+                    .collect(),
             );
             Ok(state.result_set_schema.to_owned())
         }
@@ -342,7 +356,7 @@ impl DeriveSchema for Stage {
             insert_required_key_into_document(
                 &mut state.result_set_schema,
                 Schema::Array(Box::new(lookup_schema.clone())),
-                vec![as_var.to_string()],
+                as_var.split('.').map(|s| s.to_string()).collect(),
             );
             Ok(state.result_set_schema.to_owned())
         }

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -253,8 +253,8 @@ impl DeriveSchema for Stage {
         fn lookup_derive_schema(lookup: &Lookup, state: &mut ResultSetState) -> Result<Schema> {
             match lookup {
                 Lookup::Equality(le) => derive_equality_lookup_schema(le, state),
-                Lookup::ConciseSubquery(le) => derive_concise_lookup_schema(le, state),
-                Lookup::Subquery(le) => derive_subquery_lookup_schema(le, state),
+                Lookup::ConciseSubquery(lc) => derive_concise_lookup_schema(lc, state),
+                Lookup::Subquery(ls) => derive_subquery_lookup_schema(ls, state),
             }
         }
 

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -238,14 +238,10 @@ impl DeriveSchema for Stage {
                 .collect::<Result<BTreeMap<String, Schema>>>()?;
             // if _id has not been excluded and has not been redefined, include it from the original schema
             if include_id && !keys.contains_key("_id") {
-                keys.insert(
-                    "_id".to_string(),
-                    state
-                        .result_set_schema
-                        .get_key("_id")
-                        .cloned()
-                        .unwrap_or(Schema::Missing),
-                );
+                // Only insert _id if it exists in the incoming schema
+                if let Some(id_value) = state.result_set_schema.get_key("_id") {
+                    keys.insert("_id".to_string(), id_value.clone());
+                }
             }
             Ok(Schema::Document(Document {
                 required: keys.keys().cloned().collect(),

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -320,7 +320,7 @@ impl DeriveSchema for Stage {
                 variables,
                 result_set_schema: from_schema.clone(),
                 current_db: state.current_db.clone(),
-                null_behavior: Satisfaction::Not,
+                null_behavior: state.null_behavior,
             };
             let lookup_schema = derive_schema_for_pipeline(pipeline.to_owned(), &mut lookup_state)?;
             insert_required_key_into_document(
@@ -912,7 +912,7 @@ impl DeriveSchema for TaggedOperator {
                     catalog: state.catalog,
                     variables,
                     current_db: state.current_db.clone(),
-                    null_behavior: Satisfaction::Not,
+                    null_behavior: state.null_behavior,
                 };
                 l.inside.derive_schema(&mut let_state)
             }

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -258,14 +258,11 @@ impl DeriveSchema for Stage {
                 .catalog
                 .get(&from_name)
                 .ok_or_else(|| Error::UnknownReference(from_name))?;
-            println!("from_schema: {:?}", from_schema);
-            println!("rs: {:?}", state.result_set_schema);
             insert_required_key_into_document(
                 &mut state.result_set_schema,
                 Schema::Array(Box::new(from_schema.clone())),
                 vec![lookup.as_var.to_string()],
             );
-            println!("rs: {:?}", state.result_set_schema);
             Ok(state.result_set_schema.to_owned())
         }
 

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -197,7 +197,7 @@ impl DeriveSchema for Stage {
                 &mut state.result_set_schema,
                 Schema::Array(Box::new(from_schema.clone())),
                 graph_lookup
-                    .r#as
+                    .as_var
                     .as_str()
                     .split('.')
                     .map(|s| s.to_string())

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
@@ -31,7 +31,7 @@ macro_rules! test_derive_stage_schema {
                 current_db: "test".to_string(),
                 null_behavior: Satisfaction::Not
             };
-            let result = input.derive_schema(&mut state).map(|s| Schema::simplify(&s));
+            let result = input.derive_schema(&mut state);
             assert_eq!($expected, result);
         }
     };

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
@@ -15,8 +15,12 @@ macro_rules! test_derive_stage_schema {
             $(variables = $variables;)?
             let catalog = map!{
                     "test.bar".to_string() => Schema::Document(Document {
-                        keys: map!{"baz".to_string() => Schema::Atomic(Atomic::String), "qux".to_string() => Schema::Atomic(Atomic::Integer)},
-                        required: set!{"baz".to_string(), "qux".to_string()},
+                        keys: map!{
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                            "baz".to_string() => Schema::Atomic(Atomic::String),
+                            "qux".to_string() => Schema::Atomic(Atomic::Integer)
+                        },
+                        required: set!{"baz".to_string(), "qux".to_string(), "_id".to_string()},
                         ..Default::default()
                     }),
             };

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
@@ -13,13 +13,21 @@ macro_rules! test_derive_stage_schema {
             #[allow(unused_mut, unused_assignments)]
             let mut variables = BTreeMap::new();
             $(variables = $variables;)?
+            let catalog = map!{
+                    "test.bar".to_string() => Schema::Document(Document {
+                        keys: map!{"baz".to_string() => Schema::Atomic(Atomic::String), "qux".to_string() => Schema::Atomic(Atomic::Integer)},
+                        required: set!{"baz".to_string(), "qux".to_string()},
+                        ..Default::default()
+                    }),
+            };
             let mut state = ResultSetState {
-                catalog: &BTreeMap::new(),
+                catalog: &catalog,
                 variables,
                 result_set_schema,
+                current_db: "test".to_string(),
                 null_behavior: Satisfaction::Not
             };
-            let result = input.derive_schema(&mut state);
+            let result = input.derive_schema(&mut state).map(|s| Schema::simplify(&s));
             assert_eq!($expected, result);
         }
     };
@@ -44,6 +52,7 @@ macro_rules! test_derive_expression_schema {
                 catalog: &BTreeMap::new(),
                 variables,
                 result_set_schema,
+                current_db: "test".to_string(),
                 null_behavior: Satisfaction::Not
             };
             let result = input.derive_schema(&mut state);
@@ -76,6 +85,7 @@ macro_rules! test_derive_schema_for_match_stage {
                 catalog: &BTreeMap::new(),
                 variables,
                 result_set_schema,
+                current_db: "test".to_string(),
                 null_behavior: Satisfaction::Not
             };
             let result = input.derive_schema(&mut state);

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/mod.rs
@@ -14,15 +14,15 @@ macro_rules! test_derive_stage_schema {
             let mut variables = BTreeMap::new();
             $(variables = $variables;)?
             let catalog = map!{
-                    "test.bar".to_string() => Schema::Document(Document {
-                        keys: map!{
-                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
-                            "baz".to_string() => Schema::Atomic(Atomic::String),
-                            "qux".to_string() => Schema::Atomic(Atomic::Integer)
-                        },
-                        required: set!{"baz".to_string(), "qux".to_string(), "_id".to_string()},
-                        ..Default::default()
-                    }),
+                crate::Namespace("test".to_string(), "bar".to_string()) => Schema::Document(Document {
+                    keys: map!{
+                        "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                        "baz".to_string() => Schema::Atomic(Atomic::String),
+                        "qux".to_string() => Schema::Atomic(Atomic::Integer)
+                    },
+                    required: set!{"baz".to_string(), "qux".to_string(), "_id".to_string()},
+                    ..Default::default()
+               }),
             };
             let mut state = ResultSetState {
                 catalog: &catalog,

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -345,3 +345,65 @@ mod unwind {
         })
     );
 }
+
+mod lookup {
+    use super::*;
+
+    test_derive_stage_schema!(
+        eq_lookup,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "arr".to_string() => Schema::Array(
+                    Box::new(Schema::Document(Document {
+                        keys: map! {
+                            "baz".to_string() => Schema::Atomic(Atomic::String),
+                            "qux".to_string() => Schema::Atomic(Atomic::Integer)
+                        },
+                        required: set!("baz".to_string(), "qux".to_string()),
+                        ..Default::default()
+                    }))
+                ),
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string(), "arr".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$lookup": {"from": "bar", "localField": "foo", "foreignField": "baz", "as": "arr"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_stage_schema!(
+        concise_subquery_lookup,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "arr".to_string() => Schema::Array(
+                    Box::new(Schema::Document(Document {
+                        keys: map! {
+                            "baz".to_string() => Schema::Atomic(Atomic::String),
+                            "qux".to_string() => Schema::Atomic(Atomic::Integer)
+                        },
+                        required: set!("baz".to_string(), "qux".to_string()),
+                        ..Default::default()
+                    }))
+                ),
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string(), "arr".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$lookup": {"from": "bar", "localField": "foo", "foreignField": "baz", "let": {"x": "foo"}, "pipeline": [{"$project": {"out": {"$concat": ["$$x", "$baz"]}}}], "as": "arr"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+}

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -385,10 +385,9 @@ mod lookup {
                 "arr".to_string() => Schema::Array(
                     Box::new(Schema::Document(Document {
                         keys: map! {
-                            "baz".to_string() => Schema::Atomic(Atomic::String),
-                            "qux".to_string() => Schema::Atomic(Atomic::Integer)
+                            "out".to_string() => Schema::Atomic(Atomic::String),
                         },
-                        required: set!("baz".to_string(), "qux".to_string()),
+                        required: set!("out".to_string()),
                         ..Default::default()
                     }))
                 ),
@@ -398,6 +397,33 @@ mod lookup {
             ..Default::default()
         })),
         input = r#"{"$lookup": {"from": "bar", "localField": "foo", "foreignField": "baz", "let": {"x": "foo"}, "pipeline": [{"$project": {"out": {"$concat": ["$$x", "$baz"]}}}], "as": "arr"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+    test_derive_stage_schema!(
+        subquery_lookup,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "arr".to_string() => Schema::Array(
+                    Box::new(Schema::Document(Document {
+                        keys: map! {
+                            "out".to_string() => Schema::Atomic(Atomic::String),
+                        },
+                        required: set!("out".to_string()),
+                        ..Default::default()
+                    }))
+                ),
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string(), "arr".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$lookup": {"from": "bar", "let": {"x": "foo"}, "pipeline": [{"$project": {"out": {"$concat": ["$$x", "$baz"]}}}], "as": "arr"}}"#,
         starting_schema = Schema::Document(Document {
             keys: map! {
                 "foo".to_string() => Schema::Atomic(Atomic::String)

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -437,6 +437,70 @@ mod lookup {
     );
 }
 
+mod graphlookup {
+    use super::*;
+
+    test_derive_stage_schema!(
+        graphlookup_simple,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "arr".to_string() => Schema::Array(
+                    Box::new(Schema::Document(Document {
+                        keys: map! {
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                            "baz".to_string() => Schema::Atomic(Atomic::String),
+                            "qux".to_string() => Schema::Atomic(Atomic::Integer)
+                        },
+                        required: set!("baz".to_string(), "qux".to_string(), "_id".to_string()),
+                        ..Default::default()
+                    }))
+                ),
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string(), "arr".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$graphLookup": {"from": "bar", "startWith": "$foo", "connectFromField": "foo", "connectToField": "baz", "as": "arr"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+    test_derive_stage_schema!(
+        graphlookup_depth_field,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "arr".to_string() => Schema::Array(
+                    Box::new(Schema::Document(Document {
+                        keys: map! {
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                            "baz".to_string() => Schema::Atomic(Atomic::String),
+                            "qux".to_string() => Schema::Atomic(Atomic::Integer),
+                            "DEPTH".to_string() => Schema::Atomic(Atomic::Long)
+                        },
+                        required: set!("baz".to_string(), "qux".to_string(), "_id".to_string(), "DEPTH".to_string()),
+                        ..Default::default()
+                    }))
+                ),
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string(), "arr".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$graphLookup": {"from": "bar", "startWith": "$foo", "connectFromField": "foo", "connectToField": "baz", "depthField": "DEPTH", "as": "arr"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+}
+
 mod union {
     use super::*;
 

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -380,6 +380,35 @@ mod lookup {
     );
 
     test_derive_stage_schema!(
+        eq_lookup_overwrite_as,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Array(
+                    Box::new(Schema::Document(Document {
+                        keys: map! {
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                            "baz".to_string() => Schema::Atomic(Atomic::String),
+                            "qux".to_string() => Schema::Atomic(Atomic::Integer)
+                        },
+                        required: set!("baz".to_string(), "qux".to_string(), "_id".to_string()),
+                        ..Default::default()
+                    }))
+                ),
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$lookup": {"from": "bar", "localField": "foo", "foreignField": "baz", "as": "foo"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_stage_schema!(
         concise_subquery_lookup,
         expected = Ok(Schema::Document(Document {
             keys: map! {
@@ -398,7 +427,7 @@ mod lookup {
             required: set!("foo".to_string(), "arr".to_string()),
             ..Default::default()
         })),
-        input = r#"{"$lookup": {"from": "bar", "localField": "foo", "foreignField": "baz", "let": {"x": "foo"}, "pipeline": [{"$project": {"out": {"$concat": ["$$x", "$baz"]}}}], "as": "arr"}}"#,
+        input = r#"{"$lookup": {"from": "bar", "localField": "foo", "foreignField": "baz", "let": {"x": "$foo"}, "pipeline": [{"$project": {"out": {"$concat": ["$$x", "$baz"]}}}], "as": "arr"}}"#,
         starting_schema = Schema::Document(Document {
             keys: map! {
                 "foo".to_string() => Schema::Atomic(Atomic::String)
@@ -426,7 +455,34 @@ mod lookup {
             required: set!("foo".to_string(), "arr".to_string()),
             ..Default::default()
         })),
-        input = r#"{"$lookup": {"from": "bar", "let": {"x": "foo"}, "pipeline": [{"$project": {"out": {"$concat": ["$$x", "$baz"]}}}], "as": "arr"}}"#,
+        input = r#"{"$lookup": {"from": "bar", "let": {"x": "$foo"}, "pipeline": [{"$project": {"out": {"$concat": ["$$x", "$baz"]}}}], "as": "arr"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+    test_derive_stage_schema!(
+        subquery_lookup_overwrite_as,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Array(
+                    Box::new(Schema::Document(Document {
+                        keys: map! {
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                            "out".to_string() => Schema::Atomic(Atomic::String),
+                        },
+                        required: set!("out".to_string(), "_id".to_string()),
+                        ..Default::default()
+                    }))
+                ),
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$lookup": {"from": "bar", "let": {"x": "foo"}, "pipeline": [{"$project": {"out": {"$concat": ["$$x", "$baz"]}}}], "as": "foo"}}"#,
         starting_schema = Schema::Document(Document {
             keys: map! {
                 "foo".to_string() => Schema::Atomic(Atomic::String)
@@ -491,6 +547,64 @@ mod graphlookup {
             ..Default::default()
         })),
         input = r#"{"$graphLookup": {"from": "bar", "startWith": "$foo", "connectFromField": "foo", "connectToField": "baz", "depthField": "DEPTH", "as": "arr"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+    test_derive_stage_schema!(
+        graphlookup_overwrite_depth_field,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "arr".to_string() => Schema::Array(
+                    Box::new(Schema::Document(Document {
+                        keys: map! {
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                            "baz".to_string() => Schema::Atomic(Atomic::Long),
+                            "qux".to_string() => Schema::Atomic(Atomic::Integer),
+                        },
+                        required: set!("baz".to_string(), "qux".to_string(), "_id".to_string()),
+                        ..Default::default()
+                    }))
+                ),
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string(), "arr".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$graphLookup": {"from": "bar", "startWith": "$foo", "connectFromField": "foo", "connectToField": "baz", "depthField": "baz", "as": "arr"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+    test_derive_stage_schema!(
+        graphlookup_overwrite_as,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Array(
+                    Box::new(Schema::Document(Document {
+                        keys: map! {
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                            "baz".to_string() => Schema::Atomic(Atomic::String),
+                            "qux".to_string() => Schema::Atomic(Atomic::Integer),
+                            "DEPTH".to_string() => Schema::Atomic(Atomic::Long)
+                        },
+                        required: set!("baz".to_string(), "qux".to_string(), "_id".to_string(), "DEPTH".to_string()),
+                        ..Default::default()
+                    }))
+                ),
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$graphLookup": {"from": "bar", "startWith": "$foo", "connectFromField": "foo", "connectToField": "baz", "depthField": "DEPTH", "as": "foo"}}"#,
         starting_schema = Schema::Document(Document {
             keys: map! {
                 "foo".to_string() => Schema::Atomic(Atomic::String)

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -531,17 +531,21 @@ mod union {
             keys: map! {
                 "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
                 "food".to_string() => Schema::Atomic(Atomic::String),
-                "out".to_string() => Schema::Atomic(Atomic::String),
+                "out".to_string() => Schema::AnyOf(set!{
+                    Schema::Atomic(Atomic::String),
+                    Schema::Atomic(Atomic::Decimal),
+                }),
             },
-            required: set!(),
+            required: set!("out".to_string()),
             ..Default::default()
         })),
         input = r#"{"$unionWith": {"collection": "bar", "pipeline": [{"$project": {"out": {"$concat": ["$baz", "$baz"]}}}]}}"#,
         starting_schema = Schema::Document(Document {
             keys: map! {
-                "food".to_string() => Schema::Atomic(Atomic::String)
+                "food".to_string() => Schema::Atomic(Atomic::String),
+                "out".to_string() => Schema::Atomic(Atomic::Decimal),
             },
-            required: set!("foo".to_string()),
+            required: set!("foo".to_string(), "out".to_string()),
             ..Default::default()
         })
     );

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -461,4 +461,24 @@ mod union {
             ..Default::default()
         })
     );
+    test_derive_stage_schema!(
+        union_pipeline,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                "food".to_string() => Schema::Atomic(Atomic::String),
+                "out".to_string() => Schema::Atomic(Atomic::String),
+            },
+            required: set!(),
+            ..Default::default()
+        })),
+        input = r#"{"$unionWith": {"collection": "bar", "pipeline": [{"$project": {"out": {"$concat": ["$baz", "$baz"]}}}]}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "food".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
 }

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -378,7 +378,41 @@ mod lookup {
             ..Default::default()
         })
     );
-
+    test_derive_stage_schema!(
+        eq_lookup_nested_as,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "arr".to_string() =>
+                    Schema::Document(Document {
+                        keys: map! {
+                            "arr".to_string() => Schema::Array(
+                                Box::new(Schema::Document(Document {
+                                keys: map! {
+                                    "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                                    "baz".to_string() => Schema::Atomic(Atomic::String),
+                                    "qux".to_string() => Schema::Atomic(Atomic::Integer)
+                                },
+                                required: set!("baz".to_string(), "qux".to_string(), "_id".to_string()),
+                                ..Default::default()
+                            }))),
+                        },
+                        required: set!("arr".to_string()),
+                        ..Default::default()
+                    }),
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string(), "arr".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$lookup": {"from": "bar", "localField": "foo", "foreignField": "baz", "as": "arr.arr"}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
     test_derive_stage_schema!(
         eq_lookup_overwrite_as,
         expected = Ok(Schema::Document(Document {

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -356,10 +356,11 @@ mod lookup {
                 "arr".to_string() => Schema::Array(
                     Box::new(Schema::Document(Document {
                         keys: map! {
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
                             "baz".to_string() => Schema::Atomic(Atomic::String),
                             "qux".to_string() => Schema::Atomic(Atomic::Integer)
                         },
-                        required: set!("baz".to_string(), "qux".to_string()),
+                        required: set!("baz".to_string(), "qux".to_string(), "_id".to_string()),
                         ..Default::default()
                     }))
                 ),
@@ -385,9 +386,10 @@ mod lookup {
                 "arr".to_string() => Schema::Array(
                     Box::new(Schema::Document(Document {
                         keys: map! {
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
                             "out".to_string() => Schema::Atomic(Atomic::String),
                         },
-                        required: set!("out".to_string()),
+                        required: set!("out".to_string(), "_id".to_string()),
                         ..Default::default()
                     }))
                 ),
@@ -412,9 +414,10 @@ mod lookup {
                 "arr".to_string() => Schema::Array(
                     Box::new(Schema::Document(Document {
                         keys: map! {
+                            "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
                             "out".to_string() => Schema::Atomic(Atomic::String),
                         },
-                        required: set!("out".to_string()),
+                        required: set!("out".to_string(), "_id".to_string()),
                         ..Default::default()
                     }))
                 ),

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -436,3 +436,29 @@ mod lookup {
         })
     );
 }
+
+mod union {
+    use super::*;
+
+    test_derive_stage_schema!(
+        union_simple,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "_id".to_string() => Schema::Atomic(Atomic::ObjectId),
+                "food".to_string() => Schema::Atomic(Atomic::String),
+                "baz".to_string() => Schema::Atomic(Atomic::String),
+                "qux".to_string() => Schema::Atomic(Atomic::Integer),
+            },
+            required: set!(),
+            ..Default::default()
+        })),
+        input = r#"{"$unionWith": "bar"}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "food".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })
+    );
+}

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/tagged_ops.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/tagged_ops.rs
@@ -1031,6 +1031,7 @@ mod convert {
                         keys: map! {"foo".to_string() => Schema::Any },
                         ..Default::default()
                     }),
+                    current_db: "test".to_string(),
                     null_behavior: Satisfaction::Not,
                 };
                 let to_values = vec![

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/untagged_ops.rs
@@ -19,6 +19,7 @@ macro_rules! test_type_conversion_op {
                         required: set!{"foo".to_string()},
                         ..Default::default()
                     }),
+                    current_db: "test".to_string(),
                     null_behavior: Satisfaction::Not
                 };
                 let input: Expression = serde_json::from_str(format!("{{\"{0}\":\"$foo\"}}", $op).as_str()).unwrap();


### PR DESCRIPTION
This also includes an implementation of include-only $project derivation for testing purposes.