### PR TITLE
SQL-2667: Ensure ordered tests order on all items in the select list

### DIFF
--- a/semantics.md
+++ b/semantics.md
@@ -1831,9 +1831,9 @@ not distinct is implementation-dependent.
 The only addition we make to the ordering behavior described in the SQL
 92 Specification is to clarify an implementation-defined behavior:
 
-- MongoSQL sorts MISSING before NULL, and NULL before all other values
-  (this is consistent with the behavior of MongoSQL's less-than
-  operator)
+- MongoSQL sorts NULL and MISSING (these are considered to be equivalent 
+  values when sorting) before all other values. (this is consistent with 
+  the behavior of MongoSQL's less-than operator)
 
 #### Rewrite: Positional sort keys to references
 

--- a/tests/spec_tests/query_tests/order_by.yml
+++ b/tests/spec_tests/query_tests/order_by.yml
@@ -8,10 +8,6 @@ catalog_data:
       - { '_id': 0, 'a': 3, 'b': { 'c': 1 } }
       - { '_id': 1, 'a': 2, 'b': { 'c': 3 } }
       - { '_id': 2, 'a': 1, 'b': { 'c': 2 } }
-    nullAndMissing:
-      - { '_id': 0, 'a': null }
-      - { '_id': 1 }
-      - { '_id': 2, 'a': null }
     nullAndNonNull:
       - { '_id': 0, 'a': null }
       - { '_id': 1, 'a': 1 }
@@ -74,16 +70,6 @@ catalog_schema:
                 'bsonType': 'int'
               }
             }
-          },
-        }
-      },
-      'nullAndMissing': {
-        'bsonType': "object",
-        'required': [ 'a' ],
-        'additionalProperties': false,
-        'properties': {
-          'a': {
-            'bsonType': !!str "null"
           },
         }
       },
@@ -167,15 +153,6 @@ tests:
       - { '': { 'a': 1, 'b': 'abc' } }
       - { '': { 'a': 1, 'b': 'def' } }
       - { '': { 'a': 2, 'b': 'abc' } }
-
-  - description: missing sorts before null
-    current_db: mydb
-    query: "SELECT * FROM nullAndMissing AS nullAndMissing ORDER BY a ASC, _id ASC"
-    ordered: true
-    result:
-      - { 'nullAndMissing': { '_id': 0, 'a': null } }
-      - { 'nullAndMissing': { '_id': 1 } }
-      - { 'nullAndMissing': { '_id': 2, 'a': null } }
 
   - description: null sorts before non-null values
     current_db: mydb

--- a/tests/spec_tests/query_tests/order_by.yml
+++ b/tests/spec_tests/query_tests/order_by.yml
@@ -171,7 +171,7 @@ tests:
 
   - description: column references in sort keys can be qualified with table name after select star
     current_db: mydb
-    query: "SELECT * FROM bar AS bar ORDER BY bar.a ASC, bar.b ASC, _id ASC"
+    query: "SELECT * FROM bar AS bar ORDER BY bar.a ASC, bar.b ASC, bar._id ASC"
     ordered: true
     result:
       - { 'bar': { '_id': 2, 'a': 1, 'b': { 'c': 2 } } }
@@ -180,7 +180,7 @@ tests:
 
   - description: column references in sort keys can be qualified with table name after select substar
     current_db: mydb
-    query: "SELECT VALUE bar.* FROM bar AS bar ORDER BY bar.a ASC, bar.b ASC, _id ASC"
+    query: "SELECT VALUE bar.* FROM bar AS bar ORDER BY bar.a ASC, bar.b ASC, bar._id ASC"
     ordered: true
     result:
       - { 'bar': { '_id': 2, 'a': 1, 'b': { 'c': 2 } } }
@@ -198,7 +198,7 @@ tests:
 
   - description: column references in sort keys can be compound identifiers referencing document subfields and be qualified with table name
     current_db: mydb
-    query: "SELECT * FROM bar AS bar ORDER BY bar.b.c ASC, bar.a ASC, _id ASC"
+    query: "SELECT * FROM bar AS bar ORDER BY bar.b.c ASC, bar.a ASC, bar._id ASC"
     ordered: true
     result:
       - { 'bar': { '_id': 0, 'a': 3, 'b': { 'c': 1 } } }
@@ -282,7 +282,7 @@ tests:
 
   - description: allowing ordering by column not in Select still supports ordering by computed column
     current_db: mydb
