### PR TITLE
SQL-2970: Use common install heaptrack function

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -39,6 +39,8 @@ include:
   # - filename: evergreen/grpc.yml
   - filename: evergreen/mongosqltranslate.yml
   - filename: evergreen/suite-tasks.yml
+  - filename: evergreen/configs/benchmark_util.yml
+    module: sql-engines-common-test-infra
   - filename: evergreen/configs/rust_util.yml
     module: sql-engines-common-test-infra
   - filename: evergreen/configs/mongodb_util.yml
@@ -437,24 +439,6 @@ functions:
           ${prepare_shell}
           benchmark/scripts/run_tpch.sh ${pipeline_dir} ${workload_filename} ${dataset_filename}
 
-  "install heaptrack":
-    - command: shell.exec
-      type: test
-      params:
-        shell: bash
-        working_dir: mongosql-rs
-        script: |
-          ${prepare_shell}
-          curl -LO https://mongosql-noexpire.s3.us-east-2.amazonaws.com/mem_usage/heaptrack_build.tar.gz
-          tar -xzvf heaptrack_build.tar.gz
-          cat <<EOT >> expansions.yml
-            export PATH="$PATH:$PWD/heaptrack/bin"
-            export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/heaptrack/lib"
-          EOT
-    - command: expansions.update
-      params:
-        file: mongosql-rs/expansions.yml
-
   "generate memory usage tasks":
     - command: shell.exec
       type: test
@@ -482,6 +466,10 @@ functions:
         script: |
           ${prepare_shell}
           cargo build --bin profiler --release
+
+          # Update the environment to run heaptrack
+          export PATH="$PATH:${heaptrack_path}/bin"
+          export LD_LIBRARY_PATH="${heaptrack_path}/lib:$LD_LIBRARY_PATH"
 
           # run_mem_profiler.sh writes three files
           # - memory-usage-results.log: Memory usage metrics to upload to S3

--- a/mongosql/src/air/desugarer/subquery.rs
+++ b/mongosql/src/air/desugarer/subquery.rs
@@ -287,12 +287,12 @@ impl SubqueryExprDesugarerPassVisitor {
 
         self.subquery_counter += 1;
         self.as_names.push(as_var.clone());
-        self.subquery_lookups = Box::new(Lookup(Lookup {
+        *self.subquery_lookups = Lookup(Lookup {
             source: self.subquery_lookups.clone(),
             let_vars,
             pipeline,
             as_var: as_var.clone(),
-        }));
+        });
 
         as_var
     }
@@ -322,7 +322,7 @@ impl Visitor for SubqueryExprDesugarerPassVisitor {
         // Reset values to default.
         self.subquery_counter = 0;
         self.as_names = vec![];
-        self.subquery_lookups = Box::new(Sentinel);
+        *self.subquery_lookups = Sentinel;
 
         // Walk this stage, desugaring subquery expressions and populating the
         // visitor's fields with desugared subquery data.

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -528,9 +528,9 @@ impl<'a> Algebrizer<'a> {
 
         // if we found Expressions's, algebrize them as a single document, and add it to the expression
         // under the Bottom namespace.
-        if bottom.is_some() {
+        if let Some(bottom) = bottom {
             let e = expression_algebrizer
-                .algebrize_expression(ast::Expression::Document(bottom.unwrap()), false)?;
+                .algebrize_expression(ast::Expression::Document(bottom), false)?;
             let bot = Key::bot(expression_algebrizer.scope_level);
             datasources
                 .insert(bot.clone())

--- a/mongosql/src/algebrizer/test/aggregation/mod.rs
+++ b/mongosql/src/algebrizer/test/aggregation/mod.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use crate::{
     ast, map, mir, multimap,
     schema::{Atomic, Satisfaction, Schema, ANY_DOCUMENT, NUMERIC_OR_NULLISH},

--- a/mongosql/src/algebrizer/test/expressions/mod.rs
+++ b/mongosql/src/algebrizer/test/expressions/mod.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use crate::{
     ast, map,
     mir::{self, binding_tuple::Key},


### PR DESCRIPTION
This PR updates this repo to use the new common `install heaptrack` functionality added to `common-test-infra` [here](https://github.com/mongodb/sql-engines-common-test-infra/pull/23). That PR included [this patch](https://spruce.mongodb.com/version/692df63660ca3f000734afd3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) demonstrating this all works together.