### PR TITLE
Make mongosql-cli pipelines copy-pasteable

### DIFF
--- a/mongosql-cli/src/main.rs
+++ b/mongosql-cli/src/main.rs
@@ -69,15 +69,16 @@ fn main() -> Result<(), CliError> {
         let schema = serde_json::to_string_pretty(&translation.result_set_schema)
             .map_err(|e| CliError(e.to_string()))?;
         println!(
-            "target_db: {},\ntarget_collection: {:?},\nresult set schema:\n{}\npipeline:",
+            "target_db: {},\ntarget_collection: {:?},\nresult set schema:\n{}\npipeline:\n[",
             translation.target_db, translation.target_collection, schema
         );
         let bson::Bson::Array(pipeline) = pipeline else {
             return Err(CliError("pipeline is not an array".to_string()));
         };
         for doc in pipeline {
-            println!("    {}", doc);
+            println!("    {},", doc);
         }
+        println!("]");
         Ok(())
     };
     // If the result flag is not set, we always want to print the translation, regardless of the translation flag.


### PR DESCRIPTION
This PR makes `mongosql-cli` pipelines copy-pasteable. I know the tool already runs the pipelines for us, but if I want to re-run the pipelines or make minor edits and run the pipelines, I have to copy them into an editor and manually add commas between the stages. This update puts the commas in the output for us.

I'm just going to wait on 1 approval for this one since it's so small.