-    query: "SELECT _id, a, b + 42 as c from baz order by b, c"
+    query: "SELECT _id, a, b + 42 as c from baz order by b, c, a, _id"
     result:
       - { "":
             {
@@ -301,7 +301,7 @@ tests:
 
   - description: allow ordering by column not in Select
     current_db: mydb
-    query: "SELECT _id, a from baz order by b"
+    query: "SELECT _id, a from baz order by b, a, _id"
     result:
       - { "":
             {
@@ -318,7 +318,7 @@ tests:
 
   - description: ordering by column in select list that shadows column from data sources still works
     current_db: mydb
-    query: "SELECT _id, a from baz order by a"
+    query: "SELECT _id, a from baz order by a, _id"
     result:
       - { "":
             {
@@ -340,7 +340,7 @@ tests:
 
   - description: ordering by column not in Select in join works when qualified
     current_db: mydb
-    query: "SELECT b._id, a.a, b.b + 42 as c from baz a join baz b order by a.b, c"
+    query: "SELECT b._id, a.a, b.b + 42 as c from baz a join baz b order by a.b, c, b._id, a.a"
     result:
       - { "":
             {
@@ -373,7 +373,7 @@ tests:
 
   - description: allow ordering by column not in Select even with group by
     current_db: mydb
-    query: "SELECT a, b + 42 as c from baz group by a, b order by b, c"
+    query: "SELECT a, b + 42 as c from baz group by a, b order by b, c, a"
     result:
       - { "":
             { "a": { "$numberInt": "2" }, "c": { "$numberInt": "43" } }
@@ -417,7 +417,7 @@ tests:
 
   - description: ensure ORDER BY does not introduce extraneous columns
     current_db: mydb
-    query: "SELECT COUNT(s) AS alias1, s AS alias2 FROM car GROUP BY s ORDER BY alias2"
+    query: "SELECT COUNT(s) AS alias1, s AS alias2 FROM car GROUP BY s ORDER BY alias2, alias1"
     result:
       - { '': { 'alias1': 2, 'alias2': 'abc' } }
       - { '': { 'alias1': 1, 'alias2': 'xyz' } }

--- a/tests/spec_tests/query_tests/order_by.yml
+++ b/tests/spec_tests/query_tests/order_by.yml
@@ -170,7 +170,7 @@ tests:
 
   - description: missing sorts before null
     current_db: mydb
-    query: "SELECT * FROM nullAndMissing AS nullAndMissing ORDER BY a ASC"
+    query: "SELECT * FROM nullAndMissing AS nullAndMissing ORDER BY a ASC, _id ASC"
     ordered: true
     result:
       - { 'nullAndMissing': { '_id': 0, 'a': null } }
@@ -194,7 +194,7 @@ tests:
 
   - description: column references in sort keys can be qualified with table name after select star
     current_db: mydb
-    query: "SELECT * FROM bar AS bar ORDER BY bar.a ASC"
+    query: "SELECT * FROM bar AS bar ORDER BY bar.a ASC, bar.b ASC, _id ASC"
     ordered: true
     result:
       - { 'bar': { '_id': 2, 'a': 1, 'b': { 'c': 2 } } }
@@ -203,7 +203,7 @@ tests:
 
   - description: column references in sort keys can be qualified with table name after select substar
     current_db: mydb
-    query: "SELECT VALUE bar.* FROM bar AS bar ORDER BY bar.a ASC"
+    query: "SELECT VALUE bar.* FROM bar AS bar ORDER BY bar.a ASC, bar.b ASC, _id ASC"
     ordered: true
     result:
       - { 'bar': { '_id': 2, 'a': 1, 'b': { 'c': 2 } } }
@@ -221,7 +221,7 @@ tests:
 
   - description: column references in sort keys can be compound identifiers referencing document subfields and be qualified with table name
     current_db: mydb
-    query: "SELECT * FROM bar AS bar ORDER BY bar.b.c ASC"
+    query: "SELECT * FROM bar AS bar ORDER BY bar.b.c ASC, bar.a ASC, _id ASC"
     ordered: true
     result:
       - { 'bar': { '_id': 0, 'a': 3, 'b': { 'c': 1 } } }
@@ -239,7 +239,7 @@ tests:
 
   - description: qualified order by fields in ORDER BY select the proper data source where there are multiple datasources in scope
     current_db: mydb
-    query: "SELECT * FROM bar AS a JOIN bar AS b ORDER BY a.a ASC"
+    query: "SELECT * FROM bar AS a JOIN bar AS b ORDER BY a.a ASC, a ASC, b ASC"
     ordered: true
     skip_reason: "SQL-2405"
     result:
@@ -424,7 +424,7 @@ tests:
 
   - description: Sorting by column from RHS of INNER JOIN orders the entire result set
     current_db: mydb
-    query: "SELECT l._id, f.x FROM local AS l JOIN foreign AS f ON l._id = f.l_id ORDER BY x ASC"
+    query: "SELECT l._id, f.x FROM local AS l JOIN foreign AS f ON l._id = f.l_id ORDER BY x ASC, l._id ASC"
     ordered: true
     result:
       - { '': { _id: 0, x: 0 } }


### PR DESCRIPTION
This PR updates the `ORDER BY` tests to never rely on implicit ordering. Additionally, I removed the `missing sorts before null` test and updated the spec because MongoDB doesn't work this way anymore. 