### PR TITLE
SQL-2821: Update tpch queries to use extjson syntax

### DIFF
--- a/benchmark/pipeline_generator/config/config.yml
+++ b/benchmark/pipeline_generator/config/config.yml
@@ -449,7 +449,7 @@ workloads:
       FROM
           lineitem
       WHERE
-          l_shipdate <= '1998-9-01T00:00:00.000Z'::TIMESTAMP
+          l_shipdate <= '{"$date": "1998-09-01T00:00:00.000Z"}'
       GROUP BY
           l_returnflag,
           l_linestatus
@@ -529,8 +529,8 @@ workloads:
           customer.c_mktsegment = 'BUILDING'
           and customer.c_custkey = orders.o_custkey
           and l_orderkey = o_orderkey
-          and o_orderdate < '1995-03-15T00:00:00.000Z'::TIMESTAMP
-          and l_shipdate > '1995-03-15T00:00:00.000Z'::TIMESTAMP
+          and o_orderdate < '{"$date": "1995-03-15T00:00:00.000Z"}'
+          and l_shipdate > '{"$date": "1995-03-15T00:00:00.000Z"}'
       GROUP BY
           l_orderkey,
           o_orderdate,
@@ -551,8 +551,8 @@ workloads:
       FROM
           orders
       WHERE
-          o_orderdate >= '1993-07-01T00:00:00.000Z'::TIMESTAMP
-          and o_orderdate < '1993-10-01T00:00:00.000Z'::TIMESTAMP
+          o_orderdate >= '{"$date": "1993-07-01T00:00:00.000Z"}'
+          and o_orderdate < '{"$date": "1993-10-01T00:00:00.000Z"}'
           and exists (
               SELECT
                   *
@@ -586,8 +586,8 @@ workloads:
           and s_nationkey = n_nationkey
           and n_regionkey = r_regionkey
           and r_name = 'AFRICA'
-          and o_orderdate >= '1994-01-01T00:00:00.000Z'::TIMESTAMP
-          and o_orderdate < '1995-01-01T00:00:00.000Z'::TIMESTAMP
+          and o_orderdate >= '{"$date": "1994-01-01T00:00:00.000Z"}'
+          and o_orderdate < '{"$date": "1995-01-01T00:00:00.000Z"}'
       group by
           n_name
       order by
@@ -605,8 +605,8 @@ workloads:
       from
           lineitem
       where
-          l_shipdate >= '1994-01-01T00:00:00.000Z'::TIMESTAMP
-          and l_shipdate < '1995-01-01T00:00:00.000Z'::TIMESTAMP
+          l_shipdate >= '{"$date": "1994-01-01T00:00:00.000Z"}'
+          and l_shipdate < '{"$date": "1995-01-01T00:00:00.000Z"}'
           and l_discount between 0.06 - 0.01 and 0.06 + 0.011 and l_quantity < 24
 
   - name: q7_normalized
@@ -641,8 +641,8 @@ workloads:
               and c_nationkey = n2.n_nationkey
               and ((n1.n_name = 'UNITED STATES' and n2.n_name = 'JAPAN')
               or (n1.n_name = 'JAPAN' and n2.n_name = 'UNITED STATES'))
-              and l_shipdate between '1995-01-01T00:00:00.000Z'::TIMESTAMP
-              and '1996-12-31T00:00:00.000Z'::TIMESTAMP
+              and l_shipdate between '{"$date": "1995-01-01T00:00:00.000Z"}'
+              and '{"$date": "1996-12-31T00:00:00.000Z"}'
       ) as shipping
       GROUP BY
           supp_nation,
@@ -689,8 +689,8 @@ workloads:
               and n1.n_regionkey = r_regionkey
               and r_name = 'EUROPE'
               and s_nationkey = n2.n_nationkey
-              and o_orderdate between '1995-01-01T00:00:00.000Z'::TIMESTAMP
-              and '1996-12-31T00:00:00.000Z'::TIMESTAMP
+              and o_orderdate between '{"$date": "1995-01-01T00:00:00.000Z"}'
+              and '{"$date": "1996-12-31T00:00:00.000Z"}'
               and p_type = 'ECONOMY BRUSHED STEEL'
               ) as all_nations
           GROUP BY
@@ -760,8 +760,8 @@ workloads:
       WHERE
           c_custkey = o_custkey
           AND l_orderkey = o_orderkey
-          AND o_orderdate >= '1993-10-01T00:00:00.000Z'::TIMESTAMP
-          AND o_orderdate < '1994-01-01T00:00:00.000Z'::TIMESTAMP
+          AND o_orderdate >= '{"$date": "1993-10-01T00:00:00.000Z"}'
+          AND o_orderdate < '{"$date": "1994-01-01T00:00:00.000Z"}'
           AND l_returnflag = 'R'
           AND c_nationkey = n_nationkey
       GROUP BY
