### PR TITLE
SQL-2664: Fix document comparison logic in test runner to check for matching key

### DIFF
--- a/mongosql/src/air/desugarer/remove_id.rs
+++ b/mongosql/src/air/desugarer/remove_id.rs
@@ -28,6 +28,6 @@ impl Visitor for RemoveIdDesugarerVisitor {
                 .insert(id, ProjectItem::Exclusion)
                 .unwrap();
         }
-        node
+        node.walk(self)
     }
 }

--- a/mongosql/src/air/desugarer/testdata/desugar_all.yml
+++ b/mongosql/src/air/desugarer/testdata/desugar_all.yml
@@ -62,7 +62,10 @@ tests:
                 },
                 {
                   "$project":
-                  {  "_id": 0, "eca58228-b657-498a-b76e-f48a9161a404": 0 },
+                    {
+                      "_id": 0,
+                      "eca58228-b657-498a-b76e-f48a9161a404": 0
+                    },
                 },
               ],
             "as": "__subquery_result_0",
@@ -71,6 +74,7 @@ tests:
       - {
         "$project":
           {
+            "_id": 0,
             "expr":
               {
                 "$let":
@@ -111,8 +115,8 @@ tests:
             "let": { "bar_0": "$bar" },
             "pipeline":
               [
-                { "$project": { "coll": "$$ROOT" } },
-                { "$project": { "coll": "$coll" } },
+                { "$project": { "_id": 0, "coll": "$$ROOT" } },
+                { "$project": { "_id": 0, "coll": "$coll" } },
                 {
                   "$match":
                     { "$expr":
@@ -271,9 +275,9 @@ tests:
                                     },
                                     {
                                       "$project": {
-                                          "_id": 0,
-                                          "eca58228-b657-498a-b76e-f48a9161a404": 0,
-                                        },
+                                        "_id": 0,
+                                        "eca58228-b657-498a-b76e-f48a9161a404": 0,
+                                      },
                                     },
                                   ],
                                 "as": "__subquery_result_0",
@@ -282,6 +286,7 @@ tests:
                           {
                             "$project":
                               {
+                                "_id": 0,
                                 "expr":
                                   {
                                     "$let":
@@ -301,7 +306,7 @@ tests:
                           },
                           {
                             "$project":
-                              { "__subquery_result_0": 0 },
+                              { "_id": 0, "__subquery_result_0": 0,  },
                           },
                         ],
                       "as": "eca58228-b657-498a-b76e-f48a9161a404",
@@ -332,6 +337,7 @@ tests:
       - {
         "$project":
           {
+            "_id": 0,
             "expr":
               {
                 "$let":
@@ -441,6 +447,7 @@ tests:
       - {
         "$project":
           {
+            "_id": 0,
             "expr":
               {
                 "$let":
@@ -501,6 +508,7 @@ tests:
                 {
                   "$project":
                     {
+                      "_id": 0,
                       "expr":
                         {
                           "$let":
@@ -518,7 +526,7 @@ tests:
                         },
                     },
                 },
-                { "$project": { "__subquery_result_0": 0 } },
+                { "$project": { "__subquery_result_0": 0, "_id": 0 } },
               ],
             "as": "eca58228-b657-498a-b76e-f48a9161a404",
           },
@@ -537,7 +545,7 @@ tests:
               ["$$ROOT", "$eca58228-b657-498a-b76e-f48a9161a404"],
           },
       }
-      - { "$project": { "_id": 0,"eca58228-b657-498a-b76e-f48a9161a404": 0 } }
+      - { "$project": { "_id": 0, "eca58228-b657-498a-b76e-f48a9161a404": 0 } }
 
   - name: "subquery nested in join match condition"
     input:
@@ -593,7 +601,7 @@ tests:
                         },
                     },
                 },
-                { "$project": { "__subquery_result_0": 0 } },
+                { "$project": {"_id": 0, "__subquery_result_0": 0 } },
               ],
             "as": "eca58228-b657-498a-b76e-f48a9161a404",
           },
@@ -668,7 +676,7 @@ tests:
             "as": "eca58228-b657-498a-b76e-f48a9161a404",
           },
       }
