### PR TITLE
SQL-2713: Update mongosql-cli to allow missing schema info

### DIFF
--- a/mongosql-cli/src/main.rs
+++ b/mongosql-cli/src/main.rs
@@ -164,23 +164,11 @@ fn get_schema_catalog(
     current_db: &str,
     namespaces: BTreeSet<Namespace>,
 ) -> Result<Catalog, CliError> {
-    let client = Client::with_uri_str(uri)?;
-    let db = client.database(current_db);
-    let collection_names = db.list_collection_names().run()?;
-
-    let sql_schemas_collection_exists =
-        collection_names.contains(&SQL_SCHEMAS_COLLECTION.to_string());
-
-    if !sql_schemas_collection_exists {
-        return Err(CliError(format!("There is no schema information in database `{0}`, so all the collections will be assigned empty schemas. \
-                Therefore, SQL capabilities will be very limited. Hint: Please make sure to generate schemas before using the driver", current_db)));
-    }
-
-    // If there are no namespaces (most importantly for the `SELECT 1` query) or no schema information,
-    // assign an empty schema to `current_db`.
-    if namespaces.is_empty() || !sql_schemas_collection_exists {
+    // If there are no namespaces (e.g. queries with only array datasources), assign
+    // an empty schema to `current_db`
+    if namespaces.is_empty() {
         let schema_catalog_doc = doc! {
-                current_db: doc! {},
+            current_db: doc! {},
         };
 
         return Ok(mongosql::build_catalog_from_catalog_schema(
@@ -191,6 +179,8 @@ fn get_schema_catalog(
     }
 
     // Otherwise, fetch the schema information for the specified collections.
+    let client = Client::with_uri_str(uri)?;
+    let db = client.database(current_db);
     let schema_collection = db.collection::<Document>(SQL_SCHEMAS_COLLECTION);
 
     let collection_names = namespaces
@@ -252,7 +242,7 @@ fn get_schema_catalog(
     }
 
     if schema_catalog_doc_vec.is_empty() {
-        println!("No schema information was found for the requested collections `{:?}` in database `{1}`. Either the collections don't exists \
+        println!("[WARNING] No schema information was found for the requested collections `{:?}` in database `{1}`. Either the collections don't exist \
                     in `{1}` or they don't have a schema. For now, they will be assigned empty schemas. Hint: You either need to generate schemas for your collections \
                     or correct your query.", collection_names, current_db);
 
@@ -281,7 +271,7 @@ fn get_schema_catalog(
             .filter(|collection| !collections_schema_doc.contains_key(collection.as_str()))
             .collect();
 
-        println!("No schema was found for the following collections: {:?}. These collections will be assigned empty schemas.\
+        println!("[WARNING] No schema was found for the following collections: {:?}. These collections will be assigned empty schemas.\
                     Hint: Generate schemas for your collections.", missing_collections);
 
         for collection in missing_collections {

--- a/mongosql-cli/src/main.rs
+++ b/mongosql-cli/src/main.rs
@@ -271,7 +271,7 @@ fn get_schema_catalog(
             .filter(|collection| !collections_schema_doc.contains_key(collection.as_str()))
             .collect();
 
-        println!("[WARNING] No schema was found for the following collections: {:?}. These collections will be assigned empty schemas.\
+        println!("[WARNING] No schema was found for the following collections: {:?}. These collections will be assigned empty schemas. \
                     Hint: Generate schemas for your collections.", missing_collections);
 
         for collection in missing_collections {


### PR DESCRIPTION
This PR updates the `mongosql-cli` to tolerate missing schema information. This allows more (valid) queries to be issued to `mongosql-cli`. Also, since we run in `Relaxed` schema checking mode by default, this enables a lot of flexibility with this tool, which I personally find to be a plus.

Examples (previously, these all errored with `Error: CliError("There is no schema information in database `test`, so all the collections will be assigned empty schemas. Therefore, SQL capabilities will be very limited. Hint: Please make sure to generate schemas before using the driver")`)
```
# query with only array datasources
$ cargo run --bin mongosql-cli "select * from [{'a': 1}] arr"     
target_db: test,
target_collection: None,
result set schema:
{
  "bsonType": "object",
  "properties": {
    "arr": {
      "bsonType": "object",
      "properties": {
        "a": {
          "bsonType": "int"
        }
      },
      "required": [
        "a"
      ],
      "additionalProperties": false
    }
  },
  "required": [
    "arr"
  ],
  "additionalProperties": false
}
pipeline:
[
    { "$documents": [{ "a": { "$literal": 1 } }] },
    { "$project": { "arr": "$$ROOT", "_id": 0 } },
]

# select * query with collection with no schema set
$ cargo run --bin mongosql-cli "select * from foo"                
[WARNING] No schema information was found for the requested collections `["foo"]` in database `test`. Either the collections don't exist in `test` or they don't have a schema. For now, they will be assigned empty schemas. Hint: You either need to generate schemas for your collections or correct your query.
target_db: test,
target_collection: Some("foo"),
result set schema:
{
  "bsonType": "object",
  "properties": {
    "foo": {}
  },
  "additionalProperties": false
}
pipeline:
[
    { "$project": { "foo": "$$ROOT", "_id": 0 } },
]

# query with multiple namespaces where one has schema set (foo) and one does not (bar)
$ cargo run --bin mongosql-cli "select * from foo, bar" -d tuple  
[WARNING] No schema was found for the following collections: ["bar"]. These collections will be assigned empty schemas. Hint: Generate schemas for your collections.
target_db: tuple,
target_collection: Some("foo"),
result set schema:
{
  "bsonType": "object",
  "properties": {
    "bar": {},
    "foo": {
      "bsonType": "object",
      "properties": {
        "_id": {
          "bsonType": "int"
        },
        "a": {
          "bsonType": "int"
        }
      },
      "required": [
        "_id",
        "a"
      ],
      "additionalProperties": false
    }
  },
  "required": [
    "foo"
  ],
  "additionalProperties": false
}
pipeline:
[
    { "$project": { "foo": "$$ROOT", "_id": 0 } },
    { "$lookup": { "from": "bar", "pipeline": [{ "$project": { "bar": "$$ROOT", "_id": 0 } }], "as": "eca58228-b657-498a-b76e-f48a9161a404" } },
    { "$unwind": { "path": "$eca58228-b657-498a-b76e-f48a9161a404" } },
    { "$replaceWith": { "$mergeObjects": ["$$ROOT", "$eca58228-b657-498a-b76e-f48a9161a404"] } },
    { "$project": { "_id": 0, "eca58228-b657-498a-b76e-f48a9161a404": 0 } },
]
```

Remember, the goal of this ticket is to enable translation for more valid queries. Yes, some of these are technically useless in a production setting since there is no schema information, but that's what the warning is for. It's more useful for us to be able to actually see translations than to just see an error.