### PR TITLE
SQL-2620: Add support for UNION distinct

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -45,7 +45,6 @@ The following errors occur when something goes wrong while converting the SQL qu
 |---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Error 3002](#error-3002) | A SELECT list with multiple values cannot contain a non-namespaced `*` (i.e., `SELECT a, *, b FROM myTable` is not supported). A non-namespaced `*` must be used by itself.                                  |
 | [Error 3004](#error-3004) | The array data source contains an identifier. Array data sources must be constant.                                                                                                                           |
-| [Error 3006](#error-3006) | Distinct UNION is not allowed.                                                                                                                                                                               |
 | [Error 3007](#error-3007) | A data source referenced in the SELECT list could not be found.                                                                                                                                              |
 | [Error 3008](#error-3008) | A field could not be found in any data source.                                                                                                                                                               |
 | [Error 3009](#error-3009) | A field exists in multiple data sources and is ambiguous.                                                                                                                                                    |
@@ -210,13 +209,6 @@ The following errors occur when something goes wrong while using the excludeName
 - **Description:** The array data source contains references. Array data sources must be constant.
 - **Common Causes:** Accessing a field in an array data source as shown by this query: `SELECT * FROM [{'a': foo.a}] AS arr`.
 - **Resolution Steps:** Modify your array data source to only contain constants. Corrected example query: `SELECT * FROM [{'a': 34}] AS arr`.
-
-### Error 3006
-
-- **Description:** Distinct UNION is not allowed. You can only do `UNION ALL` (i.e., duplicate values always have to be allowed).
-- **Common Causes:** Using `UNION` instead of `UNION ALL`. For example, the query `SELECT a FROM foo AS foo UNION SELECT b, c FROM bar AS bar`
-  causes this error.
-- **Resolution Steps:** Only use `UNION ALL` when doing unions. Corrected example query: `SELECT a FROM foo AS foo UNION ALL SELECT b, c FROM bar AS bar`.
 
 ### Error 3007
 

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -366,7 +366,68 @@ impl<'a> Algebrizer<'a> {
 
     pub fn algebrize_set_query(&self, ast_node: ast::SetQuery) -> Result<mir::Stage> {
         match ast_node.op {
-            ast::SetOperator::Union => Err(Error::DistinctUnion),
+            ast::SetOperator::Union => {
+                let union_all_stage = mir::Stage::Set(mir::Set {
+                    operation: mir::SetOperation::UnionAll,
+                    left: Box::new(self.algebrize_query(*ast_node.left)?),
+                    right: Box::new(self.algebrize_query(*ast_node.right)?),
+                    cache: SchemaCache::new(),
+                });
+
+                let union_result_set = union_all_stage.schema(&self.schema_inference_state())?;
+                let datasources: BTreeSet<Key> = union_result_set
+                    .schema_env
+                    .keys()
+                    .filter(|key| key.scope == self.scope_level)
+                    .cloned()
+                    .collect();
+
+                // Create group keys for each datasource
+                let group_keys: Vec<OptionallyAliasedExpr> = datasources
+                    .iter()
+                    .enumerate()
+                    .map(|(i, key)| {
+                        OptionallyAliasedExpr::Aliased(AliasedExpr {
+                            alias: format!("__groupKey{}", i),
+                            expr: Expression::Reference(ReferenceExpr { key: key.clone() }),
+                        })
+                    })
+                    .collect();
+
+                // Adding group stage to union all to remove duplicates
+                let group_stage = mir::Stage::Group(mir::Group {
+                    source: Box::new(union_all_stage),
+                    keys: group_keys,
+                    aggregations: vec![],
+                    cache: SchemaCache::new(),
+                    scope: self.scope_level,
+                });
+
+                let mut project_expression = BindingTuple::new();
+                for (i, key) in datasources.iter().enumerate() {
+                    project_expression.insert(
+                        key.clone(),
+                        Expression::FieldAccess(FieldAccess {
+                            expr: Box::new(Expression::Reference(ReferenceExpr {
+                                key: Key::bot(self.scope_level),
+                            })),
+                            field: format!("__groupKey{}", i),
+                            // Setting is_nullable to true because the result set coming into the
+                            // UNION clause could be empty.
+                            is_nullable: true,
+                        }),
+                    );
+                }
+
+                let project_stage = mir::Stage::Project(mir::Project {
+                    source: Box::new(group_stage),
+                    expression: project_expression,
+                    is_add_fields: false,
+                    cache: SchemaCache::new(),
+                });
+
+                schema_check_return!(self, project_stage)
+            }
             ast::SetOperator::UnionAll => schema_check_return!(
                 self,
                 mir::Stage::Set(mir::Set {

--- a/mongosql/src/algebrizer/errors.rs
+++ b/mongosql/src/algebrizer/errors.rs
@@ -14,7 +14,6 @@ use std::collections::HashSet;
 pub enum Error {
     NonStarStandardSelectBody,
     ArrayDatasourceMustBeLiteral,
-    DistinctUnion,
     NoSuchDatasource(DatasourceName),
     FieldNotFound(String, Option<Vec<String>>, ClauseType, u16),
     AmbiguousField(String, ClauseType, u16),
@@ -64,7 +63,6 @@ impl UserError for Error {
         match self {
             Error::NonStarStandardSelectBody => 3002,
             Error::ArrayDatasourceMustBeLiteral => 3004,
-            Error::DistinctUnion => 3006,
             Error::NoSuchDatasource(_) => 3007,
             Error::FieldNotFound(_, _, _, _) => 3008,
             Error::AmbiguousField(_, _, _) => 3009,
@@ -95,7 +93,6 @@ impl UserError for Error {
         match self {
             Error::NonStarStandardSelectBody => None,
             Error::ArrayDatasourceMustBeLiteral => None,
-            Error::DistinctUnion => None,
             Error::NoSuchDatasource(_) => None,
             Error::FieldNotFound(field, found_fields, clause_type, scope_level) => {
                 if let Some(possible_fields) = found_fields {
@@ -183,7 +180,6 @@ impl UserError for Error {
         match self{
             Error::NonStarStandardSelectBody => "standard SELECT expressions can only contain *".to_string(),
             Error::ArrayDatasourceMustBeLiteral => "array datasource must be constant".to_string(),
-            Error::DistinctUnion => "UNION DISTINCT not allowed".to_string(),
             Error::NoSuchDatasource(datasource_name) => format!("no such datasource: {0:?}", datasource_name),
             Error::FieldNotFound(field, _, clause_type, scope_level) => format!("field `{}` in the `{}` clause at the {} scope level cannot be resolved to any datasource", field, clause_type, scope_level),
             Error::AmbiguousField(field, clause_type, scope_level) => format!("ambiguous field `{}` in the `{}` clause at the {} scope level", field, clause_type, scope_level),

--- a/mongosql/src/algebrizer/test.rs
+++ b/mongosql/src/algebrizer/test.rs
@@ -7472,30 +7472,8 @@ mod set_query {
             source: Box::new(mir::Stage::Group(mir::Group {
                 source: Box::new(mir::Stage::Set(mir::Set {
                     operation: mir::SetOperation::UnionAll,
-                    left: Box::new(mir::Stage::Project(mir::Project {
-                        source: Box::new(mir::Stage::Collection(mir::Collection {
-                            db: "test".into(),
-                            collection: "foo".into(),
-                            cache: SchemaCache::new()
-                        })),
-                        expression: map! {
-                            (DatasourceName::Named("foo".into()), 0u16).into() => mir::Expression::Reference((DatasourceName::Named("foo".into()), 0u16).into())
-                        },
-                        is_add_fields: false,
-                        cache: SchemaCache::new()
-                    })),
-                    right: Box::new(mir::Stage::Project(mir::Project {
-                        source: Box::new(mir::Stage::Collection(mir::Collection {
-                            db: "test".into(),
-                            collection: "bar".into(),
-                            cache: SchemaCache::new()
-                        })),
-                        expression: map! {
-                            (DatasourceName::Named("bar".into()), 0u16).into() => mir::Expression::Reference((DatasourceName::Named("bar".into()), 0u16).into())
-                        },
-                        is_add_fields: false,
-                        cache: SchemaCache::new()
-                    })),
+                    left: Box::new(mir_source_foo()),
+                    right: Box::new(mir_source_bar()),
                     cache: SchemaCache::new()
                 })),
                 keys: vec![

--- a/mongosql/src/algebrizer/test.rs
+++ b/mongosql/src/algebrizer/test.rs
@@ -1,9 +1,15 @@
 #![allow(clippy::redundant_pattern_matching)]
-use crate::{ast::{self, CollectionSource, Datasource}, catalog::{Catalog, Namespace}, map, mir::{schema::SchemaCache, Collection, Expression, Project, Stage}, schema::ANY_DOCUMENT};
+use crate::mir::FieldAccess;
+use crate::{
+    ast::{self, CollectionSource, Datasource},
+    catalog::{Catalog, Namespace},
+    map,
+    mir::{schema::SchemaCache, Collection, Expression, Project, Stage},
+    schema::ANY_DOCUMENT,
+};
 use lazy_static::lazy_static;
 use linked_hash_map::LinkedHashMap;
 use mongosql_datastructures::binding_tuple::Key;
-use crate::mir::FieldAccess;
 
 macro_rules! test_algebrize {
     ($func_name:ident, method = $method:ident, $(in_implicit_type_conversion_context = $in_implicit_type_conversion_context:expr,)? $(expected = $expected:expr,)? $(expected_pat = $expected_pat:pat,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)? $(is_add_fields = $is_add_fields:expr, )?) => {
@@ -95,19 +101,22 @@ macro_rules! test_user_error_messages {
 fn mir_source_collection_with_project(
     collection_name: &str,
     scope: u16,
-    field_names: Vec<&str>
+    field_names: Vec<&str>,
 ) -> Stage {
     let database = "test";
     if !field_names.is_empty() {
-        let document_fields = field_names.iter()
-            .map(|field_name| (
-                field_name.to_string(),
-                Expression::FieldAccess(FieldAccess {
-                    expr: Box::new(Expression::Reference((collection_name, scope).into())),
-                    field: field_name.to_string(),
-                    is_nullable: true
-                })
-            ))
+        let document_fields = field_names
+            .iter()
+            .map(|field_name| {
+                (
+                    field_name.to_string(),
+                    Expression::FieldAccess(FieldAccess {
+                        expr: Box::new(Expression::Reference((collection_name, scope).into())),
+                        field: field_name.to_string(),
+                        is_nullable: true,
+                    }),
+                )
+            })
             .collect::<LinkedHashMap<_, _>>();
 
         Stage::Project(Project {
@@ -115,19 +124,19 @@ fn mir_source_collection_with_project(
                 source: Box::new(Stage::Collection(Collection {
                     db: database.into(),
                     collection: collection_name.into(),
-                    cache: SchemaCache::new()
+                    cache: SchemaCache::new(),
                 })),
                 expression: map! {
                     (collection_name, scope).into() => Expression::Reference((collection_name, scope).into())
                 },
                 is_add_fields: false,
-                cache: SchemaCache::new()
+                cache: SchemaCache::new(),
             })),
             expression: map! {
                 Key::bot(scope) => Expression::Document(document_fields.into())
             },
             is_add_fields: false,
-            cache: SchemaCache::new()
+            cache: SchemaCache::new(),
         })
     } else {
         Stage::Project(Project {
@@ -7482,11 +7491,12 @@ mod limit_or_offset_clause {
 }
 
 mod set_query {
-    use super::{catalog, mir_source_bar, mir_source_collection_with_project, mir_source_foo, AST_QUERY_BAR, AST_QUERY_FOO, AST_SOURCE_BAR, AST_SOURCE_FOO};
-    use crate::schema::{Document, Schema};
-    use crate::{
-        ast, map, mir, mir::schema::SchemaCache, multimap, schema, set,
+    use super::{
+        catalog, mir_source_bar, mir_source_collection_with_project, mir_source_foo, AST_QUERY_BAR,
+        AST_QUERY_FOO, AST_SOURCE_BAR, AST_SOURCE_FOO,
     };
+    use crate::schema::{Document, Schema};
+    use crate::{ast, map, mir, mir::schema::SchemaCache, multimap, schema, set};
     use mongosql_datastructures::binding_tuple::DatasourceName;
 
     test_algebrize!(
@@ -7503,15 +7513,11 @@ mod set_query {
                 keys: vec![
                     mir::OptionallyAliasedExpr::Aliased(mir::AliasedExpr {
                         alias: "__groupKey0".to_string(),
-                        expr: mir::Expression::Reference(
-                            ("bar", 0u16).into()
-                        )
+                        expr: mir::Expression::Reference(("bar", 0u16).into())
                     }),
                     mir::OptionallyAliasedExpr::Aliased(mir::AliasedExpr {
                         alias: "__groupKey1".to_string(),
-                        expr: mir::Expression::Reference(
-                            ("foo", 0u16).into()
-                        )
+                        expr: mir::Expression::Reference(("foo", 0u16).into())
                     })
                 ],
                 aggregations: vec![],
@@ -7534,114 +7540,114 @@ mod set_query {
     );
 
     test_algebrize!(
-    union_distinct_values,
-    method = algebrize_set_query,
-    expected = Ok(mir::Stage::Project(mir::Project {
-        source: Box::new(mir::Stage::Group(mir::Group {
-            source: Box::new(mir::Stage::Set(mir::Set {
-                operation: mir::SetOperation::UnionAll,
-                left: Box::new(mir_source_collection_with_project(
-                    "foo",
-                    1u16,
-                    vec!["a", "b"]
-                )),
-                right: Box::new(mir_source_collection_with_project(
-                    "bar",
-                    1u16,
-                    vec!["a", "b"]
-                )),
-                cache: SchemaCache::new()
+        union_distinct_values,
+        method = algebrize_set_query,
+        expected = Ok(mir::Stage::Project(mir::Project {
+            source: Box::new(mir::Stage::Group(mir::Group {
+                source: Box::new(mir::Stage::Set(mir::Set {
+                    operation: mir::SetOperation::UnionAll,
+                    left: Box::new(mir_source_collection_with_project(
+                        "foo",
+                        1u16,
+                        vec!["a", "b"]
+                    )),
+                    right: Box::new(mir_source_collection_with_project(
+                        "bar",
+                        1u16,
+                        vec!["a", "b"]
+                    )),
+                    cache: SchemaCache::new()
+                })),
+                keys: vec![mir::OptionallyAliasedExpr::Aliased(mir::AliasedExpr {
+                    alias: "__groupKey0".to_string(),
+                    expr: mir::Expression::Reference((DatasourceName::Bottom, 1u16).into())
+                })],
+                aggregations: vec![],
+                cache: SchemaCache::new(),
+                scope: 1
             })),
-            keys: vec![mir::OptionallyAliasedExpr::Aliased(mir::AliasedExpr {
-                alias: "__groupKey0".to_string(),
-                expr: mir::Expression::Reference((DatasourceName::Bottom, 1u16).into())
-            })],
-            aggregations: vec![],
-            cache: SchemaCache::new(),
-            scope: 1
+            expression: map! {
+                (DatasourceName::Bottom, 1u16).into() => mir::Expression::FieldAccess(mir::FieldAccess {
+                    expr: Box::new(mir::Expression::Reference((DatasourceName::Bottom, 1u16).into())),
+                    field: "__groupKey0".to_string(),
+                    is_nullable: true
+                })
+            },
+            is_add_fields: false,
+            cache: SchemaCache::new()
         })),
-        expression: map! {
-            (DatasourceName::Bottom, 1u16).into() => mir::Expression::FieldAccess(mir::FieldAccess {
-                expr: Box::new(mir::Expression::Reference((DatasourceName::Bottom, 1u16).into())),
-                field: "__groupKey0".to_string(),
-                is_nullable: true
-            })
+        input = ast::SetQuery {
+            left: Box::new(ast::Query::Select(ast::SelectQuery {
+                select_clause: ast::SelectClause {
+                    set_quantifier: ast::SetQuantifier::All,
+                    body: ast::SelectBody::Values(vec![ast::SelectValuesExpression::Expression(
+                        ast::Expression::Document(multimap! {
+                            "a".into() => ast::Expression::Subpath(ast::SubpathExpr {
+                                expr: Box::new(ast::Expression::Identifier("foo".into())),
+                                subpath: "a".into()
+                            }),
+                            "b".into() => ast::Expression::Subpath(ast::SubpathExpr {
+                                expr: Box::new(ast::Expression::Identifier("foo".into())),
+                                subpath: "b".into()
+                            })
+                        })
+                    )])
+                },
+                from_clause: Some(AST_SOURCE_FOO.clone()),
+                where_clause: None,
+                group_by_clause: None,
+                having_clause: None,
+                order_by_clause: None,
+                limit: None,
+                offset: None,
+            })),
+            op: ast::SetOperator::Union,
+            right: Box::new(ast::Query::Select(ast::SelectQuery {
+                select_clause: ast::SelectClause {
+                    set_quantifier: ast::SetQuantifier::All,
+                    body: ast::SelectBody::Values(vec![ast::SelectValuesExpression::Expression(
+                        ast::Expression::Document(multimap! {
+                            "a".into() => ast::Expression::Subpath(ast::SubpathExpr {
+                                expr: Box::new(ast::Expression::Identifier("bar".into())),
+                                subpath: "a".into()
+                            }),
+                            "b".into() => ast::Expression::Subpath(ast::SubpathExpr {
+                                expr: Box::new(ast::Expression::Identifier("bar".into())),
+                                subpath: "b".into()
+                            })
+                        })
+                    )])
+                },
+                from_clause: Some(AST_SOURCE_BAR.clone()),
+                where_clause: None,
+                group_by_clause: None,
+                having_clause: None,
+                order_by_clause: None,
+                limit: None,
+                offset: None,
+            })),
         },
-        is_add_fields: false,
-        cache: SchemaCache::new()
-    })),
-    input = ast::SetQuery {
-        left: Box::new(ast::Query::Select(ast::SelectQuery {
-            select_clause: ast::SelectClause {
-                set_quantifier: ast::SetQuantifier::All,
-                body: ast::SelectBody::Values(vec![ast::SelectValuesExpression::Expression(
-                    ast::Expression::Document(multimap! {
-                        "a".into() => ast::Expression::Subpath(ast::SubpathExpr {
-                            expr: Box::new(ast::Expression::Identifier("foo".into())),
-                            subpath: "a".into()
-                        }),
-                        "b".into() => ast::Expression::Subpath(ast::SubpathExpr {
-                            expr: Box::new(ast::Expression::Identifier("foo".into())),
-                            subpath: "b".into()
-                        })
-                    })
-                )])
-            },
-            from_clause: Some(AST_SOURCE_FOO.clone()),
-            where_clause: None,
-            group_by_clause: None,
-            having_clause: None,
-            order_by_clause: None,
-            limit: None,
-            offset: None,
-        })),
-        op: ast::SetOperator::Union,
-        right: Box::new(ast::Query::Select(ast::SelectQuery {
-            select_clause: ast::SelectClause {
-                set_quantifier: ast::SetQuantifier::All,
-                body: ast::SelectBody::Values(vec![ast::SelectValuesExpression::Expression(
-                    ast::Expression::Document(multimap! {
-                        "a".into() => ast::Expression::Subpath(ast::SubpathExpr {
-                            expr: Box::new(ast::Expression::Identifier("bar".into())),
-                            subpath: "a".into()
-                        }),
-                        "b".into() => ast::Expression::Subpath(ast::SubpathExpr {
-                            expr: Box::new(ast::Expression::Identifier("bar".into())),
-                            subpath: "b".into()
-                        })
-                    })
-                )])
-            },
-            from_clause: Some(AST_SOURCE_BAR.clone()),
-            where_clause: None,
-            group_by_clause: None,
-            having_clause: None,
-            order_by_clause: None,
-            limit: None,
-            offset: None,
-        })),
-    },
-    env = map! {
-        ("foo", 0u16).into() => Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(schema::Atomic::Integer),
-                "b".into() => Schema::Atomic(schema::Atomic::String),
-            },
-            required: set!{"a".into(), "b".into()},
-            additional_properties: false,
-            ..Default::default()
-        }),
-        ("bar", 0u16).into() => Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(schema::Atomic::Integer),
-                "b".into() => Schema::Atomic(schema::Atomic::String),
-            },
-            required: set!{"a".into(), "b".into()},
-            additional_properties: false,
-            ..Default::default()
-        }),
-    },
-    catalog = catalog(vec![("test", "foo"), ("test", "bar")]),
+        env = map! {
+            ("foo", 0u16).into() => Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(schema::Atomic::Integer),
+                    "b".into() => Schema::Atomic(schema::Atomic::String),
+                },
+                required: set!{"a".into(), "b".into()},
+                additional_properties: false,
+                ..Default::default()
+            }),
+            ("bar", 0u16).into() => Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(schema::Atomic::Integer),
+                    "b".into() => Schema::Atomic(schema::Atomic::String),
+                },
+                required: set!{"a".into(), "b".into()},
+                additional_properties: false,
+                ..Default::default()
+            }),
+        },
+        catalog = catalog(vec![("test", "foo"), ("test", "bar")]),
     );
 
     test_algebrize!(

--- a/mongosql/src/mir/definitions.rs
+++ b/mongosql/src/mir/definitions.rs
@@ -242,7 +242,6 @@ pub enum JoinType {
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum SetOperation {
     UnionAll,
-    Union,
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -566,13 +566,13 @@ impl CachedSchema for Stage {
                 let max_size = left_result_set
                     .max_size
                     .and_then(|l| right_result_set.max_size.map(|r| l + r));
-                    Ok(ResultSet {
-                        schema_env: left_result_set
-                            .schema_env
-                            .union(right_result_set.schema_env),
-                        min_size: left_result_set.min_size + right_result_set.min_size,
-                        max_size,
-                    })
+                Ok(ResultSet {
+                    schema_env: left_result_set
+                        .schema_env
+                        .union(right_result_set.schema_env),
+                    min_size: left_result_set.min_size + right_result_set.min_size,
+                    max_size,
+                })
             }
             Stage::Derived(s) => s.source.schema(&SchemaInferenceState {
                 scope_level: state.scope_level + 1,

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -566,22 +566,13 @@ impl CachedSchema for Stage {
                 let max_size = left_result_set
                     .max_size
                     .and_then(|l| right_result_set.max_size.map(|r| l + r));
-                match s.operation {
-                    SetOperation::Union => Ok(ResultSet {
-                        schema_env: left_result_set
-                            .schema_env
-                            .union(right_result_set.schema_env),
-                        min_size: min(left_result_set.min_size + right_result_set.min_size, 1),
-                        max_size,
-                    }),
-                    SetOperation::UnionAll => Ok(ResultSet {
+                    Ok(ResultSet {
                         schema_env: left_result_set
                             .schema_env
                             .union(right_result_set.schema_env),
                         min_size: left_result_set.min_size + right_result_set.min_size,
                         max_size,
-                    }),
-                }
+                    })
             }
             Stage::Derived(s) => s.source.schema(&SchemaInferenceState {
                 scope_level: state.scope_level + 1,

--- a/mongosql/src/mir/schema/test/stages/set.rs
+++ b/mongosql/src/mir/schema/test/stages/set.rs
@@ -3,8 +3,8 @@ use crate::{
     mir::{
         schema::{
             test::{
-                test_document_a, test_document_b, test_document_c, TEST_DOCUMENT_SCHEMA_A,
-                TEST_DOCUMENT_SCHEMA_B, TEST_DOCUMENT_SCHEMA_C,
+                test_document_a, test_document_b, TEST_DOCUMENT_SCHEMA_A,
+                TEST_DOCUMENT_SCHEMA_B,
             },
             SchemaCache,
         },
@@ -64,91 +64,6 @@ test_schema!(
         })),
         right: Box::new(Stage::Array(ArraySource {
             array: vec![test_document_b()],
-            alias: "bar".into(),
-            cache: SchemaCache::new(),
-        })),
-        cache: SchemaCache::new(),
-    }),
-);
-
-test_schema!(
-    set_union_same_name_unioned,
-    expected = Ok(ResultSet {
-        schema_env: map! {
-            ("foo", 0u16).into() => Schema::AnyOf(set![
-                    Schema::AnyOf(set![TEST_DOCUMENT_SCHEMA_B.clone()]),
-                    Schema::AnyOf(set![TEST_DOCUMENT_SCHEMA_A.clone()]),
-                ]
-            ),
-        },
-        min_size: 1,
-        max_size: Some(2),
-    }),
-    input = Stage::Set(Set {
-        operation: SetOperation::Union,
-        left: Box::new(Stage::Array(ArraySource {
-            array: vec![test_document_a()],
-            alias: "foo".into(),
-            cache: SchemaCache::new(),
-        })),
-        right: Box::new(Stage::Array(ArraySource {
-            array: vec![test_document_b()],
-            alias: "foo".into(),
-            cache: SchemaCache::new(),
-        })),
-        cache: SchemaCache::new(),
-    }),
-);
-
-test_schema!(
-    set_union_distinct_name_not_unioned,
-    expected = Ok(ResultSet {
-        schema_env: map! {
-            ("foo", 0u16).into() =>
-                    Schema::AnyOf(set![TEST_DOCUMENT_SCHEMA_A.clone(), TEST_DOCUMENT_SCHEMA_A.clone()]),
-            ("bar", 0u16).into() =>
-                    Schema::AnyOf(set![TEST_DOCUMENT_SCHEMA_B.clone(), TEST_DOCUMENT_SCHEMA_C.clone()]),
-        },
-        min_size: 1,
-        max_size: Some(4),
-    }),
-    input = Stage::Set(Set {
-        operation: SetOperation::Union,
-        left: Box::new(Stage::Array(ArraySource {
-            array: vec![test_document_a(), test_document_a()],
-            alias: "foo".into(),
-            cache: SchemaCache::new(),
-        })),
-        right: Box::new(Stage::Array(ArraySource {
-            array: vec![test_document_b(), test_document_c(),],
-            alias: "bar".into(),
-            cache: SchemaCache::new(),
-        })),
-        cache: SchemaCache::new(),
-    }),
-);
-
-test_schema!(
-    set_union_of_two_empty_sets_has_min_and_max_size_0,
-    expected = Ok(ResultSet {
-        schema_env: map! {
-            ("foo", 0u16).into() =>
-                    Schema::AnyOf(set![]),
-            ("bar", 0u16).into() =>
-                    Schema::AnyOf(set![]),
-        },
-        min_size: 0,
-        max_size: Some(0),
-    }),
-    input = Stage::Set(Set {
-        operation: SetOperation::Union,
-        left: Box::new(Stage::Array(ArraySource {
-            array: vec![],
-            alias: "foo".into(),
-            cache: SchemaCache::new(),
-        })),
-        right: Box::new(Stage::Array(ArraySource {
-            array: vec![],
             alias: "bar".into(),
             cache: SchemaCache::new(),
         })),

--- a/mongosql/src/mir/schema/test/stages/set.rs
+++ b/mongosql/src/mir/schema/test/stages/set.rs
@@ -3,8 +3,7 @@ use crate::{
     mir::{
         schema::{
             test::{
-                test_document_a, test_document_b, TEST_DOCUMENT_SCHEMA_A,
-                TEST_DOCUMENT_SCHEMA_B,
+                test_document_a, test_document_b, TEST_DOCUMENT_SCHEMA_A, TEST_DOCUMENT_SCHEMA_B,
             },
             SchemaCache,
         },

--- a/tests/errors/algebrizer.yml
+++ b/tests/errors/algebrizer.yml
@@ -98,12 +98,6 @@ tests:
     should_compile: false
     algebrize_error: "Error 3004: array datasource must be constant"
 
-  - description: Error 3006 DistinctUnion
-    query: "SELECT a FROM foo AS foo UNION SELECT b, c FROM bar AS bar"
-    current_db: db
-    should_compile: false
-    algebrize_error: 'Error 3006: UNION DISTINCT not allowed'
-
   - description: Error 3007 NoSuchDatasource
     query: "SELECT a.* FROM foo"
     current_db: db

--- a/tests/spec_tests/query_tests/distinct.yml
+++ b/tests/spec_tests/query_tests/distinct.yml
@@ -200,6 +200,14 @@ tests:
       - {'bar': {'a': 2, 'b': 4}}
       - {'bar': {'a': 2, 'b': 4, 'c': 1}}
 
+  - description: "UNION distinct with same value order"
+    current_db: "db"
+    query: "SELECT a,b FROM foo UNION SELECT a,b FROM bar"
+    result:
+      - {'': {'a': 1, 'b': 2}}
+      - {'': {'a': 2, 'b': 2}}
+      - {'': {'a': 2, 'b': 4}}
+
   - description: "UNION distinct with mixed value order"
     current_db: "db"
     query: "SELECT a,b FROM foo UNION SELECT b,a FROM bar"

--- a/tests/spec_tests/query_tests/distinct.yml
+++ b/tests/spec_tests/query_tests/distinct.yml
@@ -13,6 +13,7 @@ catalog_data:
       - { _id: 2, a: 2, b: 2 }
       - { _id: 3, a: 2, b: 2 }
       - { _id: 4, a: 2, b: 4 }
+      - { _id: 5, a: 2, b: 4, c: 1 }
 
     documents:
       - { _id: 1, doc: { a: 1, b: 2 } }
@@ -52,7 +53,8 @@ catalog_schema:
         "properties": {
           "_id": { "bsonType": "int" },
           "a": { "bsonType": "int" },
-          "b": { "bsonType": "int" }
+          "b": { "bsonType": "int" },
+          "c": { "bsonType": "int" }
         }
       },
       "documents": {
@@ -120,6 +122,7 @@ tests:
       - { 'foo': { "_id": 2, "a": 1, "b": 2 }, 'bar': { "_id": 2, "a": 2, "b": 2 } }
       - { 'foo': { "_id": 3, "a": 2, "b": 2 }, 'bar': { "_id": 3, "a": 2, "b": 2 } }
       - { 'foo': { "_id": 4, "a": 1, "b": 2 }, 'bar': { "_id": 4, "a": 2, "b": 4 } }
+      - { 'foo': { "_id": 5, "a": 2, "b": 2, "c": true, "d": "a", "e": null }, 'bar': { "_id": 5, "a": 2, "b": 4, "c":1 } }
 
   - description: "SELECT DISTINCT specific columns from joined tables"
     query: "SELECT DISTINCT foo.a, bar.b FROM db.foo, db.bar WHERE foo._id = bar._id"
@@ -127,6 +130,7 @@ tests:
       - { '': { "a": 1, "b": 2 } }
       - { '': { "a": 2, "b": 2 } }
       - { '': { "a": 1, "b": 4 } }
+      - { '': { "a": 2, "b": 4 } }
 
   - description: "SELECT DISTINCT columns ensures we see unique values"
     query: "SELECT DISTINCT a, b FROM db.foo"
@@ -157,3 +161,85 @@ tests:
       - { '': { "arr": [3, 2, 1] } }
       - { '': { "arr": [3, 2, 1, 4] } }
 
+  - description: "basic UNION distinct correctness test"
+    current_db: "db"
+    query: "SELECT VALUE {'a': a} FROM foo UNION SELECT VALUE {'a': a} FROM foo"
+    result:
+      - {'': {'a': 1}}
+      - {'': {'a': 2}}
+
+  - description: "duplicates are still removed when collections with different schema are unioned"
+    current_db: "db"
+    query: "SELECT VALUE {'a': a} FROM foo AS foo UNION SELECT VALUE {'b': b, 'c': c} FROM bar AS bar"
+    result:
+      - {'': {'a': 1}}
+      - {'': {'a': 2}}
+      - {'': {'b': 2 }}
+      - {'': {'b': 4 }}
+      - {'': {'b': 4, 'c': 1}}
+
+  - description: "UNION is left associative"
+    current_db: "db"
+    query: "SELECT VALUE {'a': a} FROM foo UNION ALL SELECT VALUE {'a': a} FROM foo UNION SELECT VALUE {'a': a} FROM foo"
+    result:
+      - {'': {'a': 1}}
+      - {'': {'a': 2}}
+
+  - description: "UNION distinct with select * in both queries"
+    current_db: "db"
+    query: | 
+      SELECT * FROM (SELECT a,b,c FROM foo) AS foo 
+      UNION 
+      SELECT * FROM (SELECT a,b,c FROM bar) AS bar
+    result:
+      - {'foo': {'a': 1, 'b': 2}}
+      - {'foo': {'a': 2, 'b': 2}}
+      - {'foo': {'a': 2, 'b': 2, 'c': true}}
+      - {'bar': {'a': 1, 'b': 2}}
+      - {'bar': {'a': 2, 'b': 2}}
+      - {'bar': {'a': 2, 'b': 4}}
+      - {'bar': {'a': 2, 'b': 4, 'c': 1}}
+
+  - description: "UNION distinct with mixed value order"
+    current_db: "db"
+    query: "SELECT a,b FROM foo UNION SELECT b,a FROM bar"
+    result:
+      - {'': {'a': 1, 'b': 2}}
+      - {'': {'a': 2, 'b': 2}}
+      - {'': {'b': 4, 'a': 2}}
+      - {'': {'b': 2, 'a': 1}}
+      - {'': {'b': 2, 'a': 2}}
+
+  - description: "UNION distinct with mixed star and values select list"
+    current_db: "db"
+    query: "SELECT * FROM foo UNION SELECT a,b from bar"
+    result:
+      - {'foo': {'_id': 1, 'a': 1, 'b': 2}}
+      - {'foo': {'_id': 2, 'a': 1, 'b': 2}}
+      - {'foo': {'_id': 3, 'a': 2, 'b': 2}}
+      - {'foo': {'_id': 4, 'b': 2, 'a': 1}}
+      - {'foo': {'_id': 5, 'a': 2, 'b': 2, 'c': true, 'd': 'a', 'e': null}}
+      - {'foo': {'_id': 6, 'a': 2, 'b': 2, 'c': true, 'd': 'a', 'e': null}}
+      - {'': {'a': 1, 'b': 2}}
+      - {'': {'a': 2, 'b': 2}}
+      - {'': {'a': 2, 'b': 4}}
+
+  - description: "UNION distinct with join"
+    current_db: db
+    query: | 
+      SELECT *
+      FROM 
+        (SELECT a, b FROM foo) AS foo, 
+        (SELECT a, b FROM bar) AS bar
+      UNION 
+      SELECT a, b FROM bar
+    result:
+      - { 'bar': { "a": 1, "b": 2 }, 'foo': { "a": 2, "b": 2 } }
+      - { 'bar': { "a": 2, "b": 2 }, 'foo': { "a": 2, "b": 2 } }
+      - { 'bar': { "a": 1, "b": 2 }, 'foo': { "a": 1, "b": 2 } }
+      - { 'bar': { "a": 2, "b": 4 }, 'foo': { "a": 2, "b": 2 } }
+      - { 'bar': { "a": 2, "b": 2 }, 'foo': { "a": 1, "b": 2 } }
+      - { 'bar': { "a": 2, "b": 4 }, 'foo': { "a": 1, "b": 2 } }
+      - { '': { "a": 1, "b": 2 } }
+      - { '': { "a": 2, "b": 4 } }
+      - { '': { "a": 2, "b": 2 } }

--- a/tests/spec_tests/query_tests/union.yml
+++ b/tests/spec_tests/query_tests/union.yml
@@ -32,25 +32,6 @@ tests:
       - {'foo': {'_id': 2, 'a': 1}}
       - {'bar': {'_id': 0, 'b': 1, 'c': 1}}
 
-  - description: duplicates are still removed when collections with different schema are unioned
-    current_db: mydb
-    query: "SELECT VALUE {'a': a} FROM foo AS foo UNION SELECT VALUE {'b': b, 'c': c} FROM bar AS bar"
-    ordered: false
-    skip_reason: "distinct UNION not currently supported"
-    result:
-      - {'': {'a': 1}}
-      - {'': {'a': 2}}
-      - {'': {'b': 1, 'c': 1}}
-
-  - description: basic union correctness test
-    current_db: mydb
-    query: "SELECT VALUE {'a': a} FROM foo UNION SELECT VALUE {'a': a} FROM foo"
-    ordered: false
-    skip_reason: "distinct UNION not currently supported"
-    result:
-      - {'': {'a': 1}}
-      - {'': {'a': 2}}
-
   - description: basic union all correctness test
     current_db: mydb
     query: "SELECT VALUE {'a': a} FROM foo UNION ALL SELECT VALUE {'a': a} FROM foo"
@@ -61,15 +42,6 @@ tests:
       - {'': {'a': 1}}
       - {'': {'a': 1}}
       - {'': {'a': 2}}
-      - {'': {'a': 2}}
-
-  - description: union is left associative
-    current_db: mydb
-    query: "SELECT VALUE {'a': a} FROM foo UNION ALL SELECT VALUE {'a': a} FROM foo UNION SELECT VALUE {'a': a} FROM foo"
-    ordered: false
-    skip_reason: "distinct UNION not currently supported"
-    result:
-      - {'': {'a': 1}}
       - {'': {'a': 2}}
 
   - description: union works with array datasources


### PR DESCRIPTION
Implementing UNION distinct.  It differs a bit from the initial design, I applied some of the things we did for SELECT DISTINCT such as using the `__groupKey{}` alias.  
Added tests to confirm behavior, removed `skip_reasons` from the existing union distinct tests and moved them into `distinct.yml`