-      - { "$project": { "__subquery_result_0": 0 } }
+      - { "$project": { "_id": 0, "__subquery_result_0": 0 } }
       - {
         "$unwind":
           {
@@ -739,7 +747,7 @@ tests:
               },
           },
       }
-      - { "$project": { "__subquery_result_0": 0 } }
+      - { "$project": { "_id": 0, "__subquery_result_0": 0 } }
       - { "$project": {"_id": 1, "acc": { "$avg": "$acc" } } }
 
   - name: "subquery nested in unsupported op as arg"
@@ -778,6 +786,7 @@ tests:
       - {
         "$project":
           {
+            "_id": 0,
             "expr":
               {
                 "$cond":
@@ -843,6 +852,7 @@ tests:
       - {
         "$project":
           {
+            "_id": 0,
             "expr":
               {
                 "$let":
@@ -964,6 +974,7 @@ tests:
                 {
                   "$project":
                     {
+                      "_id": 0,
                       "a": "$a",
                       "expr": { "$slice": ["$$x", "$len"] },
                     },
@@ -1134,7 +1145,7 @@ tests:
               [
                 {
                   "$project":
-                    { "v": { "$slice": ["$$arr", "$len"] } },
+                    { "_id": 0, "v": { "$slice": ["$$arr", "$len"] } },
                 },
               ],
             "as": "__subquery_result_0",
@@ -1143,6 +1154,7 @@ tests:
       - {
         "$project":
           {
+            "_id": 0,
             "expr":
               {
                 "$let":
@@ -1239,6 +1251,7 @@ tests:
                 {
                   "$project":
                     {
+                      "_id": 0,
                       "expr":
                         {
                           "$let":
@@ -1405,6 +1418,7 @@ tests:
                 {
                   "$project":
                     {
+                      "_id": 0,
                       "v":
                         {
                           "$let":
@@ -1458,6 +1472,7 @@ tests:
       - {
         "$project":
           {
+            "_id": 0,
             "expr":
               {
                 "$let":
@@ -1698,6 +1713,7 @@ tests:
       - {
         "$project":
           {
+            "_id": 0,
             "expr":
               {
                 "$let":
@@ -1756,9 +1772,9 @@ tests:
             "let": { "bar_0": "$bar" },
             "pipeline":
               [
-                { "$project": { "baz": "$$ROOT" } },
-                { "$project": { "baz": "$baz" } },
-                { "$project": { "__bot": { "a": "$baz.a" } } },
+                { "$project": { "_id": 0, "baz": "$$ROOT" } },
+                { "$project": { "_id": 0, "baz": "$baz" } },
+                { "$project": { "_id": 0, "__bot": { "a": "$baz.a" } } },
                 { "$sort": { "__bot.a": 1 } },
                 { "$skip": 1 },
               ],

--- a/mongosql/src/air/desugarer/testdata/desugar_all.yml
+++ b/mongosql/src/air/desugarer/testdata/desugar_all.yml
@@ -526,7 +526,7 @@ tests:
                         },
                     },
                 },
-                { "_id": 0, "$project": { "__subquery_result_0": 0 } },
+                { "$project": { "_id": 0, "__subquery_result_0": 0 } },
               ],
             "as": "eca58228-b657-498a-b76e-f48a9161a404",
           },

--- a/mongosql/src/air/desugarer/testdata/desugar_all.yml
+++ b/mongosql/src/air/desugarer/testdata/desugar_all.yml
@@ -306,7 +306,7 @@ tests:
                           },
                           {
                             "$project":
-                              { "_id": 0, "__subquery_result_0": 0,  },
+                              { "_id": 0, "__subquery_result_0": 0 },
                           },
                         ],
                       "as": "eca58228-b657-498a-b76e-f48a9161a404",
@@ -526,7 +526,7 @@ tests:
                         },
                     },
                 },
-                { "$project": { "__subquery_result_0": 0, "_id": 0 } },
+                { "_id": 0, "$project": { "__subquery_result_0": 0 } },
               ],
             "as": "eca58228-b657-498a-b76e-f48a9161a404",
           },

--- a/test-utils/src/query/mod.rs
+++ b/test-utils/src/query/mod.rs
@@ -218,35 +218,27 @@ pub fn compare_documents(expected: &Document, actual: &Document, type_compare: b
     if expected.len() != actual.len() {
         return false;
     }
-    expected.iter().all(|(ek, ev)| match actual.get(ek) {
-        Some(av) => {
-            if let Bson::Document(d) = ev {
-                if let Bson::Document(ad) = av {
-                    return compare_documents(d, ad, type_compare);
-                } else {
-                    return false;
+    expected
+        .iter()
+        .all(|(ek, expected_value)| match actual.get(ek) {
+            Some(actual_value) => match (expected_value, actual_value) {
+                (Bson::Document(expected_document), Bson::Document(actual_document)) => {
+                    compare_documents(expected_document, actual_document, type_compare)
                 }
-            }
-
-            if let Bson::Array(a) = ev {
-                if let Bson::Array(aa) = av {
-                    return compare_arrays(a, aa, type_compare);
-                } else {
-                    return false;
+                (Bson::Array(expected_array), Bson::Array(actual_array)) => {
+                    compare_arrays(expected_array, actual_array, type_compare)
                 }
-            }
-            if type_compare {
-                return ev.element_type() == av.element_type();
-            }
-            if is_numeric(ev) && is_numeric(av) {
-                let d = numeric_to_double(ev);
-                let ad = numeric_to_double(av);
-                return compare_doubles_for_test(d, ad);
-            }
-            ev == av
-        }
-        None => false,
-    })
+                _ if type_compare => expected_value.element_type() == actual_value.element_type(),
+                _ if is_numeric(expected_value) && is_numeric(actual_value) => {
+                    compare_doubles_for_test(
+                        numeric_to_double(expected_value),
+                        numeric_to_double(actual_value),
+                    )
+                }
+                _ => expected_value == actual_value,
+            },
+            None => false,
+        })
 }
 
 /// convert_numerics_in_results converts all numeric values in a Vec of Documents

--- a/test-utils/src/query/mod.rs
+++ b/test-utils/src/query/mod.rs
@@ -218,8 +218,8 @@ pub fn compare_documents(expected: &Document, actual: &Document, type_compare: b
     if expected.len() != actual.len() {
         return false;
     }
-    expected.iter().all(|(ek, ev)| {
-        actual.iter().any(|(ak, av)| {
+    expected.iter().all(|(ek, ev)| match actual.get(ek) {
+        Some(av) => {
             if let Bson::Document(d) = ev {
                 if let Bson::Document(ad) = av {
                     return compare_documents(d, ad, type_compare);
@@ -236,15 +236,16 @@ pub fn compare_documents(expected: &Document, actual: &Document, type_compare: b
                 }
             }
             if type_compare {
-                return ek == ak && ev.element_type() == av.element_type();
+                return ev.element_type() == av.element_type();
             }
             if is_numeric(ev) && is_numeric(av) {
                 let d = numeric_to_double(ev);
                 let ad = numeric_to_double(av);
                 return compare_doubles_for_test(d, ad);
             }
-            ev == av && ek == ak
-        })
+            ev == av
+        }
+        None => false,
     })
 }
 

--- a/tests/e2e_tests/ext_json_implicit_type_conversion.yml
+++ b/tests/e2e_tests/ext_json_implicit_type_conversion.yml
@@ -56,13 +56,13 @@ tests:
     current_db: test_db
     query: "SELECT '{\"$numberInt\": \"1\"}' AS s FROM [{}] AS t"
     result:
-      - { 't': { 's': '{"$numberInt": "1"}' } }
+      - { '': { 's': '{"$numberInt": "1"}' } }
 
   - description: Relaxed extended JSON string not converted where string is expected
     current_db: test_db
     query: "SELECT '1' AS s FROM [{}] AS t"
     result:
-      - { 't': { 's': '1' } }
+      - { '': { 's': '1' } }
 
   - description: Invalid extended JSON defaults to string when it fails to convert
     current_db: test_db
@@ -74,15 +74,15 @@ tests:
     current_db: test_db
     query: "SELECT str AS str, '{\"$oid\": \"invalid\"}' = str AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'str': '"world"', 'res': false } }
-      - { 'foo': { 'str': '{"$oid": "invalid"}', 'res': true } }
+      - { '': { 'str': '"world"', 'res': false } }
+      - { '': { 'str': '{"$oid": "invalid"}', 'res': true } }
 
   - description: Null extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT num AS num, 'null' = num AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'num': 1, 'res': null } }
-      - { 'foo': { 'num': 2, 'res': null } }
+      - { '': { 'num': 1, 'res': null } }
+      - { '': { 'num': 2, 'res': null } }
 
   - description: Boolean extended JSON string converted where string is unexpected
     current_db: test_db
@@ -105,110 +105,110 @@ tests:
     current_db: test_db
     query: "SELECT str AS str, '\"world\"' = str AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'str': '"world"', 'res': true } }
-      - { 'foo': { 'str': '{"$oid": "invalid"}', 'res': false } }
+      - { '': { 'str': '"world"', 'res': true } }
+      - { '': { 'str': '{"$oid": "invalid"}', 'res': false } }
 
   - description: Int extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT num AS num, '{\"$numberInt\": \"2\"}' = num AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'num': 1, 'res': false } }
-      - { 'foo': { 'num': 2, 'res': true } }
+      - { '': { 'num': 1, 'res': false } }
+      - { '': { 'num': 2, 'res': true } }
 
   - description: Long extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT num AS num, '{\"$numberLong\": \"3\"}' = num AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'num': 1, 'res': false } }
-      - { 'foo': { 'num': 2, 'res': false } }
+      - { '': { 'num': 1, 'res': false } }
+      - { '': { 'num': 2, 'res': false } }
 
   - description: Double extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT num AS num, '{\"$numberDouble\": \"1.0\"}' = num AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'num': 1, 'res': true } }
-      - { 'foo': { 'num': 2, 'res': false } }
+      - { '': { 'num': 1, 'res': true } }
+      - { '': { 'num': 2, 'res': false } }
 
   - description: Decimal128 extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT num AS num, '{\"$numberDecimal\": \"24.25\"}' = num AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'num': 1, 'res': false } }
-      - { 'foo': { 'num': 2, 'res': false } }
+      - { '': { 'num': 1, 'res': false } }
+      - { '': { 'num': 2, 'res': false } }
 
   - description: RegularExpression extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT '{\"$regularExpression\": {\"pattern\": \"abc*\", \"options\": \"ix\"}}'::!REGEX AS `regex` FROM [{}] as t"
     result:
-      - { 't': { 'regex': { '$regularExpression': { 'pattern': 'abc*', 'options': 'ix' } } } }
+      - { '': { 'regex': { '$regularExpression': { 'pattern': 'abc*', 'options': 'ix' } } } }
 
   - description: Javascript extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT '{\"$code\": \"function() {}\"}'::!JAVASCRIPT AS js FROM [{}] as t"
     result:
-      - { 't': { 'js': { '$code': 'function() {}' } } }
+      - { '': { 'js': { '$code': 'function() {}' } } }
 
   - description: JavascriptWithScope extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT '{\"$code\": \"function() {}\", \"$scope\": {}}'::!JAVASCRIPTWITHSCOPE AS js FROM [{}] as t"
     result:
-      - { 't': { 'js': { '$code': 'function() {}', '$scope': { } } } }
+      - { '': { 'js': { '$code': 'function() {}', '$scope': { } } } }
 
   - description: Timestamp extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT ts AS ts, '{\"$timestamp\": {\"t\": 43, \"i\": 1}}' = ts AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'ts': { '$timestamp': { 't': 42, 'i': 1 } }, 'res': false } }
-      - { 'foo': { 'ts': { '$timestamp': { 't': 43, 'i': 1 } }, 'res': true } }
+      - { '': { 'ts': { '$timestamp': { 't': 42, 'i': 1 } }, 'res': false } }
+      - { '': { 'ts': { '$timestamp': { 't': 43, 'i': 1 } }, 'res': true } }
 
   - description: BinData extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT '{\"$binary\": {\"base64\": \"yO2rw/c4TKO2jauSqRR4ow==\", \"subType\": \"04\"}}'::!BINDATA AS bin FROM [{}] as t"
     result:
-      - { 't': { 'bin': { '$binary': { 'base64': 'yO2rw/c4TKO2jauSqRR4ow==', 'subType': '04' } } } }
+      - { '': { 'bin': { '$binary': { 'base64': 'yO2rw/c4TKO2jauSqRR4ow==', 'subType': '04' } } } }
 
   - description: UUID extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT uuid AS uuid, '{\"$uuid\": \"c8edabc3-f738-4ca3-b68d-ab92a91478a3\"}' = uuid AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'uuid': { '$uuid': 'c8edabc3-f738-4ca3-b68d-ab92a91478a3' }, 'res': true } }
-      - { 'foo': { 'uuid': { '$uuid': 'b7dcbab2-e627-3b92-a57c-9a8198036792' }, 'res': false } }
+      - { '': { 'uuid': { '$uuid': 'c8edabc3-f738-4ca3-b68d-ab92a91478a3' }, 'res': true } }
+      - { '': { 'uuid': { '$uuid': 'b7dcbab2-e627-3b92-a57c-9a8198036792' }, 'res': false } }
 
   - description: ObjectId extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT oid AS oid, '{\"$oid\": \"52337cedc27316924c423d3b\"}' = oid AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'oid': { '$oid': '63448dfed38427a35d534e40' }, 'res': false } }
