### PR TITLE
SQL-2537: Remove todos

### DIFF
--- a/agg-ast/schema_derivation/src/lib.rs
+++ b/agg-ast/schema_derivation/src/lib.rs
@@ -24,6 +24,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("Cannot derive schema for undefined literals")]
     InvalidLiteralType,
+    #[error("Invalid JsonSchema")]
+    InvalidJsonSchema,
     #[error("Type value for convert invalid: {0}")]
     InvalidConvertTypeValue(String),
     #[error("Cannot derive schema for unsupported group accumulator: {0}")]

--- a/agg-ast/schema_derivation/src/match_schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/match_schema_derivation.rs
@@ -2149,7 +2149,7 @@ impl MatchConstrainSchema for Expression {
                 TaggedOperator::DateDiff(d) => match_derive_date_diff(d, state)?,
                 TaggedOperator::DateSubtract(d) => match_derive_date_subtract(d, state)?,
                 TaggedOperator::DateTrunc(d) => match_derive_date_trunc(d, state)?,
-                _ => todo!(),
+                _ => {}
             },
 
             Expression::UntaggedOperator(u) => match u.op {
@@ -2248,7 +2248,7 @@ impl MatchConstrainSchema for Expression {
                 UntaggedOperatorName::IndexOfCP | UntaggedOperatorName::IndexOfBytes => {
                     match_derive_index_of(u, state)?
                 }
-                _ => todo!(),
+                _ => {}
             },
             _ => {}
         }

