### PR TITLE
SQL-2851: handle $addFields for document fields

### DIFF
--- a/agg-ast/schema_derivation/src/schema_derivation.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation.rs
@@ -362,7 +362,11 @@ impl DeriveSchema for Stage {
                     .collect::<Vec<String>>();
                 // if the field already exists and is a document, and the field we are adding is
                 // also a document, we want the union of their two fields (rather than overwriting
-                // the existing field with the new one).
+                // the existing field with the new one). For example,
+                // db.aggregate([{$documents: [{a: {b: {c: 1}}}]}, {$addFields: {a: {d: 2}}}])
+                // [
+                //   { a: { b: { c: 1 }, d: 2 } }
+                // ]
                 if let Some(field_schema) =
                     get_schema_for_path(state.result_set_schema.clone(), path.clone())
                 {

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -8,6 +8,8 @@ use mongosql::{
 use std::collections::BTreeMap;
 
 mod add_fields {
+    use serde_json::map;
+
     use super::*;
 
     test_derive_stage_schema!(
@@ -97,6 +99,70 @@ mod add_fields {
                 "type".to_string() => Schema::Atomic(Atomic::String),
             },
             required: set!("specs".to_string(), "type".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_stage_schema!(
+        add_fields_document_to_embedded_document_doesnt_overwrite,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "specs".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "doors".to_string() => Schema::Atomic(Atomic::Integer),
+                        "wheels".to_string() => Schema::Atomic(Atomic::Integer),
+                        "fuel_type".to_string() => Schema::Atomic(Atomic::String),
+                        "color".to_string() => Schema::Atomic(Atomic::String),
+                    },
+                    ..Default::default()
+                }),
+                "type".to_string() => Schema::Atomic(Atomic::String),
+            },
+            required: set!("specs".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{ "$addFields": { "specs": {"fuel_type": "string", "color": "gray" }}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "specs".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "doors".to_string() => Schema::Atomic(Atomic::Integer),
+                        "wheels".to_string() => Schema::Atomic(Atomic::Integer)
+                    },
+                    required: set!("doors".to_string(), "wheels".to_string()),
+                    ..Default::default()
+                }),
+                "type".to_string() => Schema::Atomic(Atomic::String),
+            },
+            required: set!("specs".to_string(), "type".to_string()),
+            ..Default::default()
+        })
+    );
+
+    test_derive_stage_schema!(
+        add_fields_document_overwrites_non_embedded_document,
+        expected = Ok(Schema::Document(Document {
+            keys: map! {
+                "a".to_string() => Schema::Document(Document {
+                    keys: map! {
+                        "c".to_string() => Schema::Atomic(Atomic::String),
+                        "d".to_string() => Schema::Atomic(Atomic::String),
+                    },
+                    required: set!("c".to_string(), "d".to_string()),
+                    ..Default::default()
+                }),
+                "b".to_string() => Schema::Atomic(Atomic::String),
+            },
+            required: set!("a".to_string(), "b".to_string()),
+            ..Default::default()
+        })),
+        input = r#"{ "$addFields": { "a": {"c": "string", "d": "gray" }}}"#,
+        starting_schema = Schema::Document(Document {
+            keys: map! {
+                "a".to_string() => Schema::Atomic(Atomic::Integer),
+                "b".to_string() => Schema::Atomic(Atomic::String),
+            },
+            required: set!("a".to_string(), "b".to_string()),
             ..Default::default()
         })
     );