-      - { 'foo': { 'oid': { '$oid': '52337cedc27316924c423d3b' }, 'res': true } }
+      - { '': { 'oid': { '$oid': '63448dfed38427a35d534e40' }, 'res': false } }
+      - { '': { 'oid': { '$oid': '52337cedc27316924c423d3b' }, 'res': true } }
 
   - description: Datetime extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT `datetime` AS `datetime`, '{\"$date\": {\"$numberLong\": \"253402300799999\"}}' = `datetime` AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'datetime': { '$date': { '$numberLong': '253402300799999' } }, 'res': true } }
-      - { 'foo': { 'datetime': { '$date': { '$numberLong': '253402300776543' } }, 'res': false } }
+      - { '': { 'datetime': { '$date': { '$numberLong': '253402300799999' } }, 'res': true } }
+      - { '': { 'datetime': { '$date': { '$numberLong': '253402300776543' } }, 'res': false } }
 
   - description: Symbol extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT `symbol` AS `symbol`, '{\"$symbol\": \"sym\"}' = `symbol` AS res FROM foo AS foo"
     result:
-      - { 'foo': { 'symbol': { '$symbol': 'sym' }, 'res': true } }
-      - { 'foo': { 'symbol': { '$symbol': 'sym2' }, 'res': false } }
+      - { '': { 'symbol': { '$symbol': 'sym' }, 'res': true } }
+      - { '': { 'symbol': { '$symbol': 'sym2' }, 'res': false } }
 
   - description: MaxKey extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT '{\"$maxKey\": 1}'::!MAXKEY AS mk FROM [{}] as t"
     result:
