### PR TITLE
SQL-2732: Allow Distinct queries to return select order

### DIFF
--- a/mongosql/src/lib.rs
+++ b/mongosql/src/lib.rs
@@ -151,13 +151,13 @@ pub fn get_namespaces(current_db: &str, sql: &str) -> Result<BTreeSet<Namespace>
 }
 
 // get_select_order uses pattern matching to parse the select body from the rewritten AST.
-// Only parse if it is a non-distinct SelectQuery, otherwise return none (we won't attempt reordering).
+// Parses both distinct and non-distinct SelectQuery
 pub fn get_select_order(ast: &ast::Query) -> Option<ast::SelectBody> {
     match ast {
         ast::Query::Select(ast::SelectQuery {
             select_clause:
                 ast::SelectClause {
-                    set_quantifier: ast::SetQuantifier::All,
+                    set_quantifier: ast::SetQuantifier::All | ast::SetQuantifier::Distinct,
                     body: b,
                 },
             ..

--- a/mongosql/src/lib.rs
+++ b/mongosql/src/lib.rs
@@ -157,7 +157,7 @@ pub fn get_select_order(ast: &ast::Query) -> Option<ast::SelectBody> {
         ast::Query::Select(ast::SelectQuery {
             select_clause:
                 ast::SelectClause {
-                    set_quantifier: ast::SetQuantifier::All | ast::SetQuantifier::Distinct,
+                    set_quantifier: _,
                     body: b,
                 },
             ..

--- a/mongosql/src/test.rs
+++ b/mongosql/src/test.rs
@@ -331,8 +331,8 @@ mod test_get_select_order {
     );
 
     test_get_select_order!(
-        select_distinct_is_none,
-        expected = None,
+        select_distinct_is_some,
+        expected = Some(ast::SelectBody::Standard(vec![])),
         input = &ast::Query::Select(ast::SelectQuery {
             select_clause: ast::SelectClause {
                 set_quantifier: ast::SetQuantifier::Distinct,


### PR DESCRIPTION
Added SetQuantifier::Distinct to the pattern matching for getting select order. 

This is a fix for the issue where results were not being shown when running a DISTINCT query through DBeaver. 