@@ -841,8 +841,8 @@ workloads:
           AND l_shipmode IN ('MAIL', 'SHIP')
           AND l_commitdate < l_receiptdate
           AND l_shipdate < l_commitdate
-          AND l_receiptdate >= '1994-01-01T00:00:00.000Z'::TIMESTAMP
-          AND l_receiptdate < '1995-01-01T00:00:00.000Z'::TIMESTAMP
+          AND l_receiptdate >= '{"$date": "1994-01-01T00:00:00.000Z"}'
+          AND l_receiptdate < '{"$date": "1995-01-01T00:00:00.000Z"}'
       GROUP BY
           l_shipmode
       ORDER BY
@@ -894,8 +894,8 @@ workloads:
           part
       WHERE
           l_partkey = p_partkey
-          and l_shipdate >= '1995-09-01T00:00:00.000Z'::TIMESTAMP
-          and l_shipdate < '1995-10-01T00:00:00.000Z'::TIMESTAMP
+          and l_shipdate >= '{"$date": "1995-09-01T00:00:00.000Z"}'
+          and l_shipdate < '{"$date": "1995-10-01T00:00:00.000Z"}'
 
   - name: q15_normalized
     db: tpch
@@ -1101,8 +1101,8 @@ workloads:
                         WHERE
                             l_partkey = ps_partkey
                             and l_suppkey = ps_suppkey
-                            and l_shipdate >= '1994-01-01T00:00:00.000Z'::TIMESTAMP
-                            and l_shipdate < '1995-01-01T00:00:00.000Z'::TIMESTAMP
+                            and l_shipdate >= '{"$date": "1994-01-01T00:00:00.000Z"}'
+                            and l_shipdate < '{"$date": "1995-01-01T00:00:00.000Z"}'
                     )
             )
             and s_nationkey = n_nationkey
@@ -1261,7 +1261,7 @@ workloads:
       FROM
           lineitem
       WHERE
-          l_shipdate <= '1998-9-01T00:00:00.000Z'::TIMESTAMP
+          l_shipdate <= '{"$date": "1998-09-01T00:00:00.000Z"}'
       GROUP BY
           l_returnflag,
           l_linestatus
@@ -1340,8 +1340,8 @@ workloads:
           customer.c_mktsegment = 'BUILDING'
           and customer.c_custkey = orders.o_custkey
           and l_orderkey = o_orderkey
-          and o_orderdate < '1995-03-15T00:00:00.000Z'::TIMESTAMP
-          and l_shipdate > '1995-03-15T00:00:00.000Z'::TIMESTAMP
+          and o_orderdate < '{"$date": "1995-03-15T00:00:00.000Z"}'
+          and l_shipdate > '{"$date": "1995-03-15T00:00:00.000Z"}'
       GROUP BY
           l_orderkey,
           o_orderdate,
@@ -1362,8 +1362,8 @@ workloads:
       FROM
           orders
       WHERE
-          o_orderdate >= '1993-07-01T00:00:00.000Z'::TIMESTAMP
-          and o_orderdate < '1993-10-01T00:00:00.000Z'::TIMESTAMP
+          o_orderdate >= '{"$date": "1993-07-01T00:00:00.000Z"}'
+          and o_orderdate < '{"$date": "1993-10-01T00:00:00.000Z"}'
           and exists (
               SELECT
                   *
@@ -1397,8 +1397,8 @@ workloads:
           and s_nationkey = n_nationkey
           and n_regionkey = r_regionkey
           and r_name = 'AFRICA'
-          and o_orderdate >= '1994-01-01T00:00:00.000Z'::TIMESTAMP
-          and o_orderdate < '1995-01-01T00:00:00.000Z'::TIMESTAMP
+          and o_orderdate >= '{"$date": "1994-01-01T00:00:00.000Z"}'
+          and o_orderdate < '{"$date": "1995-01-01T00:00:00.000Z"}'
       group by
           n_name
       order by
@@ -1416,8 +1416,8 @@ workloads:
       from
           lineitem
       where
-          l_shipdate >= '1994-01-01T00:00:00.000Z'::TIMESTAMP
-          and l_shipdate < '1995-01-01T00:00:00.000Z'::TIMESTAMP
+          l_shipdate >= '{"$date": "1994-01-01T00:00:00.000Z"}'
+          and l_shipdate < '{"$date": "1995-01-01T00:00:00.000Z"}'
           and l_discount between 0.06 - 0.01 and 0.06 + 0.011 and l_quantity < 24
 
   - name: q7_normalized_distinct
@@ -1452,8 +1452,8 @@ workloads:
               and c_nationkey = n2.n_nationkey
               and ((n1.n_name = 'UNITED STATES' and n2.n_name = 'JAPAN')
               or (n1.n_name = 'JAPAN' and n2.n_name = 'UNITED STATES'))
-              and l_shipdate between '1995-01-01T00:00:00.000Z'::TIMESTAMP
-              and '1996-12-31T00:00:00.000Z'::TIMESTAMP
+              and l_shipdate between '{"$date": "1995-01-01T00:00:00.000Z"}'
+              and '{"$date": "1996-12-31T00:00:00.000Z"}'
       ) as shipping
       GROUP BY
           supp_nation,
