### PR TITLE
SQL-2752: improve $literal ergonomics

### DIFF
--- a/agg-ast/ast/src/custom_serde.rs
+++ b/agg-ast/ast/src/custom_serde.rs
@@ -1299,7 +1299,7 @@ impl<'de> Deserialize<'de> for Convert {
                         args,
                     }) = to
                     {
-                        match args.get(0) {
+                        match args.first() {
                             // the two type can either be a string (the name of the type) or a numeric (int convertible)
                             Some(Expression::Literal(LiteralValue::String(_)))
                             | Some(Expression::Literal(LiteralValue::Int32(_)))
@@ -1346,7 +1346,7 @@ impl<'de> Deserialize<'de> for SetField {
                         op: UntaggedOperatorName::Literal,
                         args: a,
                     })) => {
-                        if let Some(Expression::Literal(LiteralValue::String(s))) = a.get(0) {
+                        if let Some(Expression::Literal(LiteralValue::String(s))) = a.first() {
                             s.clone()
                         } else {
                             return Err(serde_err::custom("field to setField must be a string"));
@@ -1386,7 +1386,7 @@ impl<'de> Deserialize<'de> for GetField {
                         op: UntaggedOperatorName::Literal,
                         args: a,
                     })) => {
-                        if let Some(Expression::Literal(LiteralValue::String(s))) = a.get(0) {
+                        if let Some(Expression::Literal(LiteralValue::String(s))) = a.first() {
                             s.clone()
                         } else {
                             return Err(serde_err::custom("field to getField must be a string"));
@@ -1425,7 +1425,7 @@ impl<'de> Deserialize<'de> for UnsetField {
                         op: UntaggedOperatorName::Literal,
                         args: a,
                     })) => {
-                        if let Some(Expression::Literal(LiteralValue::String(s))) = a.get(0) {
+                        if let Some(Expression::Literal(LiteralValue::String(s))) = a.first() {
                             s.clone()
                         } else {
                             return Err(serde_err::custom("field to unsetField must be a string"));
@@ -1477,7 +1477,7 @@ impl<'de> Deserialize<'de> for TopBottomN {
                     Some(Expression::UntaggedOperator(UntaggedOperator {
                         op: UntaggedOperatorName::Literal,
                         args: a,
-                    })) => match a.get(0) {
+                    })) => match a.first() {
                         Some(Expression::Literal(LiteralValue::Int32(n))) => *n as i64,
                         Some(Expression::Literal(LiteralValue::Int64(n))) => *n,
                         Some(Expression::Literal(LiteralValue::Double(n))) => *n as i64,

--- a/agg-ast/ast/src/custom_serde.rs
+++ b/agg-ast/ast/src/custom_serde.rs
@@ -1413,7 +1413,7 @@ impl<'de> Deserialize<'de> for UnsetField {
         match expression {
             Expression::Document(mut d) => {
                 let field = get_field_setter_name(&mut d)
-                    .ok_or(serde_err::custom("field to setField must be a string"))?;
+                    .ok_or(serde_err::custom("field to unsetField must be a string"))?;
                 let input = d.remove("input");
                 if let Some(input) = input {
                     Ok(UnsetField {

--- a/agg-ast/ast/src/custom_serde.rs
+++ b/agg-ast/ast/src/custom_serde.rs
@@ -1340,12 +1340,12 @@ fn get_field_setter_name(document: &mut LinkedHashMap<String, Expression>) -> Op
             args: a,
         })) => {
             if let Some(Expression::Literal(LiteralValue::String(s))) = a.first() {
-                return Some(s.clone());
+                Some(s.clone())
             } else {
-                return None;
+                None
             }
         }
-        _ => return None,
+        _ => None,
     }
 }
 

--- a/agg-ast/ast/src/custom_serde.rs
+++ b/agg-ast/ast/src/custom_serde.rs
@@ -1386,7 +1386,7 @@ impl<'de> Deserialize<'de> for GetField {
         match expression {
             Expression::Document(mut d) => {
                 let field = get_field_setter_name(&mut d)
-                    .ok_or(serde_err::custom("field to setField must be a string"))?;
+                    .ok_or(serde_err::custom("field to getField must be a string"))?;
                 let input = d.remove("input");
                 if let Some(input) = input {
                     Ok(GetField {

--- a/agg-ast/ast/src/custom_serde.rs
+++ b/agg-ast/ast/src/custom_serde.rs
@@ -1300,7 +1300,7 @@ impl<'de> Deserialize<'de> for Convert {
                     }) = to
                     {
                         match args.first() {
-                            // the two type can either be a string (the name of the type) or a numeric (int convertible)
+                            // the to type can either be a string (the name of the type) or a numeric (int convertible)
                             Some(Expression::Literal(LiteralValue::String(_)))
                             | Some(Expression::Literal(LiteralValue::Int32(_)))
                             | Some(Expression::Literal(LiteralValue::Int64(_)))
@@ -1469,7 +1469,7 @@ impl<'de> Deserialize<'de> for TopBottomN {
                             Ok(n) => n,
                             Err(_) => {
                                 return Err(serde_err::custom(
-                                    "invalid decimal literal value for n in bottomN operator",
+                                    "invalid decimal literal value for n in top/bottomN operator",
                                 ));
                             }
                         }
@@ -1486,16 +1486,16 @@ impl<'de> Deserialize<'de> for TopBottomN {
                                 Ok(n) => n,
                                 Err(_) => {
                                     return Err(serde_err::custom(
-                                        "invalid decimal literal value for n in bottomN operator",
+                                        "invalid decimal literal value for n in top/bottomN operator",
                                     ));
                                 }
                             }
                         }
                         _ => {
-                            return Err(serde_err::custom("n to bottomN must be an numeric"));
+                            return Err(serde_err::custom("n to top/bottomN must be an numeric"));
                         }
                     },
-                    _ => return Err(serde_err::custom("n to bottomN must be an numeric")),
+                    _ => return Err(serde_err::custom("n to top/bottomN must be an numeric")),
                 };
                 match (sort_by, output) {
                     (Some(sort_by), Some(output)) => Ok(TopBottomN {
@@ -1504,11 +1504,11 @@ impl<'de> Deserialize<'de> for TopBottomN {
                         n,
                     }),
                     _ => Err(serde_err::custom(
-                        "input and value must be specified for $unsetField",
+                        "sortBy and output must be specified for top/bottomN",
                     )),
                 }
             }
-            _ => Err(serde_err::custom("input to unsetField must be document")),
+            _ => Err(serde_err::custom("input to top/bottomN must be document")),
         }
     }
 }

--- a/agg-ast/ast/src/definitions.rs
+++ b/agg-ast/ast/src/definitions.rs
@@ -1353,20 +1353,20 @@ pub struct Function {
     pub lang: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetField {
     pub field: String,
     pub input: Box<Expression>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SetField {
     pub field: String,
     pub input: Box<Expression>,
     pub value: Box<Expression>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct UnsetField {
     pub field: String,
     pub input: Box<Expression>,

--- a/agg-ast/ast/src/definitions.rs
+++ b/agg-ast/ast/src/definitions.rs
@@ -1219,7 +1219,7 @@ pub enum TaggedOperator {
     #[serde(rename = "$bottom")]
     Bottom(Bottom),
     #[serde(rename = "$bottomN")]
-    BottomN(BottomN),
+    BottomN(TopBottomN),
     #[serde(rename = "$median")]
     Median(Median),
     #[serde(rename = "$percentile")]
@@ -1227,7 +1227,7 @@ pub enum TaggedOperator {
     #[serde(rename = "$top")]
     Top(Top),
     #[serde(rename = "$topN")]
-    TopN(TopN),
+    TopN(TopBottomN),
 
     // Array Operators
     #[serde(rename = "$firstN")]
@@ -1659,17 +1659,9 @@ pub struct Top {
     pub output: Box<Expression>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BottomN {
-    pub sort_by: Box<Expression>,
-    pub output: Box<Expression>,
-    pub n: i64,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TopN {
+pub struct TopBottomN {
     pub sort_by: Box<Expression>,
     pub output: Box<Expression>,
     pub n: i64,

--- a/agg-ast/ast/src/serde_test.rs
+++ b/agg-ast/ast/src/serde_test.rs
@@ -2311,6 +2311,17 @@ mod expression_test {
         );
 
         test_serde_expr!(
+            get_field_literal,
+            expected = Expression::TaggedOperator(TaggedOperator::GetField(GetField {
+                field: "x".to_string(),
+                input: Box::new(Expression::Document(map! {
+                    "x".to_string() => Expression::Literal(LiteralValue::Int32(1))
+                }))
+            })),
+            input = r#"expr: {"$getField": {"field": {"$literal": "x"}, "input": {"x": 1}}}"#
+        );
+
+        test_serde_expr!(
             set_field,
             expected = Expression::TaggedOperator(TaggedOperator::SetField(SetField {
                 field: "x".to_string(),
@@ -2323,6 +2334,18 @@ mod expression_test {
         );
 
         test_serde_expr!(
+            set_field_literal,
+            expected = Expression::TaggedOperator(TaggedOperator::SetField(SetField {
+                field: "x".to_string(),
+                input: Box::new(Expression::Document(map! {
+                    "x".to_string() => Expression::Literal(LiteralValue::Int32(1))
+                })),
+                value: Box::new(Expression::Literal(LiteralValue::String("new".to_string())))
+            })),
+            input = r#"expr: {"$setField": {"field": {"$literal": "x"}, "input": {"x": 1}, "value": "new"}}"#
+        );
+
+        test_serde_expr!(
             unset_field,
             expected = Expression::TaggedOperator(TaggedOperator::UnsetField(UnsetField {
                 field: "x".to_string(),
@@ -2331,6 +2354,17 @@ mod expression_test {
                 }))
             })),
             input = r#"expr: {"$unsetField": {"field": "x", "input": {"x": 1}}}"#
+        );
+
+        test_serde_expr!(
+            unset_field_literal,
+            expected = Expression::TaggedOperator(TaggedOperator::UnsetField(UnsetField {
+                field: "x".to_string(),
+                input: Box::new(Expression::Document(map! {
+                    "x".to_string() => Expression::Literal(LiteralValue::Int32(1))
+                }))
+            })),
+            input = r#"expr: {"$unsetField": {"field": {"$literal": "x"}, "input": {"x": 1}}}"#
         );
 
         test_serde_expr!(

--- a/agg-ast/ast/src/serde_test.rs
+++ b/agg-ast/ast/src/serde_test.rs
@@ -3733,6 +3733,24 @@ mod expression_test {
         );
 
         test_serde_expr!(
+            literal_empty_doc,
+            expected = Expression::UntaggedOperator(UntaggedOperator {
+                op: UntaggedOperatorName::Literal,
+                args: vec![Expression::Document(map!())]
+            }),
+            input = r#"expr: {"$literal": {}}"#
+        );
+
+        test_serde_expr!(
+            literal_empty_array,
+            expected = Expression::UntaggedOperator(UntaggedOperator {
+                op: UntaggedOperatorName::Literal,
+                args: vec![]
+            }),
+            input = r#"expr: {"$literal": []}"#
+        );
+
+        test_serde_expr!(
             empty_document_argument,
             expected = Expression::UntaggedOperator(UntaggedOperator {
                 op: UntaggedOperatorName::Count,

--- a/agg-ast/ast/src/serde_test.rs
+++ b/agg-ast/ast/src/serde_test.rs
@@ -2212,14 +2212,13 @@ mod expression_test {
     mod tagged_operators {
         use crate::{
             definitions::{
-                Accumulator, Bottom, BottomN, Convert, DateAdd, DateDiff, DateExpression,
-                DateFromParts, DateFromString, DateSubtract, DateToParts, DateToString, DateTrunc,
-                Documents, Expression, Filter, Function, GetField, Let, Like, LiteralValue, Map,
-                Median, NArrayOp, Percentile, ProjectItem, ProjectStage, Reduce, Ref,
-                RegexAggExpression, Replace, SetField, SortArray, SortArraySpec, SqlConvert,
-                SqlDivide, Stage, Subquery, SubqueryComparison, SubqueryExists, Switch, SwitchCase,
-                TaggedOperator, Top, TopN, Trim, UnsetField, UntaggedOperator,
-                UntaggedOperatorName, Zip,
+                Accumulator, Bottom, Convert, DateAdd, DateDiff, DateExpression, DateFromParts,
+                DateFromString, DateSubtract, DateToParts, DateToString, DateTrunc, Documents,
+                Expression, Filter, Function, GetField, Let, Like, LiteralValue, Map, Median,
+                NArrayOp, Percentile, ProjectItem, ProjectStage, Reduce, Ref, RegexAggExpression,
+                Replace, SetField, SortArray, SortArraySpec, SqlConvert, SqlDivide, Stage,
+                Subquery, SubqueryComparison, SubqueryExists, Switch, SwitchCase, TaggedOperator,
+                Top, TopBottomN, Trim, UnsetField, UntaggedOperator, UntaggedOperatorName, Zip,
             },
             map,
         };
@@ -2768,7 +2767,7 @@ mod expression_test {
 
         test_serde_expr!(
             bottom_n,
-            expected = Expression::TaggedOperator(TaggedOperator::BottomN(BottomN {
+            expected = Expression::TaggedOperator(TaggedOperator::BottomN(TopBottomN {
                 output: Box::new(Expression::Array(vec![
                     Expression::Ref(Ref::FieldRef("playerId".to_string())),
                     Expression::Ref(Ref::FieldRef("score".to_string()))
@@ -2872,7 +2871,7 @@ mod expression_test {
 
         test_serde_expr!(
             top_n,
-            expected = Expression::TaggedOperator(TaggedOperator::TopN(TopN {
+            expected = Expression::TaggedOperator(TaggedOperator::TopN(TopBottomN {
                 output: Box::new(Expression::Array(vec![
                     Expression::Ref(Ref::FieldRef("playerId".to_string())),
                     Expression::Ref(Ref::FieldRef("score".to_string()))

--- a/agg-ast/ast/src/serde_test.rs
+++ b/agg-ast/ast/src/serde_test.rs
@@ -30,7 +30,6 @@ macro_rules! test_serde_expr {
 
             let input = $input;
             let e: TestExpr = serde_yaml::from_str(&input).unwrap();
-
             assert_eq!($expected, e.expr, "failed to deserialize");
 
             // test roundtrip by serializing to string and then deserializing

--- a/agg-ast/ast/src/serde_test.rs
+++ b/agg-ast/ast/src/serde_test.rs
@@ -2440,6 +2440,21 @@ mod expression_test {
         );
 
         test_serde_expr!(
+            convert_literal_to_type,
+            expected = Expression::TaggedOperator(TaggedOperator::Convert(Convert {
+                input: Box::new(Expression::Literal(LiteralValue::String("1".to_string()))),
+                to: Box::new(Expression::Literal(LiteralValue::String("int".to_string()))),
+                format: None,
+                on_null: None,
+                on_error: None,
+            })),
+            input = r#"expr: {"$convert": {
+                                "input": "1",
+                                "to": {"$literal": "int"}
+            }}"#
+        );
+
+        test_serde_expr!(
             convert_subtype,
             expected = Expression::TaggedOperator(TaggedOperator::Convert(Convert {
                 input: Box::new(Expression::Literal(LiteralValue::Int32(123))),

--- a/agg-ast/schema_derivation/src/match_schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/match_schema_derivation.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use crate::{
     array_element_schema_or_error, get_or_create_schema_for_path_mut, maybe_any_of,
     negative_normalize::{NegativeNormalize, DECIMAL_ZERO},

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use crate::{
     array_element_schema_or_error, get_schema_for_path, get_schema_for_path_mut,
     insert_required_key_into_document, promote_missing, remove_field, schema_difference,

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -12,10 +12,12 @@ use agg_ast::definitions::{
 };
 use linked_hash_map::LinkedHashMap;
 use mongosql::{
-    json_schema, map, schema::{
+    map,
+    schema::{
         Atomic, Document, Satisfaction, Schema, ANY_DOCUMENT, DATE_OR_NULLISH, EMPTY_DOCUMENT,
         INTEGRAL, NULLISH, NULLISH_OR_UNDEFINED, NUMERIC, NUMERIC_OR_NULLISH,
-    }, set
+    },
+    set,
 };
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -12,12 +12,10 @@ use agg_ast::definitions::{
 };
 use linked_hash_map::LinkedHashMap;
 use mongosql::{
-    map,
-    schema::{
+    json_schema, map, schema::{
         Atomic, Document, Satisfaction, Schema, ANY_DOCUMENT, DATE_OR_NULLISH, EMPTY_DOCUMENT,
         INTEGRAL, NULLISH, NULLISH_OR_UNDEFINED, NUMERIC, NUMERIC_OR_NULLISH,
-    },
-    set,
+    }, set
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -178,6 +176,10 @@ impl DeriveSchema for Stage {
                             // field namespace - field schema. We collect in such a way that we can get the error from any derivation.
                             let doc_fields = document
                                 .into_iter()
+                                .filter(|(field, expr)| {
+                                    !(*field == "$literal"
+                                        && *expr == &Expression::Document(map!()))
+                                })
                                 .map(|(field, expr)| {
                                     let field_schema = expr.derive_schema(state)?;
                                     Ok((field.clone(), field_schema))

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/tagged_ops.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/tagged_ops.rs
@@ -1555,6 +1555,13 @@ mod convert {
     );
 
     test_derive_expression_schema!(
+        convert_literal_expression_to_type,
+        expected = Ok(Schema::Atomic(Atomic::BinData)),
+        input = r#"{ "$convert": {"input": "$foo", "to": {"$literal": "binData"} } }"#,
+        ref_schema = Schema::Any
+    );
+
+    test_derive_expression_schema!(
         convert_with_on_null,
         expected = Ok(Schema::AnyOf(set!(
             Schema::Atomic(Atomic::Integer),

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/tagged_ops.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/tagged_ops.rs
@@ -1104,6 +1104,20 @@ mod field_setter_ops {
     );
 
     test_derive_expression_schema!(
+        get_field_literal,
+        expected = Ok(Schema::Atomic(Atomic::String)),
+        input = r#"{ "$getField": { "input": "$foo", "field": {"$literal": "x" } } }"#,
+        ref_schema = Schema::Document(Document {
+            keys: map! {
+                "x".to_string() => Schema::Atomic(Atomic::String),
+                "y".to_string() => Schema::Atomic(Atomic::Integer),
+            },
+            required: set!("x".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_expression_schema!(
         get_field_missing,
         expected = Ok(Schema::Missing),
         input = r#"{ "$getField": { "input": "$foo", "field": "z" } }"#,
@@ -1128,6 +1142,28 @@ mod field_setter_ops {
             ..Default::default()
         })),
         input = r#"{ "$setField": { "input": "$foo", "field": "x", "value": true } }"#,
+        ref_schema = Schema::Document(Document {
+            keys: map! {
+                "x".to_string() => Schema::Atomic(Atomic::String),
+                "y".to_string() => Schema::Atomic(Atomic::Integer),
+            },
+            required: set!("x".to_string(), "y".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_expression_schema!(
+        set_field_literal,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "x".to_string() => Schema::Atomic(Atomic::Boolean),
+                "y".to_string() => Schema::Atomic(Atomic::Integer),
+            },
+            required: set!("x".to_string(), "y".to_string()),
+            ..Default::default()
+        })),
+        input =
+            r#"{ "$setField": { "input": "$foo", "field": {"$literal": "x"}, "value": true } }"#,
         ref_schema = Schema::Document(Document {
             keys: map! {
                 "x".to_string() => Schema::Atomic(Atomic::String),
@@ -1225,6 +1261,26 @@ mod field_setter_ops {
             ..Default::default()
         })),
         input = r#"{ "$unsetField": { "input": "$foo", "field": "x" } }"#,
+        ref_schema = Schema::Document(Document {
+            keys: map! {
+                "x".to_string() => Schema::Atomic(Atomic::String),
+                "y".to_string() => Schema::Atomic(Atomic::Integer),
+            },
+            required: set!("x".to_string(), "y".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_expression_schema!(
+        unset_field_literal,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "y".to_string() => Schema::Atomic(Atomic::Integer),
+            },
+            required: set!("y".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{ "$unsetField": { "input": "$foo", "field": {"$literal": "x" } } }"#,
         ref_schema = Schema::Document(Document {
             keys: map! {
                 "x".to_string() => Schema::Atomic(Atomic::String),

--- a/mongosql/src/mir/definitions.rs
+++ b/mongosql/src/mir/definitions.rs
@@ -143,6 +143,7 @@ pub struct Unwind {
     pub is_prefiltered: bool,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(PartialEq, Debug, Clone)]
 pub enum MqlStage {
     EquiJoin(EquiJoin),

--- a/mongosql/src/mir/optimizer/use_def_analysis/mod.rs
+++ b/mongosql/src/mir/optimizer/use_def_analysis/mod.rs
@@ -541,6 +541,7 @@ impl Stage {
         (visitor.datasource_uses, ret)
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn substitute(self, theta: HashMap<Key, Expression>) -> Result<Self, Self> {
         let mut visitor = SubstituteVisitor {
             theta,

--- a/service/src/service/translate_sql_service.rs
+++ b/service/src/service/translate_sql_service.rs
@@ -301,6 +301,7 @@ impl TranslatorService for TranslateSqlService {
 }
 
 impl TranslateSqlService {
+    #[allow(clippy::result_large_err)]
     fn build_sql_options(&self, req: &TranslateSqlRequest) -> Result<SqlOptions, Status> {
         let exclude_namespaces =
             translator::ExcludeNamespacesOption::try_from(req.exclude_namespaces)

--- a/test-utils/src/build_utils/templates/schema_derivation_test_body_template
+++ b/test-utils/src/build_utils/templates/schema_derivation_test_body_template
@@ -31,7 +31,7 @@ pub fn {name}() {{
     let catalog = &catalog_schema.iter()
         .fold(BTreeMap::new(), |mut acc, (db, coll_map)| {{
             for (coll, coll_schema) in coll_map {{
-                acc.insert(Namespace(db.clone(), coll.clone()), Schema::try_from(coll_schema.to_owned()).map_err(|e| e.to_string()).unwrap());
+                acc.insert(Namespace::new(db.clone(), coll.clone()), Schema::try_from(coll_schema.to_owned()).map_err(|e| e.to_string()).unwrap());
             }}
             acc
     }});

--- a/test-utils/src/index/mod.rs
+++ b/test-utils/src/index/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use super::Error;
 use mongodb::{
     bson::{self, doc, Bson, Document},

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -79,6 +79,7 @@ impl From<mongosql::schema::Error> for Error {
 
 /// load_catalog_data drops any existing catalog data and then inserts the
 /// provided catalog data into the mongodb instance.
+#[allow(clippy::result_large_err)]
 pub fn load_catalog_data(
     client: &Client,
     catalog_data: BTreeMap<String, BTreeMap<String, Vec<Bson>>>,
@@ -102,6 +103,7 @@ pub fn load_catalog_data(
 }
 
 /// drop_catalog_data drops all dbs in the provided list.
+#[allow(clippy::result_large_err)]
 pub fn drop_catalog_data<T: Into<String>>(
     client: &Client,
     catalog_dbs: Vec<T>,

--- a/test-utils/src/query/mod.rs
+++ b/test-utils/src/query/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use mongodb::{
     bson::{doc, Bson, Decimal128, Document},
     sync::Client,

--- a/test-utils/src/schema_derivation/mod.rs
+++ b/test-utils/src/schema_derivation/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use agg_ast::definitions::Stage;
 use mongodb::bson::doc;
 use mongosql::json_schema;
@@ -8,6 +9,7 @@ use super::Error;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum SchemaDerivationYamlTestFile {
     Multiple(SpecQuerySchemaDerivationTestFile),
     Single(SchemaDerivationTest),

--- a/tests/schema_derivation_tests/query_spec_tests/array.yml
+++ b/tests/schema_derivation_tests/query_spec_tests/array.yml
@@ -20,7 +20,7 @@ catalog_schema:
 tests:
   - description: SELECT empty array literal
     current_db: test
-    skip_reason: "cannot reprsent Array(unsat) in JSON schema"
+    skip_reason: "SQL-2837: cannot reprsent Array(unsat) in JSON schema"
     pipeline: [
       {
         "$documents": [

--- a/tests/schema_derivation_tests/query_spec_tests/array.yml
+++ b/tests/schema_derivation_tests/query_spec_tests/array.yml
@@ -20,7 +20,7 @@ catalog_schema:
 tests:
   - description: SELECT empty array literal
     current_db: test
-    skip_reason: SQL-2752 improve $literal ergonomics
+    skip_reason: "cannot reprsent Array(unsat) in JSON schema"
     pipeline: [
       {
         "$documents": [
@@ -71,7 +71,8 @@ tests:
           ], 
           "properties": {
             "_1": {
-              "bsonType": "array"
+              "bsonType": "array",
+              "numItems": 0
             }
           }, 
           "bsonType": "object"

--- a/tests/schema_derivation_tests/query_spec_tests/from_array.yml
+++ b/tests/schema_derivation_tests/query_spec_tests/from_array.yml
@@ -206,7 +206,6 @@ tests:
 
 - description: array datasource with single empty document is allowed
   current_db: test
-  skip_reason: SQL-2752 improve $literal ergonomics
   pipeline: [
     {
       "$documents": [

--- a/tests/schema_derivation_tests/query_spec_tests/identifier.yml
+++ b/tests/schema_derivation_tests/query_spec_tests/identifier.yml
@@ -221,7 +221,6 @@ tests:
 - description: Delimited identifier with a $
   current_db: foo
   current_collection: bar
-  skip_reason: SQL-2752 improve $literal ergonomics
   pipeline: [
     {
       "$project": {
@@ -280,7 +279,6 @@ tests:
 - description: Nested delimited identifiers containing $ and .
   current_db: foo
   current_collection: bar
-  skip_reason: SQL-2752 improve $literal ergonomics
   pipeline: [
     {
       "$project": {
@@ -346,7 +344,6 @@ tests:
 - description: Mixed identifiers containing $ and .
   current_db: foo
   current_collection: bar
-  skip_reason: SQL-2752 improve $literal ergonomics
   pipeline: [
     {
       "$project": {

--- a/tests/schema_derivation_tests/query_spec_tests/literal.yml
+++ b/tests/schema_derivation_tests/query_spec_tests/literal.yml
@@ -332,7 +332,7 @@ tests:
   }
 - description: Signed integer literals
   current_db: test
-  skip_reason: "negative integer literals deserialize as long"
+  skip_reason: "SQL-2838: negative integer literals deserialize as long"
   pipeline: [
     {
       "$documents": [

--- a/tests/schema_derivation_tests/query_spec_tests/literal.yml
+++ b/tests/schema_derivation_tests/query_spec_tests/literal.yml
@@ -332,7 +332,7 @@ tests:
   }
 - description: Signed integer literals
   current_db: test
-  skip_reason: SQL-2752 improve $literal ergonomics
+  skip_reason: "negative integer literals deserialize as long"
   pipeline: [
     {
       "$documents": [

--- a/tests/schema_derivation_tests/query_spec_tests/operators_arithmetic.yml
+++ b/tests/schema_derivation_tests/query_spec_tests/operators_arithmetic.yml
@@ -241,9 +241,6 @@ tests:
                 "bsonType": "null"
               }, 
               {
-                "bsonType": "int"
-              }, 
-              {
                 "bsonType": "long"
               }, 
               {

--- a/tests/schema_derivation_tests/query_spec_tests/operators_precedence.yml
+++ b/tests/schema_derivation_tests/query_spec_tests/operators_precedence.yml
@@ -883,7 +883,7 @@ tests:
   }
 - description: unary ops bind tighter than mul/div
   current_db: db
-  skip_reason: "negative integer literals deserialize as long"
+  skip_reason: "SQL-2838: negative integer literals deserialize as long"
   pipeline: [
     {
       "$documents": [

--- a/tests/schema_derivation_tests/query_spec_tests/operators_precedence.yml
+++ b/tests/schema_derivation_tests/query_spec_tests/operators_precedence.yml
@@ -883,7 +883,7 @@ tests:
   }
 - description: unary ops bind tighter than mul/div
   current_db: db
-  skip_reason: SQL-2752 improve $literal ergonomics
+  skip_reason: "negative integer literals deserialize as long"
   pipeline: [
     {
       "$documents": [


### PR DESCRIPTION
At implementation time, it became clear that there weren't as many operators / stages effected as previously thought, and as such, the easiest way to implement this was to handle during deserialization rather than during derivation / translation. 

If, eg, we expect a string argument, we can get that string by deserializing the expression, and getting the value from either a. the literal value or b. the untagged $literal operator, where the first (and only) argument will be a literal value.