### PR TITLE
SQL-2725: handle missing variable refs appropriately

### DIFF
--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -923,6 +923,10 @@ impl DeriveSchema for Expression {
                                     )
                                     .unwrap()
                                     .clone())
+                                // if the top level key is present but the full path is not, agg
+                                // treats it as an empty document
+                                } else if state.variables.contains_key(&path[0]) {
+                                    Ok(Schema::Document(Document::empty()))
                                 } else {
                                     Err(Error::UnknownReference(v.into()))
                                 }

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -1,7 +1,7 @@
 use crate::{
-    get_schema_for_path_mut, insert_required_key_into_document, promote_missing, remove_field,
-    schema_difference, schema_for_bson, schema_for_type_numeric, schema_for_type_str, Error,
-    MatchConstrainSchema, Result,
+    array_element_schema_or_error, get_schema_for_path_mut, insert_required_key_into_document,
+    promote_missing, remove_field, schema_difference, schema_for_bson, schema_for_type_numeric,
+    schema_for_type_str, Error, MatchConstrainSchema, Result,
 };
 use agg_ast::definitions::{
     AtlasSearchStage, Bucket, BucketAuto, ConciseSubqueryLookup, Densify, Documents,
@@ -1025,37 +1025,6 @@ impl DeriveSchema for TaggedOperator {
                     .map_or(&Expression::Literal(LiteralValue::Boolean(true)), |x| {
                         x.as_ref()
                     })
-            }};
-        }
-        macro_rules! array_element_schema_or_error {
-            ($input_schema:expr,$input:expr) => {{
-                match $input_schema {
-                    Schema::Array(a) => *a,
-                    Schema::AnyOf(ao) => {
-                        let mut array_type = None;
-                        for schema in ao.iter() {
-                            if let Schema::Array(a) = schema {
-                                array_type = Some(*a.clone());
-                                break;
-                            }
-                        }
-                        match array_type {
-                            Some(t) => t,
-                            None => {
-                                return Err(Error::InvalidExpressionForField(
-                                    format!("{:?}", $input),
-                                    "input",
-                                ))
-                            }
-                        }
-                    }
-                    _ => {
-                        return Err(Error::InvalidExpressionForField(
-                            format!("{:?}", $input),
-                            "input",
-                        ))
-                    }
-                }
             }};
         }
         match self {

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/expression.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/expression.rs
@@ -244,6 +244,18 @@ mod variable_ref {
     );
 
     test_derive_expression_schema!(
+        ref_nested_top_level_present,
+        expected = Ok(Schema::Document(Document::empty())),
+        input = r#""$$foo.bar""#,
+        ref_schema = Schema::Any,
+        variables = map! {
+            // foo can be anything -- if the top level key is present in the
+            // var map, and the nested path is not, we will get an exmpty document.
+            "foo".to_string() => Schema::Atomic(Atomic::Integer)
+        }
+    );
+
+    test_derive_expression_schema!(
         ref_missing,
         expected = Err(Error::UnknownReference("foo".to_string())),
         input = r#""$$foo""#,

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/match_expr.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/match_expr.rs
@@ -3829,6 +3829,18 @@ mod array_ops {
         ref_schema = NULLISH.clone()
     );
     test_derive_schema_for_match_stage!(
+        reduce_references_this_and_value,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "foo".to_string() => Schema::Array(Box::new(Schema::Any)),
+            },
+            required: set!("foo".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{"$match": {"$expr": {"$reduce": {"input": "$foo", "initialValue": 1, "in": [{"$eq": ["$$this", "$$value"]}]}}}}"#,
+        ref_schema = Schema::Any
+    );
+    test_derive_schema_for_match_stage!(
         slice_not_null,
         expected = Ok(Schema::Document(Document {
             keys: map! {


### PR DESCRIPTION
the update to $match: $reduce was (sort of) a driveby addressing the same core error message we were getting back from deserializing pipelines. This is the one array op we'll _need_ to handle this for -- for $filter, for example, we just investigate the input, but dont bother scanning the array, so $$this won't come up there!