### PR TITLE
SQL-2848: Update common-test-infra references to use mongodb instead of 10gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "test-generator"
 version = "0.1.0"
-source = "git+https://github.com/10gen/sql-engines-common-test-infra.git?branch=main#930a020fe9e542a1ed8a53707c2613fc5dcbf59e"
+source = "git+https://github.com/mongodb/sql-engines-common-test-infra.git?branch=main#3982744ff33b353898d87be664de651c64fc47e8"
 dependencies = [
  "serde",
  "serde_yaml",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ exist in (sub)modules named `fuzz_test`, so this common name is used as a filter
 tests. All integration tests require a running mongod with data loaded into it. Integration tests
 include: e2e, error, index_usage, spec/query, and schema_derivation tests. The tests are specified
 in the `tests` directory, and their data is specified in the `testdata` directory. To load the data,
-use the [sql-engines-common-test-infra](https://github.com/10gen/sql-engines-common-test-infra)
+use the [sql-engines-common-test-infra](https://github.com/mongodb/sql-engines-common-test-infra)
 `data-loader` tool. See `cargo run --bin data-loader -- --help` in that repo for more details.
 
 The [Rust handbook](https://doc.rust-lang.org/cargo/commands/cargo-test.html) has full guidelines

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -11,12 +11,12 @@ bson = { workspace = true }
 mongodb = { workspace = true }
 mongosql = { path = "../mongosql" }
 schema_derivation = { path = "../agg-ast/schema_derivation" }
-sql-engines-common-test-infra = { git = "https://github.com/10gen/sql-engines-common-test-infra.git", branch = "main", package = "test-generator" }
+sql-engines-common-test-infra = { git = "https://github.com/mongodb/sql-engines-common-test-infra.git", branch = "main", package = "test-generator" }
 test-utils = { path = "../test-utils" }
 
 [build-dependencies]
 serde = { workspace = true }
-sql-engines-common-test-infra = { git = "https://github.com/10gen/sql-engines-common-test-infra.git", branch = "main", package = "test-generator" }
+sql-engines-common-test-infra = { git = "https://github.com/mongodb/sql-engines-common-test-infra.git", branch = "main", package = "test-generator" }
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -34,7 +34,7 @@ such as documents, schema, view pipeline, and/or indexes are needed.
 ## Updating sql-engines-common-test-infra
 
 This test generation build script depends on the
-[sql-engines-common-test-infra](https://github.com/10gen/sql-engines-common-test-infra)
+[sql-engines-common-test-infra](https://github.com/mongodb/sql-engines-common-test-infra)
 repository's `test-generator` crate. If you need to use updated features from that
 crate, run `cargo update test-generator` to update the `Cargo.lock` file to use the
 latest commit. Note you likely need to set `CARGO_NET_GIT_FETCH_WITH_CLI=true` for this

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -48,7 +48,6 @@ pre:
   - func: "fetch source"
   - func: "create expansions"
   - func: "prepare resources"
-  - func: "prepare common-test-infra github token usage"
 
 post:
   - func: "stop mongo-orchestration"
@@ -75,21 +74,6 @@ functions:
     - command: expansions.update
       params:
         file: mongosql-rs/expansions.yml
-
-  "prepare common-test-infra github token usage":
-    - command: github.generate_token
-      params:
-        owner: 10gen
-        repo: sql-engines-common-test-infra
-        expansion_name: common_test_infra_github_token
-    - command: subprocess.exec
-      params:
-        working_dir: mongosql-rs
-        binary: bash
-        include_expansions_in_env:
-          - common_test_infra_github_token
-        args:
-          - ./evergreen/setup-common-test-infra-git-config.sh
 
   "check gofmt":
     - command: shell.exec

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -29,7 +29,7 @@ timeout:
 
 modules:
   - name: sql-engines-common-test-infra
-    owner: 10gen
+    owner: mongodb
     repo: sql-engines-common-test-infra
     branch: main
     auto_update: true

--- a/evergreen/setup-common-test-infra-git-config.sh
+++ b/evergreen/setup-common-test-infra-git-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Setting global git config to use token: $common_test_infra_github_token"
-git config --global url."https://x-access-token:$common_test_infra_github_token@github.com/10gen/sql-engines-common-test-infra".insteadOf https://github.com/10gen/sql-engines-common-test-infra
+git config --global url."https://x-access-token:$common_test_infra_github_token@github.com/mongodb/sql-engines-common-test-infra".insteadOf https://github.com/mongodb/sql-engines-common-test-infra
 
 echo "git config:"
 git config --list

--- a/evergreen/setup-common-test-infra-git-config.sh
+++ b/evergreen/setup-common-test-infra-git-config.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo "Setting global git config to use token: $common_test_infra_github_token"
-git config --global url."https://x-access-token:$common_test_infra_github_token@github.com/mongodb/sql-engines-common-test-infra".insteadOf https://github.com/mongodb/sql-engines-common-test-infra
-
-echo "git config:"
-git config --list

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,7 +13,7 @@ mongosql = { path = "../mongosql" }
 serde = { workspace = true, features = ["derive"] }
 serde_stacker = { workspace = true }
 serde_yaml = { workspace = true }
-sql-engines-common-test-infra = { git = "https://github.com/10gen/sql-engines-common-test-infra.git", branch = "main", package = "test-generator" }
+sql-engines-common-test-infra = { git = "https://github.com/mongodb/sql-engines-common-test-infra.git", branch = "main", package = "test-generator" }
 thiserror = { workspace = true }
 
 [dependencies.mongodb]


### PR DESCRIPTION
This PR updates the references to `sql-engines-common-test-infra` to use the `mongodb` org instead of the `10gen` org since the repo has now been migrated.