-      - { 't': { 'mk': { '$maxKey': 1 } } }
+      - { '': { 'mk': { '$maxKey': 1 } } }
 
   - description: MinKey extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT '{\"$minKey\": 1}'::!MINKEY AS mk FROM [{}] as t"
     result:
-      - { 't': { 'mk': { '$minKey': 1 } } }
+      - { '': { 'mk': { '$minKey': 1 } } }
 
   - description: DBPointer extended JSON string converted where string is unexpected
     current_db: test_db
     query: "SELECT '{\"$dbPointer\": {\"$ref\": \"foo\", \"$id\": {\"$oid\": \"57e193d7a9cc81b4027498b5\"}}}'::!DBPOINTER AS dbp FROM [{}] as t"
     result:
-      - { 't': { 'dbp': { '$dbPointer': { '$ref': 'foo', '$id': { '$oid': '57e193d7a9cc81b4027498b5' } } } } }
+      - { '': { 'dbp': { '$dbPointer': { '$ref': 'foo', '$id': { '$oid': '57e193d7a9cc81b4027498b5' } } } } }

--- a/tests/spec_tests/query_tests/group_by.yml
+++ b/tests/spec_tests/query_tests/group_by.yml
@@ -620,8 +620,8 @@ tests:
     query: "SELECT * FROM (SELECT a, b FROM foo.multi AS m) AS arr GROUP BY a AS a AGGREGATE COUNT(DISTINCT *) AS gcount"
     current_db: foo
     result:
-      - { "": { "a": 1, "gcount": 1 } }
-      - { "": { "a": 2, "gcount": 2 } }
+      - { "": { "a": 1, "gcount": 2 } }
+      - { "": { "a": 2, "gcount": 3 } }
       - { "": { "a": null, "gcount": 1 } }
 
   - description: COUNT(MISSING) and COUNT(NULL) skip MISSING and NULL values

--- a/tests/spec_tests/query_tests/group_by.yml
+++ b/tests/spec_tests/query_tests/group_by.yml
@@ -618,10 +618,11 @@ tests:
 
   - description: COUNT(DISTINCT *) correctness test unconditionally count distinct rows
     query: "SELECT * FROM (SELECT a, b FROM foo.multi AS m) AS arr GROUP BY a AS a AGGREGATE COUNT(DISTINCT *) AS gcount"
+    skip_reason: "_id is not being projected out in translation"
     current_db: foo
     result:
-      - { "": { "a": 1, "gcount": 2 } }
-      - { "": { "a": 2, "gcount": 3 } }
+      - { "": { "a": 1, "gcount": 1 } }
+      - { "": { "a": 2, "gcount": 2 } }
       - { "": { "a": null, "gcount": 1 } }
 
   - description: COUNT(MISSING) and COUNT(NULL) skip MISSING and NULL values

