### PR TITLE
SQL-2688: Disallow order by missing cols for SELECT DISTINCT

### DIFF
--- a/mongosql-cli/src/main.rs
+++ b/mongosql-cli/src/main.rs
@@ -59,8 +59,10 @@ fn main() -> Result<(), CliError> {
     let query = args.query;
     let namespaces = mongosql::get_namespaces(current_db.as_str(), query.as_str())?;
     let catalog = get_schema_catalog(uri.as_str(), current_db.as_str(), namespaces)?;
-    let mut options = mongosql::options::SqlOptions::default();
-    options.allow_order_by_missing_columns = true;
+    let options = mongosql::options::SqlOptions {
+        allow_order_by_missing_columns: true,
+        ..Default::default()
+    };
     let translation =
         mongosql::translate_sql(current_db.as_str(), query.as_str(), &catalog, options)?;
     let print_translation = |pipeline: bson::Bson| -> Result<(), CliError> {

--- a/mongosql-cli/src/main.rs
+++ b/mongosql-cli/src/main.rs
@@ -59,12 +59,10 @@ fn main() -> Result<(), CliError> {
     let query = args.query;
     let namespaces = mongosql::get_namespaces(current_db.as_str(), query.as_str())?;
     let catalog = get_schema_catalog(uri.as_str(), current_db.as_str(), namespaces)?;
-    let translation = mongosql::translate_sql(
-        current_db.as_str(),
-        query.as_str(),
-        &catalog,
-        mongosql::options::SqlOptions::default(),
-    )?;
+    let mut options = mongosql::options::SqlOptions::default();
+    options.allow_order_by_missing_columns = true;
+    let translation =
+        mongosql::translate_sql(current_db.as_str(), query.as_str(), &catalog, options)?;
     let print_translation = |pipeline: bson::Bson| -> Result<(), CliError> {
         let schema = serde_json::to_string_pretty(&translation.result_set_schema)
             .map_err(|e| CliError(e.to_string()))?;

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -349,7 +349,9 @@ impl<'a> Algebrizer<'a> {
         let plan = self.algebrize_where_clause(ast_node.where_clause, plan)?;
         let plan = self.algebrize_group_by_clause(ast_node.group_by_clause, plan)?;
         let plan = self.algebrize_having_clause(ast_node.having_clause, plan)?;
-        let plan = if self.allow_order_by_missing_columns {
+        let plan = if self.allow_order_by_missing_columns
+            && ast_node.select_clause.set_quantifier != ast::SetQuantifier::Distinct
+        {
             self.algebrize_select_and_order_by_clause(
                 ast_node.select_clause,
                 ast_node.order_by_clause,

--- a/tests/spec_tests/query_tests/distinct.yml
+++ b/tests/spec_tests/query_tests/distinct.yml
@@ -161,6 +161,13 @@ tests:
       - { '': { "arr": [3, 2, 1] } }
       - { '': { "arr": [3, 2, 1, 4] } }
 
+  - description: "SELECT DISTINCT with ORDER BY"
+    query: "SELECT DISTINCT a FROM db.foo ORDER BY a ASC"
+    ordered: true
+    result:
+      - { '': { "a": 1 } }
+      - { '': { "a": 2 } }
+
   - description: "basic UNION distinct correctness test"
     current_db: "db"
     query: "SELECT VALUE {'a': a} FROM foo UNION SELECT VALUE {'a': a} FROM foo"


### PR DESCRIPTION
This resolves an issue where schema checking was failing when order by missing columns option is true and the query has `SELECT DISTINCT` and `ORDER BY`. 
It follows the behavior of Postgres that order by expressions must appear in the select list. 
Added a query test to confirm the behavior. 
Also added a fix in the mongosql-cli, for it to set the expected default of `allow_order_by_missing_columns = true`. 