### PR TITLE
SQL-2626: Add spec tests for subquery comparison expressions

### DIFF
--- a/mongosql/src/internal_spec_test/mod.rs
+++ b/mongosql/src/internal_spec_test/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     catalog::Catalog,
     map, parser,
     schema::{Atomic, Document, Schema},
-    set, SchemaCheckingMode,
+    SchemaCheckingMode,
 };
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -222,17 +222,21 @@ pub fn create_catalog(schemas: Vec<Schema>) -> Result<Catalog, Error> {
     let required = keys.keys().cloned().collect::<BTreeSet<String>>();
 
     // Every type constraint test uses either one or two datasources:
-    // 'foo' and/or 'bar'.
+    // 'foo' and/or 'bar'. For now, we simply include the same keys in
+    // both datasources. The fields are disambiguated in the test queries
+    // via namespacing. This set up is sufficient for all existing tests.
+    // Future implementors may have reason to have 'foo' and 'bar' diverge.
+    // If that happens, this framework could be updated accordingly.
     Ok(map! {
       (TEST_DB.to_string(), "foo".to_string()).into() => Schema::Document( Document {
-        keys,
-        required,
+        keys: keys.clone(),
+        required: required.clone(),
         additional_properties: false,
         ..Default::default()
         }),
       (TEST_DB.to_string(), "bar".to_string()).into() => Schema::Document( Document {
-        keys: map!{},
-        required: set!{},
+        keys,
+        required,
         additional_properties: false,
         ..Default::default()
         }),

--- a/tests/spec_tests/type_constraint_tests/README.md
+++ b/tests/spec_tests/type_constraint_tests/README.md
@@ -59,10 +59,10 @@ Here is an example of such a test, followed by a brief explanation:
 ```
 In this example, the query contains the expression `arg1 + arg2`, an addition operation.
 There is one map in the `valid_types` sequence. It indicates that `arg1` can be any
-numeric type, `NULL`, or missing; it also indicates that `arg2` can be any numeric type,
-`NULL`, or missing. Since these lists are included in the same map, that means any
-combination from the cross product of the lists is valid (i.e. `INT, INT`, `LONG, DECIMAL`,
-and `DOUBLE,  NULL` are all valid, among others).
+numeric type or `NULL`; it also indicates that `arg2` can be any numeric type or `NULL`.
+Since these lists are included in the same map, that means any combination from the cross
+product of the lists is valid (i.e. `INT, INT`, `LONG, DECIMAL`, and `DOUBLE,  NULL` are
+all valid, among others).
 
 #### How to Run
 The test runner for these test cases will substitute each argument in the query with a value

--- a/tests/spec_tests/type_constraint_tests/join.yml
+++ b/tests/spec_tests/type_constraint_tests/join.yml
@@ -1,11 +1,11 @@
 tests:
   - description: JOIN condition must have type BOOL or NULL
-    query: "SELECT * FROM foo JOIN bar ON arg1"
+    query: "SELECT * FROM foo JOIN bar ON foo.arg1"
     valid_types:
       - { "arg1": ["BOOL", "NULL"] }
 
   - description: Columns in USING must have constrained types for equality to work
-    query: "SELECT * FROM foo JOIN bar USING arg1"
+    query: "SELECT * FROM foo JOIN bar USING foo.arg1"
     skip_reason: "DROP support for USING Clause initially"
     valid_types:
       - { "arg1": ["STRING", "NULL"] }

--- a/tests/spec_tests/type_constraint_tests/subquery.yml
+++ b/tests/spec_tests/type_constraint_tests/subquery.yml
@@ -26,3 +26,47 @@ tests:
   - description: eq ANY must have comparable types (NULL and MISSING are always allowed)
     query: "SELECT * FROM foo WHERE arg1 = ANY(SELECT arg2 FROM bar)"
     valid_types: *comparisonValidTypes
+
+  - description: neq ANY must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 <> ANY(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: gt ANY must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 > ANY(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: gte ANY must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 >= ANY(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: lt ANY must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 < ANY(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: lte ANY must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 <= ANY(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: eq ALL must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 = ALL(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: neq ALL must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 <> ALL(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: gt ALL must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 > ALL(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: gte ALL must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 >= ALL(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: lt ALL must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 < ALL(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes
+
+  - description: lte ALL must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 <= ALL(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes

--- a/tests/spec_tests/type_constraint_tests/subquery.yml
+++ b/tests/spec_tests/type_constraint_tests/subquery.yml
@@ -1,0 +1,28 @@
+variables:
+  comparisonValidTypes: &comparisonValidTypes
+    - { "arg1": ["STRING", "NULL"], "arg2": ["STRING", "NULL"] }
+    - { "arg1": ["DOCUMENT", "NULL"], "arg2": ["DOCUMENT", "NULL"] }
+    - { "arg1": ["ARRAY", "NULL"], "arg2": ["ARRAY", "NULL"] }
+    - { "arg1": ["BINDATA", "NULL"], "arg2": ["BINDATA", "NULL"] }
+    - { "arg1": ["UNDEFINED", "NULL"], "arg2": ["UNDEFINED", "NULL"] }
+    - { "arg1": ["OBJECTID", "NULL"], "arg2": ["OBJECTID", "NULL"] }
+    - { "arg1": ["BOOL", "NULL"], "arg2": ["BOOL", "NULL"] }
+    - { "arg1": ["BSON_DATE", "NULL"], "arg2": ["BSON_DATE", "NULL"] }
+    - { "arg1": ["NULL"], "arg2": ["NULL"] }
+    - { "arg1": ["REGEX", "NULL"], "arg2": ["REGEX", "NULL"] }
+    - { "arg1": ["DBPOINTER", "NULL"], "arg2": ["NULL"] }
+    - { "arg1": ["NULL"], "arg2": ["DBPOINTER", "NULL"] }
+    - { "arg1": ["JAVASCRIPT", "NULL"], "arg2": ["NULL"] }
+    - { "arg1": ["NULL"], "arg2": ["JAVASCRIPT", "NULL"] }
+    - { "arg1": ["SYMBOL", "NULL"], "arg2": ["SYMBOL", "NULL"] }
+    - { "arg1": ["JAVASCRIPTWITHSCOPE", "NULL"], "arg2": ["NULL"] }
+    - { "arg1": ["NULL"], "arg2": ["JAVASCRIPTWITHSCOPE", "NULL"] }
+    - { "arg1": ["BSON_TIMESTAMP", "NULL"], "arg2": ["BSON_TIMESTAMP", "NULL"] }
+    - { "arg1": ["MINKEY", "NULL"], "arg2": ["MINKEY", "NULL"] }
+    - { "arg1": ["MAXKEY", "NULL"], "arg2": ["MAXKEY", "NULL"] }
+    - { "arg1": ["INT", "LONG", "DOUBLE", "DECIMAL", "NULL"], "arg2": ["INT", "LONG", "DOUBLE", "DECIMAL", "NULL"] }
+
+tests:
+  - description: eq ANY must have comparable types (NULL and MISSING are always allowed)
+    query: "SELECT * FROM foo WHERE arg1 = ANY(SELECT arg2 FROM bar)"
+    valid_types: *comparisonValidTypes


### PR DESCRIPTION
This PR adds type constraint spec tests for subquery comparison expressions. In the design doc, we initially said we would query test the new document and array comparison features for subquery expressions. However, as I audited the existing spec query and spec type constraint tests, I realized (1) we do not have any other type-related query tests for subquery comparison expressions and (2) we did not have any existing spec type constraint tests for subquery comparison expressions. Given that, I decided to make these new type constraint tests and they demonstrate exactly what we wanted to check.