--- a/tests/spec_tests/query_tests/group_by.yml
+++ b/tests/spec_tests/query_tests/group_by.yml
@@ -618,7 +618,6 @@ tests:
 
   - description: COUNT(DISTINCT *) correctness test unconditionally count distinct rows
     query: "SELECT * FROM (SELECT a, b FROM foo.multi AS m) AS arr GROUP BY a AS a AGGREGATE COUNT(DISTINCT *) AS gcount"
-    skip_reason: "_id is not being projected out in translation"
     current_db: foo
     result:
       - { "": { "a": 1, "gcount": 1 } }

--- a/tests/spec_tests/query_tests/order_by.yml
+++ b/tests/spec_tests/query_tests/order_by.yml
@@ -407,7 +407,7 @@ tests:
 
   - description: Sorting by column from RHS of LEFT JOIN orders the entire result set
     current_db: mydb
-    query: "SELECT l._id, f.x FROM local AS l LEFT JOIN foreign AS f ON l._id = f.l_id ORDER BY x ASC"
+    query: "SELECT l._id, f.x FROM local AS l LEFT JOIN foreign AS f ON l._id = f.l_id ORDER BY x, l._id ASC"
     ordered: true
     result:
       - { '': { _id: 2 } }

--- a/tests/spec_tests/query_tests/where.yml
+++ b/tests/spec_tests/query_tests/where.yml
@@ -120,8 +120,8 @@ tests:
     query: "SELECT * FROM UNWIND(foo.biz WITH PATH => foo) WHERE foo = 2"
     current_db: test
     result:
-      - {'bar': {'_id': 0, 'foo': 2}}
-      - {'bar': {'_id': 3, 'foo': 2}}
+      - {'biz': {'_id': 0, 'foo': 2}}
+      - {'biz': {'_id': 3, 'foo': 2}}
 
   - description: WHERE after FLATTEN UNWIND returns expected results
     query: "SELECT * FROM FLATTEN(UNWIND(foo.nested WITH PATH => foo.bar)) WHERE foo_bar = 2"


### PR DESCRIPTION
Change to the document comparison logic to also check that they keys match. 
It required some minor changes to our existing tests, many of which are expected with the fix.  One is unexpected related to count(distinct *) which I've mentioned to @mattChiaravalloti 