--- a/agg-ast/schema_derivation/src/negative_normalize.rs
+++ b/agg-ast/schema_derivation/src/negative_normalize.rs
@@ -267,29 +267,107 @@ impl NegativeNormalize<Expression> for Expression {
                     // these operators will never return nullish values -- instead, they may return empty string,
                     // or array, which are truish. Wrapping with null will ensure if they are negated, the schema
                     // will evaluate to Unsat
-                    | UntaggedOperatorName::Meta | UntaggedOperatorName::MergeObjects | UntaggedOperatorName::Rand | UntaggedOperatorName::Range | UntaggedOperatorName::Substr | UntaggedOperatorName::SubstrBytes | UntaggedOperatorName::SubstrCP | UntaggedOperatorName::ToHashedIndexKey | UntaggedOperatorName::ToLower | UntaggedOperatorName::ToUpper | UntaggedOperatorName::Type => return wrap_in_null_or_missing_check!(self.clone()),
+                    | UntaggedOperatorName::Meta | UntaggedOperatorName::MergeObjects 
+                    | UntaggedOperatorName::Rand | UntaggedOperatorName::Range 
+                    | UntaggedOperatorName::Substr | UntaggedOperatorName::SubstrBytes 
+                    | UntaggedOperatorName::SubstrCP | UntaggedOperatorName::ToHashedIndexKey 
+                    | UntaggedOperatorName::ToLower | UntaggedOperatorName::ToUpper 
+                    | UntaggedOperatorName::Type => return wrap_in_null_or_missing_check!(self.clone()),
                     // The following operators may evaluate to the falsy values null or 0, so the
                     // negation asserts that equality to any of those values.
-                    UntaggedOperatorName::Abs | UntaggedOperatorName::Acos | UntaggedOperatorName::Acosh | UntaggedOperatorName::Asin | UntaggedOperatorName::Asinh | UntaggedOperatorName::Atan | UntaggedOperatorName::Atan2
-                    | UntaggedOperatorName::Atanh | UntaggedOperatorName::Avg | UntaggedOperatorName::Cos | UntaggedOperatorName::Cosh | UntaggedOperatorName::DegreesToRadians | UntaggedOperatorName::Divide
-                    | UntaggedOperatorName::Exp | UntaggedOperatorName::Ln | UntaggedOperatorName::Log | UntaggedOperatorName::Log10 | UntaggedOperatorName::Mod | UntaggedOperatorName::Multiply | UntaggedOperatorName::Pow
-                    | UntaggedOperatorName::RadiansToDegrees | UntaggedOperatorName::Sin | UntaggedOperatorName::Sinh | UntaggedOperatorName::Sqrt | UntaggedOperatorName::Tan | UntaggedOperatorName::Tanh
-                    | UntaggedOperatorName::Trunc | UntaggedOperatorName::Ceil | UntaggedOperatorName::Floor | UntaggedOperatorName::IndexOfArray | UntaggedOperatorName::IndexOfBytes
-                    | UntaggedOperatorName::IndexOfCP | UntaggedOperatorName::ToInt | UntaggedOperatorName::Add | UntaggedOperatorName::Subtract | UntaggedOperatorName::ArrayElemAt
-                    | UntaggedOperatorName::BinarySize | UntaggedOperatorName::BitAnd | UntaggedOperatorName::BitNot | UntaggedOperatorName::BitOr | UntaggedOperatorName::BitXor
-                    | UntaggedOperatorName::BsonSize | UntaggedOperatorName::CovariancePop | UntaggedOperatorName::CovarianceSamp | UntaggedOperatorName::StdDevPop
-                    | UntaggedOperatorName::StdDevSamp | UntaggedOperatorName::Round | UntaggedOperatorName::ToDecimal | UntaggedOperatorName::ToDouble | UntaggedOperatorName::ToLong => {
+                    UntaggedOperatorName::Abs | UntaggedOperatorName::Acos 
+                    | UntaggedOperatorName::Acosh | UntaggedOperatorName::Asin 
+                    | UntaggedOperatorName::Asinh | UntaggedOperatorName::Atan 
+                    | UntaggedOperatorName::Atan2 | UntaggedOperatorName::Atanh 
+                    | UntaggedOperatorName::Avg | UntaggedOperatorName::Count
+                    | UntaggedOperatorName::Cos | UntaggedOperatorName::Cosh 
+                    | UntaggedOperatorName::SQLCos | UntaggedOperatorName::DegreesToRadians 
+                    | UntaggedOperatorName::Divide | UntaggedOperatorName::Exp 
+                    | UntaggedOperatorName::Ln | UntaggedOperatorName::Log 
+                    | UntaggedOperatorName::Log10 | UntaggedOperatorName::Mod 
+                    | UntaggedOperatorName::Multiply | UntaggedOperatorName::Pow 
+                    | UntaggedOperatorName::RadiansToDegrees | UntaggedOperatorName::Sin 
+                    | UntaggedOperatorName::Sinh | UntaggedOperatorName::SQLSin 
+                    | UntaggedOperatorName::Sqrt | UntaggedOperatorName::Tan 
+                    | UntaggedOperatorName::Tanh | UntaggedOperatorName::Trunc 
+                    | UntaggedOperatorName::Ceil | UntaggedOperatorName::Floor 
+                    | UntaggedOperatorName::IndexOfArray | UntaggedOperatorName::IndexOfBytes
+                    | UntaggedOperatorName::IndexOfCP | UntaggedOperatorName::ToInt 
+                    | UntaggedOperatorName::Add | UntaggedOperatorName::Subtract 
+                    | UntaggedOperatorName::ArrayElemAt | UntaggedOperatorName::BinarySize 
+                    | UntaggedOperatorName::SQLBitLength | UntaggedOperatorName::SQLIndexOfCP
+                    | UntaggedOperatorName::SQLStrLenBytes | UntaggedOperatorName::SQLStrLenCP
+                    | UntaggedOperatorName::SQLLog | UntaggedOperatorName::SQLMod
+                    | UntaggedOperatorName::SQLNeg | UntaggedOperatorName::SQLPos 
+                    | UntaggedOperatorName::SQLRound | UntaggedOperatorName::SQLSize
+                    | UntaggedOperatorName::SQLSqrt | UntaggedOperatorName::BitAnd 
+                    | UntaggedOperatorName::BitNot | UntaggedOperatorName::BitOr 
+                    | UntaggedOperatorName::BitXor | UntaggedOperatorName::BsonSize 
+                    | UntaggedOperatorName::CovariancePop | UntaggedOperatorName::CovarianceSamp 
+                    | UntaggedOperatorName::StdDevPop| UntaggedOperatorName::StdDevSamp 
+                    | UntaggedOperatorName::Round | UntaggedOperatorName::ToDecimal 
+                    | UntaggedOperatorName::ToDouble | UntaggedOperatorName::ToLong 
+                    | UntaggedOperatorName::NumberDouble | UntaggedOperatorName::SQLSum 
+                    | UntaggedOperatorName::SQLTan => {
                         let null_check = wrap_in_null_or_missing_check!(self.clone());
                         let zero_check = wrap_in_zero_check!(self.clone());
                         (UntaggedOperatorName::Or, vec![null_check, zero_check])
                     }
+                    // The following operators may evaluate to 0 or false
+                    UntaggedOperatorName::Is | UntaggedOperatorName::Locf => {
+                        let zero_check = wrap_in_zero_check!(self.clone());
+                        let false_check = wrap_in_false_check!(self.clone());
+                        (UntaggedOperatorName::Or, vec![zero_check, false_check])
+                    }
                     // The following operators may evaluate to the falsy values missing, null, 0, or
                     // false, so the negation asserts equality to any of those values.
-                    UntaggedOperatorName::First | UntaggedOperatorName::IfNull | UntaggedOperatorName::Last | UntaggedOperatorName::Literal | UntaggedOperatorName::Max | UntaggedOperatorName::Min => {
+                    UntaggedOperatorName::Coalesce | UntaggedOperatorName::NullIf
+                    | UntaggedOperatorName::First | UntaggedOperatorName::IfNull 
+                    | UntaggedOperatorName::Last | UntaggedOperatorName::Literal 
+                    | UntaggedOperatorName::Max | UntaggedOperatorName::Min => {
                         let null_check = wrap_in_null_or_missing_check!(self.clone());
                         let zero_check = wrap_in_zero_check!(self.clone());
                         let false_check = wrap_in_false_check!(self.clone());
                         (UntaggedOperatorName::Or, vec![null_check, zero_check, false_check])
+                    }
+                    // the following can only evaluate to true or false
+                    | UntaggedOperatorName::MQLBetween => {
+                        let false_check = wrap_in_false_check!(self.clone());
+                        return false_check;
+                    }
+                    // the following can evaluate only to strings or null
+                    | UntaggedOperatorName::SQLSubstrCP | UntaggedOperatorName::SQLToLower
+                    | UntaggedOperatorName::SQLToUpper => {
+                        let null_check = wrap_in_null_or_missing_check!(self.clone());
+                        return null_check;
+                    }
+                    // the following can evalute to null, true, or false
+                    | UntaggedOperatorName::SQLAnd | UntaggedOperatorName::SQLOr
+                    | UntaggedOperatorName::SQLBetween | UntaggedOperatorName::SQLEq
+                    | UntaggedOperatorName::SQLGt | UntaggedOperatorName::SQLGte
+                    | UntaggedOperatorName::SQLIs | UntaggedOperatorName::SQLLt 
+                    | UntaggedOperatorName::SQLLte | UntaggedOperatorName::SQLNe
+                    | UntaggedOperatorName::SQLNot => {
+                        let null_check = wrap_in_null_or_missing_check!(self.clone());
+                        let false_check = wrap_in_false_check!(self.clone());
+                        (UntaggedOperatorName::Or, vec![null_check, false_check])
+                    }
+                    // the following operators can be expensive and evaluate to null, 0, or false,
+                    // so we bind them to a let.
+                    | UntaggedOperatorName::Cond => {
+                        return Expression::TaggedOperator(TaggedOperator::Let(Let {
+                            vars: map!{"expression_to_negate".to_string() => self.clone()},
+                            inside: Box::new(
+                                Expression::UntaggedOperator(UntaggedOperator {
+                                    op: UntaggedOperatorName::Or,
+                                    args: vec![
+                                        wrap_in_null_or_missing_check!(Expression::Ref(Ref::VariableRef("expression_to_negate".to_string()))),
+                                        wrap_in_zero_check!(Expression::Ref(Ref::VariableRef("expression_to_negate".to_string()))),
+                                        wrap_in_false_check!(Expression::Ref(Ref::VariableRef("expression_to_negate".to_string()))),
+                                    ],
+                                })
+                            ),
+                        }));
                     }
                     // the following operators negation depends on the underlying documents -- thus,
                     // for the sake of schema derivation, they function the same way negated as they do normally
@@ -313,8 +391,11 @@ impl NegativeNormalize<Expression> for Expression {
                     ),
                     // the negation of not(X) is X, so we short circuit here and just return X
                     UntaggedOperatorName::Not => return u.args[0].clone(),
-                    // Do this in another ticket
-                    _ => todo!(),
+                    // arrays are always truthy
+                    UntaggedOperatorName::AddToSet | UntaggedOperatorName::Push 
+                    | UntaggedOperatorName::SQLSlice | UntaggedOperatorName::SQLSplit => return Expression::Literal(LiteralValue::Boolean(false)),
+                    // sampleRate is always truthy
+                    UntaggedOperatorName::SampleRate => return Expression::Literal(LiteralValue::Boolean(false)),
                 };
                 Expression::UntaggedOperator(UntaggedOperator { op, args })
             }

--- a/agg-ast/schema_derivation/src/negative_normalize.rs
+++ b/agg-ast/schema_derivation/src/negative_normalize.rs
@@ -411,7 +411,18 @@ impl NegativeNormalize<MatchExpression> for MatchExpression {
                     UntaggedOperatorName::Not => MatchExpression::Expr(MatchExpr {
                         expr: Box::new(untagged_operator.args[0].get_negation()),
                     }),
-                    UntaggedOperatorName::Cond => todo!(),
+                    UntaggedOperatorName::Cond => {
+                        MatchExpression::Expr(MatchExpr {
+                            expr: Box::new(Expression::UntaggedOperator(UntaggedOperator {
+                                op: UntaggedOperatorName::Cond,
+                                args: vec![
+                                    untagged_operator.args[0].get_negative_normal_form(),
+                                    untagged_operator.args[1].get_negative_normal_form(),
+                                    untagged_operator.args[2].get_negative_normal_form(),
+                                ],
+                            })),
+                        })
+                    }
                     _ => self.clone(),
                 },
                 _ => self.clone(),

--- a/agg-ast/schema_derivation/src/negative_normalize.rs
+++ b/agg-ast/schema_derivation/src/negative_normalize.rs
@@ -260,47 +260,47 @@ impl NegativeNormalize<Expression> for Expression {
                     // these operators will never return nullish values -- instead, they may return empty string,
                     // or array, which are truish. Wrapping with null will ensure if they are negated, the schema
                     // will evaluate to Unsat
-                    | UntaggedOperatorName::Meta | UntaggedOperatorName::MergeObjects 
-                    | UntaggedOperatorName::Rand | UntaggedOperatorName::Range 
-                    | UntaggedOperatorName::Substr | UntaggedOperatorName::SubstrBytes 
-                    | UntaggedOperatorName::SubstrCP | UntaggedOperatorName::ToHashedIndexKey 
-                    | UntaggedOperatorName::ToLower | UntaggedOperatorName::ToUpper 
+                    | UntaggedOperatorName::Meta | UntaggedOperatorName::MergeObjects
+                    | UntaggedOperatorName::Rand | UntaggedOperatorName::Range
+                    | UntaggedOperatorName::Substr | UntaggedOperatorName::SubstrBytes
+                    | UntaggedOperatorName::SubstrCP | UntaggedOperatorName::ToHashedIndexKey
+                    | UntaggedOperatorName::ToLower | UntaggedOperatorName::ToUpper
                     | UntaggedOperatorName::Type => return wrap_in_null_or_missing_check!(self.clone()),
                     // The following operators may evaluate to the falsy values null or 0, so the
                     // negation asserts that equality to any of those values.
-                    UntaggedOperatorName::Abs | UntaggedOperatorName::Acos 
-                    | UntaggedOperatorName::Acosh | UntaggedOperatorName::Asin 
-                    | UntaggedOperatorName::Asinh | UntaggedOperatorName::Atan 
-                    | UntaggedOperatorName::Atan2 | UntaggedOperatorName::Atanh 
+                    UntaggedOperatorName::Abs | UntaggedOperatorName::Acos
+                    | UntaggedOperatorName::Acosh | UntaggedOperatorName::Asin
+                    | UntaggedOperatorName::Asinh | UntaggedOperatorName::Atan
+                    | UntaggedOperatorName::Atan2 | UntaggedOperatorName::Atanh
                     | UntaggedOperatorName::Avg | UntaggedOperatorName::Count
-                    | UntaggedOperatorName::Cos | UntaggedOperatorName::Cosh 
-                    | UntaggedOperatorName::SQLCos | UntaggedOperatorName::DegreesToRadians 
-                    | UntaggedOperatorName::Divide | UntaggedOperatorName::Exp 
-                    | UntaggedOperatorName::Ln | UntaggedOperatorName::Log 
-                    | UntaggedOperatorName::Log10 | UntaggedOperatorName::Mod 
-                    | UntaggedOperatorName::Multiply | UntaggedOperatorName::Pow 
-                    | UntaggedOperatorName::RadiansToDegrees | UntaggedOperatorName::Sin 
-                    | UntaggedOperatorName::Sinh | UntaggedOperatorName::SQLSin 
-                    | UntaggedOperatorName::Sqrt | UntaggedOperatorName::Tan 
-                    | UntaggedOperatorName::Tanh | UntaggedOperatorName::Trunc 
-                    | UntaggedOperatorName::Ceil | UntaggedOperatorName::Floor 
+                    | UntaggedOperatorName::Cos | UntaggedOperatorName::Cosh
+                    | UntaggedOperatorName::SQLCos | UntaggedOperatorName::DegreesToRadians
+                    | UntaggedOperatorName::Divide | UntaggedOperatorName::Exp
+                    | UntaggedOperatorName::Ln | UntaggedOperatorName::Log
+                    | UntaggedOperatorName::Log10 | UntaggedOperatorName::Mod
+                    | UntaggedOperatorName::Multiply | UntaggedOperatorName::Pow
+                    | UntaggedOperatorName::RadiansToDegrees | UntaggedOperatorName::Sin
+                    | UntaggedOperatorName::Sinh | UntaggedOperatorName::SQLSin
+                    | UntaggedOperatorName::Sqrt | UntaggedOperatorName::Tan
+                    | UntaggedOperatorName::Tanh | UntaggedOperatorName::Trunc
+                    | UntaggedOperatorName::Ceil | UntaggedOperatorName::Floor
                     | UntaggedOperatorName::IndexOfArray | UntaggedOperatorName::IndexOfBytes
-                    | UntaggedOperatorName::IndexOfCP | UntaggedOperatorName::ToInt 
-                    | UntaggedOperatorName::Add | UntaggedOperatorName::Subtract 
-                    | UntaggedOperatorName::ArrayElemAt | UntaggedOperatorName::BinarySize 
+                    | UntaggedOperatorName::IndexOfCP | UntaggedOperatorName::ToInt
+                    | UntaggedOperatorName::Add | UntaggedOperatorName::Subtract
+                    | UntaggedOperatorName::ArrayElemAt | UntaggedOperatorName::BinarySize
                     | UntaggedOperatorName::SQLBitLength | UntaggedOperatorName::SQLIndexOfCP
                     | UntaggedOperatorName::SQLStrLenBytes | UntaggedOperatorName::SQLStrLenCP
                     | UntaggedOperatorName::SQLLog | UntaggedOperatorName::SQLMod
-                    | UntaggedOperatorName::SQLNeg | UntaggedOperatorName::SQLPos 
+                    | UntaggedOperatorName::SQLNeg | UntaggedOperatorName::SQLPos
                     | UntaggedOperatorName::SQLRound | UntaggedOperatorName::SQLSize
-                    | UntaggedOperatorName::SQLSqrt | UntaggedOperatorName::BitAnd 
-                    | UntaggedOperatorName::BitNot | UntaggedOperatorName::BitOr 
-                    | UntaggedOperatorName::BitXor | UntaggedOperatorName::BsonSize 
-                    | UntaggedOperatorName::CovariancePop | UntaggedOperatorName::CovarianceSamp 
-                    | UntaggedOperatorName::StdDevPop| UntaggedOperatorName::StdDevSamp 
-                    | UntaggedOperatorName::Round | UntaggedOperatorName::ToDecimal 
-                    | UntaggedOperatorName::ToDouble | UntaggedOperatorName::ToLong 
-                    | UntaggedOperatorName::NumberDouble | UntaggedOperatorName::SQLSum 
+                    | UntaggedOperatorName::SQLSqrt | UntaggedOperatorName::BitAnd
+                    | UntaggedOperatorName::BitNot | UntaggedOperatorName::BitOr
+                    | UntaggedOperatorName::BitXor | UntaggedOperatorName::BsonSize
+                    | UntaggedOperatorName::CovariancePop | UntaggedOperatorName::CovarianceSamp
+                    | UntaggedOperatorName::StdDevPop| UntaggedOperatorName::StdDevSamp
+                    | UntaggedOperatorName::Round | UntaggedOperatorName::ToDecimal
+                    | UntaggedOperatorName::ToDouble | UntaggedOperatorName::ToLong
+                    | UntaggedOperatorName::NumberDouble | UntaggedOperatorName::SQLSum
                     | UntaggedOperatorName::SQLTan => {
                         let null_check = wrap_in_null_or_missing_check!(self.clone());
                         let zero_check = wrap_in_zero_check!(self.clone());
@@ -315,8 +315,8 @@ impl NegativeNormalize<Expression> for Expression {
                     // The following operators may evaluate to the falsy values missing, null, 0, or
                     // false, so the negation asserts equality to any of those values.
                     UntaggedOperatorName::Coalesce | UntaggedOperatorName::NullIf
-                    | UntaggedOperatorName::First | UntaggedOperatorName::IfNull 
-                    | UntaggedOperatorName::Last | UntaggedOperatorName::Literal 
+                    | UntaggedOperatorName::First | UntaggedOperatorName::IfNull
+                    | UntaggedOperatorName::Last | UntaggedOperatorName::Literal
                     | UntaggedOperatorName::Max | UntaggedOperatorName::Min => {
                         let null_check = wrap_in_null_or_missing_check!(self.clone());
                         let zero_check = wrap_in_zero_check!(self.clone());
@@ -338,7 +338,7 @@ impl NegativeNormalize<Expression> for Expression {
                     | UntaggedOperatorName::SQLAnd | UntaggedOperatorName::SQLOr
                     | UntaggedOperatorName::SQLBetween | UntaggedOperatorName::SQLEq
                     | UntaggedOperatorName::SQLGt | UntaggedOperatorName::SQLGte
-                    | UntaggedOperatorName::SQLIs | UntaggedOperatorName::SQLLt 
+                    | UntaggedOperatorName::SQLIs | UntaggedOperatorName::SQLLt
                     | UntaggedOperatorName::SQLLte | UntaggedOperatorName::SQLNe
                     | UntaggedOperatorName::SQLNot => {
                         let null_check = wrap_in_null_or_missing_check!(self.clone());
@@ -385,7 +385,7 @@ impl NegativeNormalize<Expression> for Expression {
                     // the negation of not(X) is X, so we short circuit here and just return X
                     UntaggedOperatorName::Not => return u.args[0].clone(),
                     // arrays are always truthy
-                    UntaggedOperatorName::AddToSet | UntaggedOperatorName::Push 
+                    UntaggedOperatorName::AddToSet | UntaggedOperatorName::Push
                     | UntaggedOperatorName::SQLSlice | UntaggedOperatorName::SQLSplit => return Expression::Literal(LiteralValue::Boolean(false)),
                     // sampleRate is always truthy
                     UntaggedOperatorName::SampleRate => return Expression::Literal(LiteralValue::Boolean(false)),
@@ -404,18 +404,16 @@ impl NegativeNormalize<MatchExpression> for MatchExpression {
                     UntaggedOperatorName::Not => MatchExpression::Expr(MatchExpr {
                         expr: Box::new(untagged_operator.args[0].get_negation()),
                     }),
-                    UntaggedOperatorName::Cond => {
-                        MatchExpression::Expr(MatchExpr {
-                            expr: Box::new(Expression::UntaggedOperator(UntaggedOperator {
-                                op: UntaggedOperatorName::Cond,
-                                args: vec![
-                                    untagged_operator.args[0].get_negative_normal_form(),
-                                    untagged_operator.args[1].get_negative_normal_form(),
-                                    untagged_operator.args[2].get_negative_normal_form(),
-                                ],
-                            })),
-                        })
-                    }
+                    UntaggedOperatorName::Cond => MatchExpression::Expr(MatchExpr {
+                        expr: Box::new(Expression::UntaggedOperator(UntaggedOperator {
+                            op: UntaggedOperatorName::Cond,
+                            args: vec![
+                                untagged_operator.args[0].get_negative_normal_form(),
+                                untagged_operator.args[1].get_negative_normal_form(),
+                                untagged_operator.args[2].get_negative_normal_form(),
+                            ],
+                        })),
+                    }),
                     _ => self.clone(),
                 },
                 _ => self.clone(),

--- a/agg-ast/schema_derivation/src/negative_normalize.rs
+++ b/agg-ast/schema_derivation/src/negative_normalize.rs
@@ -325,14 +325,12 @@ impl NegativeNormalize<Expression> for Expression {
                     }
                     // the following can only evaluate to true or false
                     | UntaggedOperatorName::MQLBetween => {
-                        let false_check = wrap_in_false_check!(self.clone());
-                        return false_check;
+                        return wrap_in_false_check!(self.clone());
                     }
                     // the following can evaluate only to strings or null
                     | UntaggedOperatorName::SQLSubstrCP | UntaggedOperatorName::SQLToLower
                     | UntaggedOperatorName::SQLToUpper => {
-                        let null_check = wrap_in_null_or_missing_check!(self.clone());
-                        return null_check;
+                        return wrap_in_null_or_missing_check!(self.clone());
                     }
                     // the following can evalute to null, true, or false
                     | UntaggedOperatorName::SQLAnd | UntaggedOperatorName::SQLOr

--- a/agg-ast/schema_derivation/src/negative_normalize.rs
+++ b/agg-ast/schema_derivation/src/negative_normalize.rs
@@ -222,21 +222,14 @@ impl NegativeNormalize<Expression> for Expression {
                 | TaggedOperator::Top(_)
                 | TaggedOperator::TopN(_)
                 | TaggedOperator::UnsetField(_) => {
-                    // Some of these expressions would be fairly expensive, so we bind them to a
-                    // $let variable to avoid repeating the calculation three times.
-                    Expression::TaggedOperator(TaggedOperator::Let(Let {
-                        vars: map!{"expression_to_negate".to_string() => self.clone()},
-                        inside: Box::new(
-                            Expression::UntaggedOperator(UntaggedOperator {
-                                op: UntaggedOperatorName::Or,
-                                args: vec![
-                                    wrap_in_null_or_missing_check!(Expression::Ref(Ref::VariableRef("expression_to_negate".to_string()))),
-                                    wrap_in_zero_check!(Expression::Ref(Ref::VariableRef("expression_to_negate".to_string()))),
-                                    wrap_in_false_check!(Expression::Ref(Ref::VariableRef("expression_to_negate".to_string()))),
-                                ],
-                            })
-                        ),
-                    }))
+                     Expression::UntaggedOperator(UntaggedOperator {
+                         op: UntaggedOperatorName::Or,
+                         args: vec![
+                             wrap_in_null_or_missing_check!(self.clone()),
+                             wrap_in_zero_check!(self.clone()),
+                             wrap_in_false_check!(self.clone()),
+                         ],
+                     })
                 }
             },
             Expression::UntaggedOperator(u) => {

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -4,10 +4,10 @@ use crate::{
     MatchConstrainSchema, Result,
 };
 use agg_ast::definitions::{
-    Bucket, BucketAuto, ConciseSubqueryLookup, Densify, EqualityLookup, Expression, GraphLookup,
-    Group, LiteralValue, Lookup, LookupFrom, ProjectItem, ProjectStage, Ref, SetWindowFields,
-    Stage, SubqueryLookup, TaggedOperator, UnionWith, Unset, UntaggedOperator,
-    UntaggedOperatorName, Unwind,
+    Bucket, BucketAuto, ConciseSubqueryLookup, Densify, EqualityLookup, Expression, Fill,
+    FillOutput, GraphLookup, Group, LiteralValue, Lookup, LookupFrom, ProjectItem, ProjectStage,
+    Ref, SetWindowFields, Stage, SubqueryLookup, TaggedOperator, UnionWith, Unset,
+    UntaggedOperator, UntaggedOperatorName, Unwind,
 };
 use linked_hash_map::LinkedHashMap;
 use mongosql::{
@@ -170,6 +170,47 @@ impl DeriveSchema for Stage {
                 keys: facet_schema,
                 ..Default::default()
             }))
+        }
+
+        fn fill_derive_schema(fill: &Fill, state: &mut ResultSetState) -> Result<Schema> {
+            for (path, fill_output) in fill.output.iter() {
+                // Every key that appears in the output can no longer be missing, and can only be
+                // null if the fill value is null.
+                let path_vec = path
+                    .split('.')
+                    .map(|s| s.to_string())
+                    .collect::<Vec<String>>();
+                macro_rules! get_path_schema {
+                    () => {{
+                        // Unfortunately, the borrow checker requires us to compute path_schema in
+                        // both branches because we have a mutable borrow on state when
+                        // we compute the fill_schema in the Value case. This macro cleans up some
+                        // duplication.
+                        get_schema_for_path_mut(&mut state.result_set_schema, path_vec)
+                            .ok_or_else(|| Error::UnknownReference(path.clone()))?
+                    }};
+                }
+                match fill_output {
+                    FillOutput::Value(e) => {
+                        let fill_schema = e.derive_schema(state)?;
+                        let path_schema = get_path_schema!();
+                        // Null is possible if the value expression can evaluate to null, but
+                        // missing will always be impossible. We subtract NULL so it can only be
+                        // reintroduced via the union of the fill_schema
+                        *path_schema = std::mem::take(path_schema)
+                            .subtract_nullish()
+                            .union(&fill_schema);
+                    }
+                    // The method does not matter, either of the currently supported methdos will
+                    // remove null and missing from the schema, and cannot change the schema in
+                    // any other meaningful way.
+                    FillOutput::Method(_m) => {
+                        let path_schema = get_path_schema!();
+                        *path_schema = std::mem::take(path_schema).subtract_nullish();
+                    }
+                }
+            }
+            Ok(state.result_set_schema.to_owned())
         }
 
         fn graph_lookup_derive_schema(
@@ -664,12 +705,12 @@ impl DeriveSchema for Stage {
             }
             Stage::Densify(d) => densify_derive_schema(d, state),
             Stage::Documents(d) => documents_derive_schema(d, state),
-            Stage::EquiJoin(_) => todo!(),
+            e @ Stage::EquiJoin(_) => Err(Error::InvalidStage(e.clone())),
             Stage::Facet(f) => facet_derive_schema(f, state),
-            Stage::Fill(_) => todo!(),
+            Stage::Fill(f) => fill_derive_schema(f, state),
             Stage::GraphLookup(g) => graph_lookup_derive_schema(g, state),
             Stage::Group(g) => group_derive_schema(g, state),
-            Stage::Join(_) => todo!(),
+            j @ Stage::Join(_) => Err(Error::InvalidStage(j.clone())),
             Stage::Limit(_) => Ok(state.result_set_schema.to_owned()),
             Stage::Lookup(l) => lookup_derive_schema(l, state),
             Stage::Match(ref m) => m.derive_schema(state),

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -160,8 +160,10 @@ impl DeriveSchema for Stage {
                 .into_iter()
                 .map(|(field, pipeline)| {
                     let mut field_state = state.clone();
-                    let field_schema =
-                        derive_schema_for_pipeline(pipeline.clone(), &mut field_state)?;
+                    let field_schema = Schema::Array(Box::new(derive_schema_for_pipeline(
+                        pipeline.clone(),
+                        &mut field_state,
+                    )?));
                     Ok((field.clone(), field_schema))
                 })
                 .collect::<Result<BTreeMap<String, Schema>>>()?;

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/match_stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/match_stage.rs
@@ -112,6 +112,22 @@ test_derive_schema_for_match_stage! {
 }
 
 test_derive_schema_for_match_stage! {
+    derivation_for_json_schema,
+    expected = Ok(Schema::Document(Document {
+        keys: map! {
+            "foo".to_string() => Schema::Atomic(Atomic::Null),
+        },
+        required: set!{"foo".to_string()},
+        ..Default::default()
+    })),
+    input = r#"{"$match": {"$jsonSchema": {"bsonType": "object", "required": ["foo"], "properties": {"foo": {"bsonType": "null"}}, "required": ["foo"]}}}"#,
+    ref_schema = Schema::AnyOf(set!{
+        Schema::Atomic(Atomic::Null),
+        Schema::Missing,
+    })
+}
+
+test_derive_schema_for_match_stage! {
     derivation_for_two_constraints,
     expected = Ok(Schema::Document(Document {
         keys: map! {

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -440,7 +440,7 @@ mod facet {
     test_derive_stage_schema!(
         empty,
         expected = Ok(Schema::Document(Document::default())),
-        input = r#"stage: {"$facet": {}}"#
+        input = r#"{"$facet": {}}"#
     );
 
     test_derive_stage_schema!(
@@ -450,7 +450,10 @@ mod facet {
                 "outputField1".to_string() => Schema::Array(Box::new(
                     Schema::Document(Document {
                         keys: map! {
-                            "x".to_string() => Schema::Atomic(Atomic::Integer)
+                            "x".to_string() => Schema::AnyOf(set!{
+                                Schema::Atomic(Atomic::Integer),
+                                Schema::Atomic(Atomic::Long)
+                            })
                         },
                         required: set!("x".to_string()),
                         ..Default::default()
@@ -479,19 +482,22 @@ mod facet {
                 "outputField2".to_string() => Schema::Array(Box::new(
                     Schema::Document(Document {
                         keys: map! {
-                            "x".to_string() => Schema::Atomic(Atomic::Integer)
+                            "x".to_string() => Schema::AnyOf(set!{
+                                Schema::Atomic(Atomic::Integer),
+                                Schema::Atomic(Atomic::Long)
+                            })
                         },
-                        required: set!(),
+                        required: set!("x".to_string()),
                         ..Default::default()
                     })
                 ))
             },
-            required: set!("outputField1".to_string()),
+            required: set!("o1".to_string(), "outputField2".to_string()),
             ..Default::default()
         })),
         input = r#"{"$facet": {
             "o1": [{"$limit": 10}, {"$project": {"_id": 0}}],
-            "outputField2": [{"$count": "x"}],
+            "outputField2": [{"$count": "x"}]
         }}"#,
         starting_schema = Schema::Document(Document {
             keys: map! {

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -435,74 +435,100 @@ mod documents {
 }
 
 mod facet {
-    // SQL-2369: implement schema derivation for bucketing stages
-    //     use super::*;
+    use super::*;
 
-    //     test_derive_stage_schema!(
-    //         empty,
-    //         expected = Ok(Schema::Document(Document::default())),
-    //         input = r#"stage: {"$facet": {}}"#
-    //     );
+    test_derive_stage_schema!(
+        empty,
+        expected = Ok(Schema::Document(Document::default())),
+        input = r#"stage: {"$facet": {}}"#
+    );
 
-    //     test_derive_stage_schema!(
-    //         single,
-    //         expected = Ok(Schema::Document(Document {
-    //             keys: map! {
-    //                 "outputField1".to_string() => Schema::Array(Box::new(
-    //                     Schema::Document(Document {
-    //                         keys: map! {
-    //                             "x".to_string() => Schema::Atomic(Atomic::Integer)
-    //                         },
-    //                         required: set!("x".to_string()),
-    //                         ..Default::default()
-    //                     })
-    //                 ))
-    //             },
-    //             required: set!("outputField1".to_string()),
-    //             ..Default::default()
-    //         })),
-    //         input = r#"{"$facet": { "outputField1": [{"$count": "x"}] }}"#
-    //     );
+    test_derive_stage_schema!(
+        single,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "outputField1".to_string() => Schema::Array(Box::new(
+                    Schema::Document(Document {
+                        keys: map! {
+                            "x".to_string() => Schema::Atomic(Atomic::Integer)
+                        },
+                        required: set!("x".to_string()),
+                        ..Default::default()
+                    })
+                ))
+            },
+            required: set!("outputField1".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$facet": { "outputField1": [{"$count": "x"}] }}"#
+    );
 
-    //     test_derive_stage_schema!(
-    //         multiple,
-    //         expected = Ok(Schema::Document(Document {
-    //             keys: map! {
-    //                 "o1".to_string() => Schema::Array(Box::new(
-    //                     Schema::Document(Document {
-    //                         keys: map! {
-    //                             "x".to_string() => Schema::Atomic(Atomic::String),
-    //                         },
-    //                         required: set!(),
-    //                         ..Default::default()
-    //                     })
-    //                 )),
-    //                 "outputField2".to_string() => Schema::Array(Box::new(
-    //                     Schema::Document(Document {
-    //                         keys: map! {
-    //                             "x".to_string() => Schema::Atomic(Atomic::Integer)
-    //                         },
-    //                         required: set!(),
-    //                         ..Default::default()
-    //                     })
-    //                 ))
-    //             },
-    //             required: set!("outputField1".to_string()),
-    //             ..Default::default()
-    //         })),
-    //         input = r#"{"$facet": {
-    //             "o1": [{"$limit": 10}, {"$project": {"_id": 0}}],
-    //             "outputField2": [{"$count": "x"}],
-    //         }}"#,
-    //         starting_schema = Schema::Document(Document {
-    //             keys: map! {
-    //                 "x".to_string() => Schema::Atomic(Atomic::String),
-    //                 "_id".to_string() => Schema::Atomic(Atomic::ObjectId)
-    //             },
-    //             required: set!("_id".to_string()),
-    //             ..Default::default()
-    //         })
-    //     );
+    test_derive_stage_schema!(
+        multiple,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "o1".to_string() => Schema::Array(Box::new(
+                    Schema::Document(Document {
+                        keys: map! {
+                            "x".to_string() => Schema::Atomic(Atomic::String),
+                        },
+                        required: set!(),
+                        ..Default::default()
+                    })
+                )),
+                "outputField2".to_string() => Schema::Array(Box::new(
+                    Schema::Document(Document {
+                        keys: map! {
+                            "x".to_string() => Schema::Atomic(Atomic::Integer)
+                        },
+                        required: set!(),
+                        ..Default::default()
+                    })
+                ))
+            },
+            required: set!("outputField1".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$facet": {
+            "o1": [{"$limit": 10}, {"$project": {"_id": 0}}],
+            "outputField2": [{"$count": "x"}],
+        }}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "x".to_string() => Schema::Atomic(Atomic::String),
+                "_id".to_string() => Schema::Atomic(Atomic::ObjectId)
+            },
+            required: set!("_id".to_string()),
+            ..Default::default()
+        })
+    );
+}
+
+mod fill {
+    use super::*;
+
+    test_derive_stage_schema!(
+        fill,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::AnyOf(set!{Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::Long)}),
+                "bar".to_string() => Schema::Atomic(Atomic::String),
+                "baz".to_string() => Schema::AnyOf(set!{Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::Null)}),
+            },
+            required: set!("foo".to_string(), "bar".to_string(), "baz".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$fill": {"output": {"foo": {"value": {"$add": [3, 4]}}, "bar": {"method": "linear"}, "baz": {"value": null}}}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::AnyOf(set!{Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::Null)}),
+                "bar".to_string() => Schema::Atomic(Atomic::String),
+                "baz".to_string() => Schema::AnyOf(set!{Schema::Atomic(Atomic::Integer), Schema::Atomic(Atomic::Null)}),
+            },
+            required: set!(),
+            ..Default::default()
+        })
+    );
 }
 
 mod group {

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -1429,6 +1429,92 @@ mod replace {
     );
 }
 
+mod search {
+    use super::*;
+
+    test_derive_stage_schema!(
+        search,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String),
+                "bar".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string(), "bar".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$search": {
+            "near": {
+                "path": "released",
+                "origin": "2011-09-01T00:00:00.000+00:00",
+                "pivot": 7776000000
+            }
+        }}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String),
+                "bar".to_string() => Schema::Atomic(Atomic::String),
+            },
+            required: set!("foo".to_string(), "bar".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_stage_schema!(
+        vector_search,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String),
+                "bar".to_string() => Schema::Atomic(Atomic::String)
+            },
+            required: set!("foo".to_string(), "bar".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$vectorSearch": {
+                "exact": true,
+                "filter": {},
+                "index": "x",
+                "limit": 23,
+                "numCandidates": 42,
+                "path": "baz",
+                "queryVector": [1,2,3,41]
+            }
+        }"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String),
+                "bar".to_string() => Schema::Atomic(Atomic::String),
+            },
+            required: set!("foo".to_string(), "bar".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_stage_schema!(
+        search_meta,
+        expected = Ok(crate::schema_derivation::SEARCH_META.clone()),
+        input = r#"{
+            "$searchMeta": {
+                "range": {
+                    "path": "year",
+                    "gte": 1998,
+                    "lt": 1999
+                },
+                "count": {
+                    "type": "total"
+                }
+            }
+        }"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Atomic(Atomic::String),
+                "bar".to_string() => Schema::Atomic(Atomic::String),
+            },
+            required: set!("foo".to_string(), "bar".to_string()),
+            ..Default::default()
+        })
+    );
+}
+
 mod unset_fields {
     use super::*;
 

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -1629,7 +1629,7 @@ impl Schema {
                             Schema::Unsat => {}
                             intersection => {
                                 doc_intersection.keys.insert(key.clone(), intersection);
-                                if a.required.contains(&key) && b.required.contains(&key) {
+                                if a.required.contains(&key) || b.required.contains(&key) {
                                     doc_intersection.required.insert(key);
                                 }
                             }

--- a/mongosql/src/schema/test.rs
+++ b/mongosql/src/schema/test.rs
@@ -3266,7 +3266,7 @@ mod intersection {
                 "a".to_string() => Schema::Atomic(Atomic::Integer),
                 "b".to_string() => Schema::Atomic(Atomic::String),
             },
-            required: set!["a".into()],
+            required: set!["a".into(), "b".into()],
             additional_properties: false,
             ..Default::default()
         }),
@@ -3310,7 +3310,7 @@ mod intersection {
                 "a".to_string() => Schema::Atomic(Atomic::Integer),
                 "b".to_string() => Schema::Atomic(Atomic::String),
             },
-            required: set!["a".into()],
+            required: set!["a".into(), "b".into()],
             additional_properties: false,
             ..Default::default()
         }),
@@ -3346,7 +3346,7 @@ mod intersection {
                     "a".to_string() => Schema::Atomic(Atomic::Integer),
                     "b".to_string() => Schema::Atomic(Atomic::String),
                 },
-                required: set!["a".into()],
+                required: set!["a".into(), "b".into()],
                 additional_properties: false,
                 ..Default::default()
             }),


### PR DESCRIPTION
Noticed our Document schema intersection was actually wrong in that requiring a key is smaller than not.