@@ -1500,8 +1500,8 @@ workloads:
               and n1.n_regionkey = r_regionkey
               and r_name = 'EUROPE'
               and s_nationkey = n2.n_nationkey
-              and o_orderdate between '1995-01-01T00:00:00.000Z'::TIMESTAMP
-              and '1996-12-31T00:00:00.000Z'::TIMESTAMP
+              and o_orderdate between '{"$date": "1995-01-01T00:00:00.000Z"}'
+              and '{"$date": "1996-12-31T00:00:00.000Z"}'
               and p_type = 'ECONOMY BRUSHED STEEL'
               ) as all_nations
           GROUP BY
@@ -1570,8 +1570,8 @@ workloads:
       WHERE
           c_custkey = o_custkey
           AND l_orderkey = o_orderkey
-          AND o_orderdate >= '1993-10-01T00:00:00.000Z'::TIMESTAMP
-          AND o_orderdate < '1994-01-01T00:00:00.000Z'::TIMESTAMP
+          AND o_orderdate >= '{"$date": "1993-10-01T00:00:00.000Z"}'
+          AND o_orderdate < '{"$date": "1994-01-01T00:00:00.000Z"}'
           AND l_returnflag = 'R'
           AND c_nationkey = n_nationkey
       GROUP BY
@@ -1651,8 +1651,8 @@ workloads:
           AND l_shipmode IN ('MAIL', 'SHIP')
           AND l_commitdate < l_receiptdate
           AND l_shipdate < l_commitdate
-          AND l_receiptdate >= '1994-01-01T00:00:00.000Z'::TIMESTAMP
-          AND l_receiptdate < '1995-01-01T00:00:00.000Z'::TIMESTAMP
+          AND l_receiptdate >= '{"$date": "1994-01-01T00:00:00.000Z"}'
+          AND l_receiptdate < '{"$date": "1995-01-01T00:00:00.000Z"}'
       GROUP BY
           l_shipmode
       ORDER BY
@@ -1704,8 +1704,8 @@ workloads:
           part
       WHERE
           l_partkey = p_partkey
-          and l_shipdate >= '1995-09-01T00:00:00.000Z'::TIMESTAMP
-          and l_shipdate < '1995-10-01T00:00:00.000Z'::TIMESTAMP
+          and l_shipdate >= '{"$date": "1995-09-01T00:00:00.000Z"}'
+          and l_shipdate < '{"$date": "1995-10-01T00:00:00.000Z"}'
 
   - name: q15_normalized_distinct
     db: tpch
@@ -1911,8 +1911,8 @@ workloads:
                         WHERE
                             l_partkey = ps_partkey
                             and l_suppkey = ps_suppkey
-                            and l_shipdate >= '1994-01-01T00:00:00.000Z'::TIMESTAMP
-                            and l_shipdate < '1995-01-01T00:00:00.000Z'::TIMESTAMP
+                            and l_shipdate >= '{"$date": "1994-01-01T00:00:00.000Z"}'
+                            and l_shipdate < '{"$date": "1995-01-01T00:00:00.000Z"}'
                     )
             )
             and s_nationkey = n_nationkey
@@ -2074,7 +2074,7 @@ workloads:
               FLATTEN(UNWIND(customer WITH PATH => orders))
           WITH PATH => orders_lineitem))
       WHERE
-          orders_lineitem_l_shipdate <= DATEADD(DAY, -90, '1998-12-01T00:00:00.000Z'::TIMESTAMP)
+          orders_lineitem_l_shipdate <= DATEADD(DAY, -90, '{"$date": "1998-12-01T00:00:00.000Z"}')
       GROUP BY
           l_returnflag, l_linestatus
       ORDER BY

--- a/mongosql/src/mir/optimizer/match_null_filtering/mod.rs
+++ b/mongosql/src/mir/optimizer/match_null_filtering/mod.rs
@@ -184,8 +184,6 @@ impl Visitor for NullableSetter {
         node
     }
 
-    // todo: only set nullable for expressions that don't include a null literal
-
     fn visit_scalar_function_application(
         &mut self,
         node: ScalarFunctionApplication,


### PR DESCRIPTION
This PR updates the tpch queries to use extjson syntax for date literals. We previously converted date strings to datetimes via `::TIMESTAMP`. However, this was problematic since the implicit `ON ERROR` value for that `CAST` expression is the literal `NULL` value. That prevents any filters that use that `CAST` expressions by being treated as an MQL-semantic operator.

That translation is actually semantically correct but does lead to performance hits in cases like these tpch queries. The best way to work around it is to remove statically nullable non-field ref exprs from the filters. We did this here by using extjson syntax to represent literals instead of non-foldable `CAST` expressions. We will advise the same strategy to customers. I'll make that a "docs changes needed" note on this ticket when I close it.