--- a/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
+++ b/agg-ast/schema_derivation/src/schema_derivation_tests/stage.rs
@@ -8,7 +8,6 @@ use mongosql::{
 use std::collections::BTreeMap;
 
 mod add_fields {
-    use serde_json::map;
 
     use super::*;
 


### PR DESCRIPTION
Additional details in the ticket regarding the specific case this covers. Open to any ideas that might improve precision, but this does ensure correctness.

Unioning the documents is not ideal, but something like {$addFields: {a: {b: {c: ...}}}} could be arbitrarily nested and a full traversal to determine overwriting vs inserting rules would involve a potentially complex algorithm. This is correct but imprecise. This pattern also strikes me as potentially unlikely (I would imagine anything achieving this from a users end would more likely be achieved by a $project assignment).

Below is an example of the translated tpch-1 pipeline. I am curious why we have _both_ the addFields followed by the project assignment, which seemingly do the same thing, and maybe this is also a place we can improve translations.

`[
      {
        "$match": {
          "$expr": {
            "$and": [
              {
                "$lte": [
                  "$l_shipdate",
                  ISODate("1998-09-01T00:00:00")
                ]
              },
              {
                "$gt": [
                  "$l_shipdate",
                  {
                    "$literal": null
                  }
                ]
              }
            ]
          }
        }
      },
      {
        "$group": {
          "_id": {
            "__unaliasedKey1": "$l_returnflag",
            "__unaliasedKey2": "$l_linestatus"
          },
          "_agg1": {
            "$sum": "$l_quantity"
          },
          "_agg2": {
            "$sum": "$l_extendedprice"
          },
          "_agg3": {
            "$sum": {
              "$multiply": [
                "$l_extendedprice",
                {
                  "$subtract": [
                    {
                      "$literal": 1
                    },
                    "$l_discount"
                  ]
                }
              ]
            }
          },
          "_agg4": {
            "$sum": {
              "$multiply": [
                "$l_extendedprice",
                {
                  "$subtract": [
                    {
                      "$literal": 1
                    },
                    "$l_discount"
                  ]
                },
                {
                  "$add": [
                    {
                      "$literal": 1
                    },
                    "$l_tax"
                  ]
                }
              ]
            }
          },
          "_agg5": {
            "$avg": "$l_quantity"
          },
          "_agg6": {
            "$avg": "$l_extendedprice"
          },
          "_agg7": {
            "$avg": "$l_discount"
          },
          "_agg8": {
            "$sum": {
              "$literal": 1
            }
          }
        }
      },
      {
        "$project": {
          "lineitem": {
            "l_returnflag": "$_id.__unaliasedKey1",
            "l_linestatus": "$_id.__unaliasedKey2"
          },
          "__bot": {
            "_agg1": "$_agg1",
            "_agg2": "$_agg2",
            "_agg3": "$_agg3",
            "_agg4": "$_agg4",
            "_agg5": "$_agg5",
            "_agg6": "$_agg6",
            "_agg7": "$_agg7",
            "_agg8": "$_agg8"
          }
        }
      },
      {
        "$sort": {
          "lineitem.l_returnflag": 1,
          "lineitem.l_linestatus": 1
        }
      },
      {
        "$project": {
          "__bot": "$__bot",
          "lineitem": "$lineitem"
        }
      },
      {
        "$addFields": {
          "__bot": {
            "l_returnflag": "$lineitem.l_returnflag",
            "l_linestatus": "$lineitem.l_linestatus",
            "sum_qty": "$__bot._agg1",
            "sum_base_price": "$__bot._agg2",
            "sum_disc_price": "$__bot._agg3",
            "sum_charge": "$__bot._agg4",
            "avg_qty": "$__bot._agg5",
            "avg_price": "$__bot._agg6",
            "avg_disc": "$__bot._agg7",
            "count_order": "$__bot._agg8"
          }
        }
      },
      {
        "$project": {
          "__bot": {
            "l_returnflag": "$lineitem.l_returnflag",
            "l_linestatus": "$lineitem.l_linestatus",
            "sum_qty": "$__bot._agg1",
            "sum_base_price": "$__bot._agg2",
            "sum_disc_price": "$__bot._agg3",
            "sum_charge": "$__bot._agg4",
            "avg_qty": "$__bot._agg5",
            "avg_price": "$__bot._agg6",
            "avg_disc": "$__bot._agg7",
            "count_order": "$__bot._agg8"
          },
          "_id": 0
        }
      },
      {
        "$replaceWith": {
          "$unsetField": {
            "field": "__bot",
            "input": {
              "$setField": {
                "field": "",
                "input": "$$ROOT",
                "value": "$__bot"
              }
            }
          }
        }
      }
    ]`