### PR TITLE
SQL-3101: Update algorithm for unioning unstable schemas

### DIFF
--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -2115,7 +2115,7 @@ impl Document {
         mut m1: BTreeMap<String, Schema>,
         m2: &BTreeMap<String, Schema>,
     ) -> BTreeMap<String, Schema> {
-        for (key, s1) in m2.into_iter() {
+        for (key, s1) in m2.iter() {
             if let Some(s2) = m1.remove(key) {
                 m1.insert(key.clone(), s1.union(&s2));
             }

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -2111,14 +2111,13 @@ impl Document {
 
     /// retain_keys retains keys from the m1 map argument, creating an AnyOf for the Schema of any
     /// that overlap, and ignoring the keys from the m2 map that are not overlapping with m1.
-    #[allow(dead_code)]
     fn retain_keys(
         mut m1: BTreeMap<String, Schema>,
-        m2: BTreeMap<String, Schema>,
+        m2: &BTreeMap<String, Schema>,
     ) -> BTreeMap<String, Schema> {
         for (key, s1) in m2.into_iter() {
-            if let Some(s2) = m1.remove(&key) {
-                m1.insert(key, s1.union(&s2));
+            if let Some(s2) = m1.remove(key) {
+                m1.insert(key.clone(), s1.union(&s2));
             }
         }
         m1
@@ -2266,44 +2265,29 @@ impl Document {
         }
     }
 
-    /// Performs an unstable union.
-    ///
-    /// An unstable union chooses a preferred document between the two and uses that as the basis of
-    /// the returned schema. If exactly one of `self` or `other` is unstable, then the stable
-    /// document is preferred. If both are unstable, then the document with the greater JaccardIndex
-    /// value is preferred. If both are unstable and have equal JaccardIndex values, `self` is
-    /// preferred. The returned schema is constructed as follows:
-    ///   1. `keys` - All keys from the preferred doc are retained. Any keys that overlap between
-    ///      the preferred doc and the other doc are unioned. Any keys that appear only in the other
-    ///      doc are ignored.
-    ///   2. `required` - The intersection between the preferred doc's `required` list and the other
-    ///      doc's `required` list.
-    ///   3. `additional_properties` - True if the preferred doc already has this value set to true,
-    ///      or if the other doc contains any `keys` not contained in the preferred doc.
-    ///   4. `jaccard_index` - Updated JaccardIndex using the preferred doc's JaccardIndex as the
-    ///      base value.
-    ///   5. `unstable` - Unconditionally set to `true`.
+    /// Performs an unstable union. See the `union` doc comment for further details, as that method
+    /// is public and therefore contains all relevant information.
     fn unstable_union(self, other: Document) -> Document {
         let (pref_doc, other_doc) = if self.unstable && other.unstable {
             match (self.jaccard_index, other.jaccard_index) {
                 // If neither has a JaccardIndex or only self has one, prefer self.
-                (None, None) | (Some(_), None) => (self.clone(), other.clone()),
+                (None, None) | (Some(_), None) => (self, other),
                 // If only other has one, prefer other.
-                (None, Some(_)) => (other.clone(), self.clone()),
+                (None, Some(_)) => (other, self),
                 // If both have a JaccardIndex, prefer the one with the larger avg_ji value. If
                 // those values are equal, prefer self.
                 (Some(self_ji), Some(other_ji)) => {
                     if self_ji.avg_ji >= other_ji.avg_ji {
-                        (self.clone(), other.clone())
+                        (self, other)
                     } else {
-                        (other.clone(), self.clone())
+                        (other, self)
                     }
                 }
             }
         } else if self.unstable {
-            (other.clone(), self.clone())
+            (other, self)
         } else {
-            (self.clone(), other.clone())
+            (self, other)
         };
 
         let jaccard_index = pref_doc.jaccard_index.map(|ji| {
@@ -2317,7 +2301,7 @@ impl Document {
             Self::update_jaccard_index(ji, union_size, intersection_size)
         });
 
-        let keys = Self::retain_keys(pref_doc.keys, other_doc.keys.clone());
+        let keys = Self::retain_keys(pref_doc.keys, &other_doc.keys);
 
         let required = pref_doc
             .required

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -2176,80 +2176,45 @@ impl Document {
         }
     }
 
-    /// union unions together two Schema::Documents returning a single Document schema that matches
-    /// all document values matched by either `self` or `other`. Additional properties will
-    /// be allowed if either `self` or `other` allows them. There are caveats to this if either
-    /// Document is unstable or if either has a JaccardIndex. See below.
-    ///
-    /// If both Documents are stable, if either of the two documents has a JaccardIndex, the union
-    /// calculates the moving average. Once the 5th union is reached, each union will inspect the
-    /// index. If the index is less than the stability_limit specified in the JaccardIndex, the
-    /// union will proceed but will also mark the schema as unstable. Prior to comparison, the
-    /// inverse of the number of unions is added to the average Jaccard index to allow for some
-    /// variance, becoming more sensitive as more unions are processed. Documents that are a subset
-    /// or superset of each other will be considered equivalent and will always have a
-    /// JaccardIndex of 1.
+    /// Unions together two Schema::Documents returning a single Document schema that matches all
+    /// document values matched by either `self` or `other`. Additional properties will be allowed
+    /// if either `self` or `other` allows them. There are caveats to this if either Document is
+    /// unstable or if either has a JaccardIndex. See below.
     ///
     /// If both Documents are stable and neither has a JaccardIndex, the union will proceed as
     /// initially described: returning a single Document schema that matches all document values
     /// matched by either `self` or `other`. Additional properties will be allowed if either `self`
     /// or `other` allows them.
     ///
-    /// If exactly one of `self` or `other` is unstable -- meaning a previous union caused the
-    /// document's JaccardIndex to exceed the stability limit -- union is not attempted. Instead,
-    /// the stable schema will be returned with additional_properties set to true and the unstable
-    /// flag set to true.
+    /// If both Documents are stable and at least one has a JaccardIndex, the union calculates the
+    /// moving average. Once the MAX_NUM_DOC_UNIONS is reached, each union will inspect the index.
+    /// If the index is less than the stability_limit specified in the JaccardIndex, the union will
+    /// proceed but will also mark the schema as unstable. Prior to comparison, the inverse of the
+    /// number of unions is added to the average Jaccard index to allow for some variance, becoming
+    /// more sensitive as more unions are processed. Documents that are a subset or superset of each
+    /// other will be considered equivalent and will always have a JaccardIndex of 1.
     ///
-    /// If both of the two documents are unstable, union is not attempted. Instead, the unstable
-    /// schema with the higher avg_ji value will be returned with additional_properties set to true.
-    /// If the avg_ji value is equal, then `self` is preferred.
+    /// If either of the Documents is unstable -- meaning a previous union caused the document's
+    /// JaccardIndex to exceed the stability_limit -- traditional union as described above is not
+    /// attempted. Instead, an unstable union is performed. An unstable union chooses a preferred
+    /// document between the two and uses that as the basis of the returned schema. If exactly one
+    ///  of `self` or `other` is unstable, then the stable document is preferred. If both are
+    /// unstable, then the document with the greater JaccardIndex value is preferred. If both are
+    /// unstable and have equal JaccardIndex values, `self` is preferred. The returned schema is
+    /// constructed as follows:
+    ///   1. `keys` - All keys from the preferred doc are retained. Any keys that overlap between
+    ///      the preferred doc and the other doc are unioned. Any keys that appear only in the other
+    ///      doc are ignored.
+    ///   2. `required` - The intersection between the preferred doc's `required` list and the other
+    ///      doc's `required` list.
+    ///   3. `additional_properties` - True if the preferred doc already has this value set to true,
+    ///      or if the other doc contains any `keys` not contained in the preferred doc.
+    ///   4. `jaccard_index` - Updated JaccardIndex using the preferred doc's JaccardIndex as the
+    //       base value.
+    ///   5. `unstable` - Unconditionally set to `true`.
     pub fn union(self, other: Document) -> Document {
         if self.unstable || other.unstable {
-            let (pref_doc, other_doc) = if self.unstable && other.unstable {
-                match (self.jaccard_index, other.jaccard_index) {
-                    // If neither has a JaccardIndex, or only Self has one, prefer self.
-                    (None, None) | (Some(_), None) => (self.clone(), other.clone()),
-                    // If only other has one, prefer other.
-                    (None, Some(_)) => (other.clone(), self.clone()),
-                    // If both have a JaccardIndex, prefer the one with the larger avg_ji value. If
-                    // those values are equal, prefer self.
-                    (Some(self_ji), Some(other_ji)) => {
-                        if self_ji.avg_ji >= other_ji.avg_ji {
-                            (self.clone(), other.clone())
-                        } else {
-                            (other.clone(), self.clone())
-                        }
-                    }
-                }
-            } else if self.unstable {
-                (other.clone(), self.clone())
-            } else {
-                (self.clone(), other.clone())
-            };
-
-            let required = pref_doc
-                .required
-                .intersection(&other_doc.required)
-                .cloned()
-                .collect();
-
-            let other_contains_extra_keys = other_doc
-                .keys
-                .keys()
-                .any(|k| !pref_doc.keys.contains_key(k));
-
-            // We know there are additional properties if either has additional properties or if any
-            // of the non-preferred document's keys do not appear in the preferred document's keyset
-            let additional_properties = pref_doc.additional_properties
-                || other_doc.additional_properties
-                || other_contains_extra_keys;
-
-            return Document {
-                required,
-                additional_properties,
-                unstable: true,
-                ..pref_doc
-            };
+            return self.unstable_union(other);
         }
 
         // If both are stable, attempt to union using Jaccard Index information, or union "normally"
@@ -2258,14 +2223,14 @@ impl Document {
             let union = Document::union_keys(self.keys.clone(), other.keys.clone());
             let left_keys = self.keys.keys().collect::<HashSet<_>>();
             let right_keys = other.keys.keys().collect::<HashSet<_>>();
-            let intersection_count = left_keys.intersection(&right_keys).count();
-            // if the left keys are a subset of the right keys, or vice versa, then we will consider
-            // then equivalent documents
+
+            // If the left keys are a subset of the right keys, or vice versa, then we will consider
+            // them equivalent documents
             let intersection_size =
                 if left_keys.is_subset(&right_keys) || left_keys.is_superset(&right_keys) {
                     union.len()
                 } else {
-                    intersection_count
+                    left_keys.intersection(&right_keys).count()
                 };
 
             let jaccard_index =
@@ -2298,6 +2263,90 @@ impl Document {
                 additional_properties: self.additional_properties || other.additional_properties,
                 ..Default::default()
             }
+        }
+    }
+
+    /// Performs an unstable union.
+    ///
+    /// An unstable union chooses a preferred document between the two and uses that as the basis of
+    /// the returned schema. If exactly one of `self` or `other` is unstable, then the stable
+    /// document is preferred. If both are unstable, then the document with the greater JaccardIndex
+    /// value is preferred. If both are unstable and have equal JaccardIndex values, `self` is
+    /// preferred. The returned schema is constructed as follows:
+    ///   1. `keys` - All keys from the preferred doc are retained. Any keys that overlap between
+    ///      the preferred doc and the other doc are unioned. Any keys that appear only in the other
+    ///      doc are ignored.
+    ///   2. `required` - The intersection between the preferred doc's `required` list and the other
+    ///      doc's `required` list.
+    ///   3. `additional_properties` - True if the preferred doc already has this value set to true,
+    ///      or if the other doc contains any `keys` not contained in the preferred doc.
+    ///   4. `jaccard_index` - Updated JaccardIndex using the preferred doc's JaccardIndex as the
+    ///      base value.
+    ///   5. `unstable` - Unconditionally set to `true`.
+    fn unstable_union(self, other: Document) -> Document {
+        let (pref_doc, other_doc) = if self.unstable && other.unstable {
+            match (self.jaccard_index, other.jaccard_index) {
+                // If neither has a JaccardIndex or only self has one, prefer self.
+                (None, None) | (Some(_), None) => (self.clone(), other.clone()),
+                // If only other has one, prefer other.
+                (None, Some(_)) => (other.clone(), self.clone()),
+                // If both have a JaccardIndex, prefer the one with the larger avg_ji value. If
+                // those values are equal, prefer self.
+                (Some(self_ji), Some(other_ji)) => {
+                    if self_ji.avg_ji >= other_ji.avg_ji {
+                        (self.clone(), other.clone())
+                    } else {
+                        (other.clone(), self.clone())
+                    }
+                }
+            }
+        } else if self.unstable {
+            (other.clone(), self.clone())
+        } else {
+            (self.clone(), other.clone())
+        };
+
+        let jaccard_index = pref_doc.jaccard_index.map(|ji| {
+            let union_size = pref_doc.keys.len();
+            let intersection_size = pref_doc
+                .keys
+                .keys()
+                .collect::<HashSet<_>>()
+                .intersection(&other_doc.keys.keys().collect::<HashSet<_>>())
+                .count();
+            Self::update_jaccard_index(ji, union_size, intersection_size)
+        });
+
+        let keys = Self::retain_keys(pref_doc.keys, other_doc.keys.clone());
+
+        let required = pref_doc
+            .required
+            .intersection(&other_doc.required)
+            .cloned()
+            .collect();
+
+        let other_contains_extra_keys = other_doc.keys.keys().any(|k| !keys.contains_key(k));
+
+        // We know with certainty that the result schema must indicate there are additional
+        // properties if pref_doc already indicates that there are or if any of other_doc's keys do
+        // not appear in pref_doc's keyset.
+        //
+        // We cannot know with certainty if there are additional properties if neither of those
+        // conditions is true and only other_doc indicates there are additional properties. For
+        // example, it may be possible other_doc set that value to true because it omitted some of
+        // the now-retained fields during an earlier union. However, to stay on the safe side, we
+        // still also consider the result schema to have additional properties if
+        // other_doc.additional_properties is true.
+        let additional_properties = pref_doc.additional_properties
+            || other_doc.additional_properties
+            || other_contains_extra_keys;
+
+        Document {
+            keys,
+            required,
+            additional_properties,
+            jaccard_index,
+            unstable: true,
         }
     }
 

--- a/mongosql/src/schema/jaccard_test.rs
+++ b/mongosql/src/schema/jaccard_test.rs
@@ -482,15 +482,13 @@ mod jaccard {
             jaccard_index: JaccardIndex::default().into(),
             ..Default::default()
         };
-        let new_doc = iter::repeat(a_doc.clone())
-            .take(MAX_NUM_DOC_UNIONS as usize / 2)
+        let new_doc = iter::repeat_n(a_doc.clone(), MAX_NUM_DOC_UNIONS as usize / 2)
             .reduce(|acc, doc| acc.union(doc))
             .unwrap();
         let new_doc = new_doc
             .union(DOC_SCHEMAS[&"a2".to_string()].clone())
             .union(DOC_SCHEMAS[&"a3".to_string()].clone());
-        let new_doc = iter::repeat(a_doc.clone())
-            .take(MAX_NUM_DOC_UNIONS as usize / 2 - 2)
+        let new_doc = iter::repeat_n(a_doc.clone(), MAX_NUM_DOC_UNIONS as usize / 2 - 2)
             .fold(new_doc, |acc, doc| acc.union(doc));
 
         assert!(!new_doc.unstable);
@@ -509,8 +507,7 @@ mod jaccard {
             ..Default::default()
         };
         let num_stable_unions = MAX_NUM_DOC_UNIONS as usize / 2;
-        let new_doc = iter::repeat(a_doc.clone())
-            .take(num_stable_unions)
+        let new_doc = iter::repeat_n(a_doc.clone(), num_stable_unions)
             .reduce(|acc, doc| acc.union(doc))
             .unwrap();
         let new_doc = n_chars_iter!(MAX_NUM_DOC_UNIONS as usize - num_stable_unions + 1)

--- a/mongosql/src/schema/jaccard_test.rs
+++ b/mongosql/src/schema/jaccard_test.rs
@@ -1,71 +1,38 @@
 use lazy_static::lazy_static;
+use std::collections::HashMap;
 
 use crate::{
     map,
-    schema::{Atomic, Document, JaccardIndex, Schema},
+    schema::{Atomic, Document, JaccardIndex, Schema, MAX_NUM_DOC_UNIONS},
 };
 
+macro_rules! n_chars_iter {
+    ($n:expr) => {
+        "a".repeat($n).chars().enumerate()
+    };
+}
+
 lazy_static! {
-    static ref A_DOCUMENT: Document = Document {
-        keys: map! {
-            "a".into() => Schema::Atomic(Atomic::Integer),
-        },
-        jaccard_index: JaccardIndex::default().into(),
-        ..Default::default()
-    };
-    static ref B_DOCUMENT: Document = Document {
-        keys: map! {
-            "b".into() => Schema::Atomic(Atomic::Integer),
-        },
-        jaccard_index: JaccardIndex::default().into(),
-        ..Default::default()
-    };
-    static ref C_DOCUMENT: Document = Document {
-        keys: map! {
-            "c".into() => Schema::Atomic(Atomic::Integer),
-        },
-        jaccard_index: JaccardIndex::default().into(),
-        ..Default::default()
-    };
-    static ref D_DOCUMENT: Document = Document {
-        keys: map! {
-            "d".into() => Schema::Atomic(Atomic::Integer),
-        },
-        jaccard_index: JaccardIndex::default().into(),
-        ..Default::default()
-    };
-    static ref E_DOCUMENT: Document = Document {
-        keys: map! {
-            "e".into() => Schema::Atomic(Atomic::Integer),
-        },
-        jaccard_index: JaccardIndex::default().into(),
-        ..Default::default()
-    };
-    static ref F_DOCUMENT: Document = Document {
-        keys: map! {
-            "f".into() => Schema::Atomic(Atomic::Integer),
-        },
-        jaccard_index: JaccardIndex::default().into(),
-        ..Default::default()
-    };
-    static ref G_DOCUMENT: Document = Document {
-        keys: map! {
-            "g".into() => Schema::Atomic(Atomic::Integer),
-        },
-        jaccard_index: JaccardIndex::default().into(),
-        ..Default::default()
-    };
-    static ref H_DOCUMENT: Document = Document {
-        keys: map! {
-            "h".into() => Schema::Atomic(Atomic::Integer),
-        },
-        jaccard_index: JaccardIndex::default().into(),
-        ..Default::default()
-    };
+    static ref DOC_SCHEMAS: HashMap<String, Document> =
+        n_chars_iter!(MAX_NUM_DOC_UNIONS as usize * 2)
+            .map(|(i, c)| {
+                (
+                    format!("{c}{i}"),
+                    Document {
+                        keys: map! {
+                            format!("{c}{i}") => Schema::Atomic(Atomic::Integer),
+                        },
+                        jaccard_index: JaccardIndex::default().into(),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
 }
 
 mod jaccard {
     use crate::{schema::JaccardIndex, set};
+    use std::iter;
 
     use super::*;
 
@@ -159,27 +126,28 @@ mod jaccard {
     }
 
     #[test]
-    fn four_unions_with_zero_jaccard_index_preserves_document() {
-        let new_left = A_DOCUMENT.clone().union(B_DOCUMENT.clone());
-        assert!(!new_left.unstable);
-        let new_left = new_left.union(C_DOCUMENT.clone());
-        assert!(!new_left.unstable);
-        let new_left = new_left.union(D_DOCUMENT.clone());
-        assert!(!new_left.unstable);
-        let new_left = new_left.union(E_DOCUMENT.clone());
-        assert!(new_left.eq_with_jaccard_index(&Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-                "b".into() => Schema::Atomic(Atomic::Integer),
-                "c".into() => Schema::Atomic(Atomic::Integer),
-                "d".into() => Schema::Atomic(Atomic::Integer),
-                "e".into() => Schema::Atomic(Atomic::Integer),
-            },
+    fn unions_of_unstable_data_remains_stable_up_to_one_less_than_max_num_doc_unions() {
+        let doc = n_chars_iter!(MAX_NUM_DOC_UNIONS as usize)
+            .map(|(i, c)| DOC_SCHEMAS[&format!("{c}{i}")].clone())
+            .reduce(|acc, doc| {
+                let res = acc.union(doc);
+                // assert that each union results in a stable Document schema
+                assert!(!res.unstable);
+                res
+            });
+
+        // Assert the full final stable schema
+        assert!(doc.unwrap().eq_with_jaccard_index(&Document {
+            keys: n_chars_iter!(MAX_NUM_DOC_UNIONS as usize)
+                .map(|(i, c)| (format!("{c}{i}"), Schema::Atomic(Atomic::Integer)))
+                .collect(),
             required: set! {},
             additional_properties: false,
             jaccard_index: Some(JaccardIndex {
+                // 0 because each document contains a unique key, so the intersection is always 0
                 avg_ji: 0.0,
-                num_unions: 4,
+                // the number of unions among MAX_NUM_DOC_UNIONS documents is MAX_NUM_DOC_UNIONS - 1
+                num_unions: MAX_NUM_DOC_UNIONS - 1,
                 stability_limit: 0.8,
             }),
             unstable: false,
@@ -187,38 +155,30 @@ mod jaccard {
     }
 
     #[test]
-    fn five_unions_with_zero_jaccard_index_is_unstable() {
-        let new_left = A_DOCUMENT.clone().union(B_DOCUMENT.clone());
-        assert!(!new_left.unstable);
-        let new_left = new_left.union(C_DOCUMENT.clone());
-        assert!(!new_left.unstable);
-        let new_left = new_left.union(D_DOCUMENT.clone());
-        assert!(!new_left.unstable);
-        let new_left = new_left.union(E_DOCUMENT.clone());
-        assert!(!new_left.unstable);
-        let new_left = new_left.union(F_DOCUMENT.clone());
-        assert!(new_left.eq_with_jaccard_index(&Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-                "b".into() => Schema::Atomic(Atomic::Integer),
-                "c".into() => Schema::Atomic(Atomic::Integer),
-                "d".into() => Schema::Atomic(Atomic::Integer),
-                "e".into() => Schema::Atomic(Atomic::Integer),
-                "f".into() => Schema::Atomic(Atomic::Integer),
-            },
+    fn unions_of_unstable_data_results_in_unstable_schema_after_max_num_doc_unions() {
+        let doc = n_chars_iter!(MAX_NUM_DOC_UNIONS as usize + 1)
+            .map(|(i, c)| DOC_SCHEMAS[&format!("{c}{i}")].clone())
+            .reduce(|acc, doc| acc.union(doc));
+
+        // Assert the full final unstable schema
+        assert!(doc.unwrap().eq_with_jaccard_index(&Document {
+            keys: n_chars_iter!(MAX_NUM_DOC_UNIONS as usize + 1)
+                .map(|(i, c)| (format!("{c}{i}"), Schema::Atomic(Atomic::Integer)))
+                .collect(),
             required: set! {},
             additional_properties: false,
             jaccard_index: Some(JaccardIndex {
+                // 0 because each document contains a unique key, so the intersection is always 0
                 avg_ji: 0.0,
-                num_unions: 5,
+                num_unions: MAX_NUM_DOC_UNIONS,
                 stability_limit: 0.8,
             }),
             unstable: true,
-        }))
+        }));
     }
 
     #[test]
-    fn union_stable_and_unstable_schemas_returns_the_stable_schema_marked_as_unstable() {
+    fn union_stable_and_unstable_schemas_prefers_stable_schema_data() {
         let stable_doc = Document {
             keys: map! {
                 "a".into() => Schema::Atomic(Atomic::Integer)
@@ -255,16 +215,21 @@ mod jaccard {
         };
 
         let expected_doc = Document {
+            // Retain only the stable keys
             keys: map! {
                 "a".into() => Schema::Atomic(Atomic::Integer),
             },
-            required: set! {"a".into()},
+            // Intersect the required fields
+            required: set! {},
+            // Set to true if there are properties in the unstable schema that are not in the stable
+            // schema
             additional_properties: true,
+            // Updated jaccard_index with stable doc as the base value
             jaccard_index: Some(JaccardIndex {
-                // ((weighted avg_ji for stable_doc and unstable_doc) * total # unions) / (total # unions + 1)
-                avg_ji: (10f64 * 15f64) / 16f64,
-                // 10 unions from stable_doc + 5 unions from unstable_doc + 1 union of them together
-                num_unions: 16,
+                // (avg_ji * num_unions + intersection_size / union_size) / num_unions + 1
+                avg_ji: (1f64 * 10f64 + 0f64 / 7f64) / 11f64,
+                // Treat this as one union added to the preferred schema's count
+                num_unions: 11,
                 stability_limit: 0.8,
             }),
             unstable: true,
@@ -324,12 +289,12 @@ mod jaccard {
         };
 
         // Assume this document schema is the result of unioning the following 6 documents:
-        // 1. { a: 1 }
-        // 2. { a: 1, b: 1 }
-        // 3. { a: 1, c: 1 }
-        // 4. { a: 1, d: 1 }
-        // 5. { a: 1, e: 1 }
-        // 6. { f: 1 }
+        // 1. { b: 1 }
+        // 2. { b: 1, c: true }
+        // 3. { b: 1, d: true }
+        // 4. { b: 1, e: true }
+        // 5. { b: 1, f: true }
+        // 6. { g: 1 }
         // That results in the Jaccard Index updating as follows as each document is unioned:
         // 1. num_unions = 0, avg_ji = 1
         // 2. num_unions = 1, avg_ji = 1 / 2
@@ -339,12 +304,12 @@ mod jaccard {
         // 6. num_unions = 5, avg_ji = (77/240 * 4 + 0/6) / 5 = 77 / 300
         let unstable_doc_2 = Document {
             keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
                 "b".into() => Schema::Atomic(Atomic::Integer),
-                "c".into() => Schema::Atomic(Atomic::Integer),
-                "d".into() => Schema::Atomic(Atomic::Integer),
-                "e".into() => Schema::Atomic(Atomic::Integer),
-                "f".into() => Schema::Atomic(Atomic::Integer),
+                "c".into() => Schema::Atomic(Atomic::Boolean),
+                "d".into() => Schema::Atomic(Atomic::Boolean),
+                "e".into() => Schema::Atomic(Atomic::Boolean),
+                "f".into() => Schema::Atomic(Atomic::Boolean),
+                "g".into() => Schema::Atomic(Atomic::Integer),
             },
             required: set! {},
             additional_properties: false,
@@ -356,20 +321,54 @@ mod jaccard {
             unstable: true,
         };
 
+        let expected_doc = Document {
+            // Retain the more stable doc's keys, unioning new info for overlapping keys
+            keys: map! {
+                "a".into() => Schema::Atomic(Atomic::Integer),
+                "b".into() => Schema::Atomic(Atomic::Integer),
+                "c".into() => Schema::AnyOf(set! {
+                    Schema::Atomic(Atomic::Integer),
+                    Schema::Atomic(Atomic::Boolean),
+                }),
+                "d".into() => Schema::AnyOf(set! {
+                    Schema::Atomic(Atomic::Integer),
+                    Schema::Atomic(Atomic::Boolean),
+                }),
+                "e".into() => Schema::AnyOf(set! {
+                    Schema::Atomic(Atomic::Integer),
+                    Schema::Atomic(Atomic::Boolean),
+                }),
+                "f".into() => Schema::AnyOf(set! {
+                    Schema::Atomic(Atomic::Integer),
+                    Schema::Atomic(Atomic::Boolean),
+                }),
+            },
+            // Intersect the required sets
+            required: set! {},
+            // Mark additional_properties as true since the less stable doc contains a key, "g",
+            // that is not in the retained keyset
+            additional_properties: true,
+            // Updated jaccard_index with stable doc as the base value
+            jaccard_index: Some(JaccardIndex {
+                // (avg_ji * num_unions + intersection_size / union_size) / num_unions + 1
+                // intersection = { b, c, d, e, f }
+                // union = { a, b, c, d, e, f, g }
+                avg_ji: (0.29 * 5f64 + 5f64 / 7f64) / 6f64,
+                // Treat this as one union added to the preferred schema's count
+                num_unions: 6,
+                stability_limit: 0.8,
+            }),
+            unstable: true,
+        };
+
         // When we union an unstable document and an unstable document, we want to retain schema
         // with the higher avg_ji value and mark it with additional_properties true.
         let new_doc = unstable_doc_1.clone().union(unstable_doc_2.clone());
-        assert!(new_doc.eq_with_jaccard_index(&Document {
-            additional_properties: true,
-            ..unstable_doc_1.clone()
-        }));
+        assert!(new_doc.eq_with_jaccard_index(&expected_doc));
 
         // Order should not impact this behavior
         let new_doc = unstable_doc_2.union(unstable_doc_1.clone());
-        assert!(new_doc.eq_with_jaccard_index(&Document {
-            additional_properties: true,
-            ..unstable_doc_1
-        }));
+        assert!(new_doc.eq_with_jaccard_index(&expected_doc));
     }
 
     #[test]
@@ -383,11 +382,12 @@ mod jaccard {
                 "e".into() => Schema::Atomic(Atomic::Integer),
                 "f".into() => Schema::Atomic(Atomic::Integer),
             },
-            required: set! {"a".into()},
+            required: set! {"a".into(), "c".into()},
             additional_properties: false,
             jaccard_index: Some(JaccardIndex {
-                avg_ji: 0.29,
-                num_unions: 5,
+                // These values are completely artificial
+                avg_ji: 0.3,
+                num_unions: 20,
                 stability_limit: 0.8,
             }),
             unstable: true,
@@ -395,18 +395,19 @@ mod jaccard {
 
         let unstable_doc_2 = Document {
             keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
                 "b".into() => Schema::Atomic(Atomic::Integer),
                 "c".into() => Schema::Atomic(Atomic::Integer),
                 "d".into() => Schema::Atomic(Atomic::Integer),
                 "e".into() => Schema::Atomic(Atomic::Integer),
                 "f".into() => Schema::Atomic(Atomic::Integer),
+                "g".into() => Schema::Atomic(Atomic::Integer),
             },
-            required: set! {"b".into()},
+            required: set! {"b".into(), "c".into()},
             additional_properties: false,
             jaccard_index: Some(JaccardIndex {
-                avg_ji: 0.29,
-                num_unions: 5,
+                // These values are completely artificial
+                avg_ji: 0.3,
+                num_unions: 20,
                 stability_limit: 0.8,
             }),
             unstable: true,
@@ -414,15 +415,29 @@ mod jaccard {
 
         let new_doc = unstable_doc_1.clone().union(unstable_doc_2.clone());
         assert!(new_doc.eq_with_jaccard_index(&Document {
+            required: set! {"c".into()},
             additional_properties: true,
+            jaccard_index: Some(JaccardIndex {
+                avg_ji: (0.3 * 5f64 + 5f64 / 7f64) / 6f64,
+                num_unions: 6,
+                stability_limit: 0.8,
+            }),
+            unstable: true,
             ..unstable_doc_1.clone()
         }));
 
         let new_doc = unstable_doc_2.clone().union(unstable_doc_1);
         assert!(new_doc.eq_with_jaccard_index(&Document {
+            required: set! {"c".into()},
             additional_properties: true,
+            jaccard_index: Some(JaccardIndex {
+                avg_ji: (0.3 * 5f64 + 5f64 / 7f64) / 6f64,
+                num_unions: 6,
+                stability_limit: 0.8,
+            }),
+            unstable: true,
             ..unstable_doc_2
-        }))
+        }));
     }
 
     #[test]
@@ -467,20 +482,18 @@ mod jaccard {
             jaccard_index: JaccardIndex::default().into(),
             ..Default::default()
         };
-        let new_left = a_doc
-            .clone()
-            .union(a_doc.clone())
-            .union(a_doc.clone())
-            .union(a_doc.clone())
-            .union(a_doc.clone())
-            .union(a_doc.clone())
-            .union(E_DOCUMENT.clone())
-            .union(F_DOCUMENT.clone())
-            .union(a_doc.clone())
-            .union(a_doc.clone())
-            .union(a_doc.clone());
+        let new_doc = iter::repeat(a_doc.clone())
+            .take(MAX_NUM_DOC_UNIONS as usize / 2)
+            .reduce(|acc, doc| acc.union(doc))
+            .unwrap();
+        let new_doc = new_doc
+            .union(DOC_SCHEMAS[&"a2".to_string()].clone())
+            .union(DOC_SCHEMAS[&"a3".to_string()].clone());
+        let new_doc = iter::repeat(a_doc.clone())
+            .take(MAX_NUM_DOC_UNIONS as usize / 2 - 2)
+            .fold(new_doc, |acc, doc| acc.union(doc));
 
-        assert!(!new_left.unstable);
+        assert!(!new_doc.unstable);
     }
 
     #[test]
@@ -495,61 +508,65 @@ mod jaccard {
             jaccard_index: JaccardIndex::default().into(),
             ..Default::default()
         };
-        let new_left = a_doc
-            .clone()
-            .union(a_doc.clone())
-            .union(a_doc.clone())
-            .union(a_doc.clone())
-            .union(a_doc.clone())
-            .union(a_doc.clone())
-            .union(E_DOCUMENT.clone())
-            .union(F_DOCUMENT.clone())
-            .union(G_DOCUMENT.clone())
-            .union(H_DOCUMENT.clone());
+        let num_stable_unions = MAX_NUM_DOC_UNIONS as usize / 2;
+        let new_doc = iter::repeat(a_doc.clone())
+            .take(num_stable_unions)
+            .reduce(|acc, doc| acc.union(doc))
+            .unwrap();
+        let new_doc = n_chars_iter!(MAX_NUM_DOC_UNIONS as usize - num_stable_unions + 1)
+            .map(|(i, c)| DOC_SCHEMAS[&format!("{c}{i}")].clone())
+            .fold(new_doc, |acc, doc| acc.union(doc));
 
-        assert!(new_left.unstable);
+        assert!(new_doc.unstable);
     }
 
     #[test]
     fn nested_stable_documents() {
+        let nested_doc = Document {
+            keys: map! {
+                "n".into() => Schema::Atomic(Atomic::Boolean),
+            },
+            jaccard_index: JaccardIndex::default().into(),
+            ..Default::default()
+        };
         let a_doc = Document {
             keys: map! {
-                "a".into() => Schema::Document(A_DOCUMENT.clone()),
+                "a".into() => Schema::Document(nested_doc.clone()),
             },
             jaccard_index: JaccardIndex::default().into(),
             ..Default::default()
         };
         let b_doc = Document {
             keys: map! {
-                "a".into() => Schema::Document(A_DOCUMENT.clone()),
+                "a".into() => Schema::Document(nested_doc.clone()),
             },
             jaccard_index: JaccardIndex::default().into(),
             ..Default::default()
         };
         let c_doc = Document {
             keys: map! {
-                "a".into() => Schema::Document(A_DOCUMENT.clone()),
+                "a".into() => Schema::Document(nested_doc.clone()),
             },
             jaccard_index: JaccardIndex::default().into(),
             ..Default::default()
         };
         let d_doc = Document {
             keys: map! {
-                "a".into() => Schema::Document(A_DOCUMENT.clone()),
+                "a".into() => Schema::Document(nested_doc.clone()),
             },
             jaccard_index: JaccardIndex::default().into(),
             ..Default::default()
         };
         let e_doc = Document {
             keys: map! {
-                "a".into() => Schema::Document(A_DOCUMENT.clone()),
+                "a".into() => Schema::Document(nested_doc.clone()),
             },
             jaccard_index: JaccardIndex::default().into(),
             ..Default::default()
         };
         let f_doc = Document {
             keys: map! {
-                "a".into() => Schema::Document(A_DOCUMENT.clone()),
+                "a".into() => Schema::Document(nested_doc.clone()),
             },
             jaccard_index: JaccardIndex::default().into(),
             ..Default::default()
@@ -568,11 +585,18 @@ mod jaccard {
 
     #[test]
     fn nested_nested_stable_documents() {
+        let nested_doc = Document {
+            keys: map! {
+                "n".into() => Schema::Atomic(Atomic::Boolean),
+            },
+            jaccard_index: JaccardIndex::default().into(),
+            ..Default::default()
+        };
         let a_doc = Document {
             keys: map! {
                 "a".into() => Schema::Document(Document {
                     keys: map! {
-                        "b".into() => Schema::Document(A_DOCUMENT.clone()),
+                        "b".into() => Schema::Document(nested_doc.clone()),
                     },
                     ..Default::default()
                 }),
@@ -584,7 +608,7 @@ mod jaccard {
             keys: map! {
                 "a".into() => Schema::Document(Document {
                     keys: map! {
-                        "b".into() => Schema::Document(A_DOCUMENT.clone()),
+                        "b".into() => Schema::Document(nested_doc.clone()),
                     },
                     ..Default::default()
                 }),
@@ -596,7 +620,7 @@ mod jaccard {
             keys: map! {
                 "a".into() => Schema::Document(Document {
                     keys: map! {
-                        "b".into() => Schema::Document(A_DOCUMENT.clone()),
+                        "b".into() => Schema::Document(nested_doc.clone()),
                     },
                     ..Default::default()
                 }),
@@ -608,7 +632,7 @@ mod jaccard {
             keys: map! {
                 "a".into() => Schema::Document(Document {
                     keys: map! {
-                        "b".into() => Schema::Document(A_DOCUMENT.clone()),
+                        "b".into() => Schema::Document(nested_doc.clone()),
                     },
                 ..Default::default()
                 }),
@@ -620,7 +644,7 @@ mod jaccard {
             keys: map! {
                 "a".into() => Schema::Document(Document {
                     keys: map! {
-                        "b".into() => Schema::Document(A_DOCUMENT.clone()),
+                        "b".into() => Schema::Document(nested_doc.clone()),
                     },
                     ..Default::default()
                 }),
@@ -632,7 +656,7 @@ mod jaccard {
             keys: map! {
                 "a".into() => Schema::Document(Document {
                     keys: map! {
-                        "b".into() => Schema::Document(A_DOCUMENT.clone()),
+                        "b".into() => Schema::Document(nested_doc.clone()),
                     },
                     ..Default::default()
                 }),
@@ -654,110 +678,33 @@ mod jaccard {
 
     #[test]
     fn nested_nested_unstable_documents() {
-        let a_doc = Document {
-            keys: map! {
-                "a".into() => Schema::Document(Document {
-                    keys: map! {
-                        "b".into() => Schema::Document(A_DOCUMENT.clone()),
-                    },
-                    ..Default::default()
-                }),
-            },
-            jaccard_index: JaccardIndex::default().into(),
-            ..Default::default()
-        };
-        let b_doc = Document {
-            keys: map! {
-                "a".into() => Schema::Document(Document {
-                    keys: map! {
-                        "b".into() => Schema::Document(B_DOCUMENT.clone()),
-                    },
-                    jaccard_index: JaccardIndex::default().into(),
-                    ..Default::default()
-                }),
-            },
-            jaccard_index: JaccardIndex::default().into(),
-            ..Default::default()
-        };
-        let c_doc = Document {
-            keys: map! {
-                "a".into() => Schema::Document(Document {
-                    keys: map! {
-                        "b".into() => Schema::Document(C_DOCUMENT.clone()),
-                    },
-                    jaccard_index: JaccardIndex::default().into(),
-                    ..Default::default()
-                }),
-            },
-            jaccard_index: JaccardIndex::default().into(),
-            ..Default::default()
-        };
-        let d_doc = Document {
-            keys: map! {
-                "a".into() => Schema::Document(Document {
-                    keys: map! {
-                        "b".into() => Schema::Document(D_DOCUMENT.clone()),
-                    },
-                    jaccard_index: JaccardIndex::default().into(),
-                    ..Default::default()
-                }),
-            },
-            jaccard_index: JaccardIndex::default().into(),
-            ..Default::default()
-        };
-        let e_doc = Document {
-            keys: map! {
-                "a".into() => Schema::Document(Document {
-                    keys: map! {
-                        "b".into() => Schema::Document(E_DOCUMENT.clone()),
-                    },
-                    jaccard_index: JaccardIndex::default().into(),
-                    ..Default::default()
-                }),
-            },
-            jaccard_index: JaccardIndex::default().into(),
-            ..Default::default()
-        };
-        let f_doc = Document {
-            keys: map! {
-                "a".into() => Schema::Document(Document {
-                    keys: map! {
-                        "b".into() => Schema::Document(F_DOCUMENT.clone()),
-                    },
-                    jaccard_index: JaccardIndex::default().into(),
-                    ..Default::default()
-                }),
-            },
-            jaccard_index: JaccardIndex::default().into(),
-            ..Default::default()
-        };
+        let doc = n_chars_iter!(MAX_NUM_DOC_UNIONS as usize + 1)
+            .map(|(i, c)| Document {
+                keys: map! {
+                    "a".into() => Schema::Document(Document {
+                        keys: map! {
+                            "b".into() => Schema::Document(DOC_SCHEMAS[&format!("{c}{i}")].clone())
+                        },
+                        ..Default::default()
+                    }),
+                },
+                jaccard_index: JaccardIndex::default().into(),
+                ..Default::default()
+            })
+            .reduce(|acc, doc| acc.union(doc));
 
-        let new_left = a_doc
-            .clone()
-            .union(b_doc)
-            .union(c_doc)
-            .union(d_doc)
-            .union(e_doc)
-            .union(f_doc);
-
-        assert!(new_left.eq_with_jaccard_index(&Document {
+        // Assert the full final unstable schema
+        assert!(doc.unwrap().eq_with_jaccard_index(&Document {
             keys: map! {
                 "a".into() => Schema::Document(Document {
                     keys: map! {
                         "b".into() => Schema::Document(Document {
-                            keys: map! {
-                                "a".into() => Schema::Atomic(Atomic::Integer),
-                                "b".into() => Schema::Atomic(Atomic::Integer),
-                                "c".into() => Schema::Atomic(Atomic::Integer),
-                                "d".into() => Schema::Atomic(Atomic::Integer),
-                                "e".into() => Schema::Atomic(Atomic::Integer),
-                                "f".into() => Schema::Atomic(Atomic::Integer),
-                            },
+                            keys: n_chars_iter!(MAX_NUM_DOC_UNIONS as usize + 1).map(|(i, c)| (format!("{c}{i}"), Schema::Atomic(Atomic::Integer))).collect(),
                             required: set!{},
                             additional_properties: false,
                             jaccard_index: Some(JaccardIndex {
                                 avg_ji: 0.0,
-                                num_unions: 5,
+                                num_unions: MAX_NUM_DOC_UNIONS,
                                 stability_limit: 0.8,
                             }),
                             unstable: true,

--- a/mongosql/src/schema/test.rs
+++ b/mongosql/src/schema/test.rs
@@ -1448,176 +1448,39 @@ mod document_union {
         };
     }
 
-    test_document_union!(
-        schema_does_not_satisfy_document_results_in_any,
-        expected = EMPTY_DOCUMENT.clone(),
-        schema1 = Schema::Atomic(Atomic::Integer),
-        schema2 = ANY_DOCUMENT.clone(),
-    );
-    test_document_union!(
-        schema_does_not_satisfy_document_results_in_any_symmetric,
-        expected = EMPTY_DOCUMENT.clone(),
-        schema1 = ANY_DOCUMENT.clone(),
-        schema2 = Schema::Atomic(Atomic::Integer),
-    );
-    test_document_union!(
-        document_union_of_two_documents_will_document_union_keys_and_intersect_required_wo_additional_properties,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::AnyOf(set![
-                    Schema::Atomic(Atomic::Decimal),
-                    Schema::Atomic(Atomic::Integer),
-                ]),
-                "b".into() => Schema::AnyOf(set![
-                    Schema::Atomic(Atomic::Double),
-                    Schema::Atomic(Atomic::Integer),
-                ]),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            ..Default::default()
-            }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Decimal),
-                "b".into() => Schema::Atomic(Atomic::Double),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            ..Default::default()
-            }),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into(), "b".into()},
-            additional_properties: false,
-            ..Default::default()
-            }),
-    );
-    test_document_union!(
-        document_union_of_two_documents_will_document_union_keys_and_intersect_required_wo_additional_properties_symmetric,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::AnyOf(set![
-                    Schema::Atomic(Atomic::Integer),
-                    Schema::Atomic(Atomic::Decimal),
-                ]),
-                "b".into() => Schema::AnyOf(set![
-                    Schema::Atomic(Atomic::Integer),
-                    Schema::Atomic(Atomic::Double),
-                ]),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            ..Default::default()
-            }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into(), "b".into()},
-            additional_properties: false,
-            ..Default::default()
-            }),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Decimal),
-                "b".into() => Schema::Atomic(Atomic::Double),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            ..Default::default()
-            }),
-    );
-    test_document_union!(
-        document_union_of_doc_with_empty_doc_is_doc_with_no_required,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-                "c".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {},
-            additional_properties: false,
-            ..Default::default()
-        }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-                "c".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into(), "c".into()},
-            additional_properties: false,
-            ..Default::default()
-        }),
-        schema2 = EMPTY_DOCUMENT.clone(),
-    );
-    test_document_union!(
-        document_union_of_doc_with_empty_doc_is_doc_with_no_required_symmetric,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-                "c".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {},
-            additional_properties: false,
-            ..Default::default()
-        }),
-        schema1 = EMPTY_DOCUMENT.clone(),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-                "c".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into(), "c".into()},
-            additional_properties: false,
-            ..Default::default()
-        }),
-    );
-    test_document_union!(
-        document_union_of_any_of_recursively_applies_document_union,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::AnyOf(set![
-                    Schema::Atomic(Atomic::Integer),
-                    Schema::Atomic(Atomic::Decimal),
-                ]),
-                "b".into() => Schema::AnyOf(set![
-                    Schema::Atomic(Atomic::Integer),
-                    Schema::Atomic(Atomic::Double),
-                ]),
-                "c".into() => Schema::Atomic(Atomic::Integer),
-                "d".into() => Schema::Atomic(Atomic::Double),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            ..Default::default()
-        }),
-        schema1 = Schema::AnyOf(set![
-            Schema::Document(Document {
+    mod stable {
+        use super::*;
+
+        test_document_union!(
+            schema_does_not_satisfy_document_results_in_any,
+            expected = EMPTY_DOCUMENT.clone(),
+            schema1 = Schema::Atomic(Atomic::Integer),
+            schema2 = ANY_DOCUMENT.clone(),
+        );
+        test_document_union!(
+            schema_does_not_satisfy_document_results_in_any_symmetric,
+            expected = EMPTY_DOCUMENT.clone(),
+            schema1 = ANY_DOCUMENT.clone(),
+            schema2 = Schema::Atomic(Atomic::Integer),
+        );
+        test_document_union!(
+            document_union_of_two_documents_will_document_union_keys_and_intersect_required_wo_additional_properties,
+            expected = Schema::Document(Document {
                 keys: map! {
-                    "a".into() => Schema::Atomic(Atomic::Integer),
-                    "b".into() => Schema::Atomic(Atomic::Integer),
+                    "a".into() => Schema::AnyOf(set![
+                        Schema::Atomic(Atomic::Decimal),
+                        Schema::Atomic(Atomic::Integer),
+                    ]),
+                    "b".into() => Schema::AnyOf(set![
+                        Schema::Atomic(Atomic::Double),
+                        Schema::Atomic(Atomic::Integer),
+                    ]),
                 },
-                required: set! {"a".into(), "b".into()},
+                required: set! {"a".into()},
                 additional_properties: false,
                 ..Default::default()
-            }),
-            Schema::Document(Document {
-                keys: map! {
-                    "a".into() => Schema::Atomic(Atomic::Integer),
-                    "b".into() => Schema::Atomic(Atomic::Integer),
-                    "c".into() => Schema::Atomic(Atomic::Integer),
-                },
-                required: set! {"a".into(), "b".into()},
-                additional_properties: false,
-                ..Default::default()
-            })
-        ]),
-        schema2 = Schema::AnyOf(set![
-            Schema::Document(Document {
+                }),
+            schema1 = Schema::Document(Document {
                 keys: map! {
                     "a".into() => Schema::Atomic(Atomic::Decimal),
                     "b".into() => Schema::Atomic(Atomic::Double),
@@ -1625,240 +1488,503 @@ mod document_union {
                 required: set! {"a".into()},
                 additional_properties: false,
                 ..Default::default()
-            }),
-            Schema::Document(Document {
+                }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into(), "b".into()},
+                additional_properties: false,
+                ..Default::default()
+                }),
+        );
+        test_document_union!(
+            document_union_of_two_documents_will_document_union_keys_and_intersect_required_wo_additional_properties_symmetric,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::AnyOf(set![
+                        Schema::Atomic(Atomic::Integer),
+                        Schema::Atomic(Atomic::Decimal),
+                    ]),
+                    "b".into() => Schema::AnyOf(set![
+                        Schema::Atomic(Atomic::Integer),
+                        Schema::Atomic(Atomic::Double),
+                    ]),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                ..Default::default()
+                }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into(), "b".into()},
+                additional_properties: false,
+                ..Default::default()
+                }),
+            schema2 = Schema::Document(Document {
                 keys: map! {
                     "a".into() => Schema::Atomic(Atomic::Decimal),
+                    "b".into() => Schema::Atomic(Atomic::Double),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                ..Default::default()
+                }),
+        );
+        test_document_union!(
+            document_union_of_doc_with_empty_doc_is_doc_with_no_required,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                    "c".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: false,
+                ..Default::default()
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                    "c".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into(), "c".into()},
+                additional_properties: false,
+                ..Default::default()
+            }),
+            schema2 = EMPTY_DOCUMENT.clone(),
+        );
+        test_document_union!(
+            document_union_of_doc_with_empty_doc_is_doc_with_no_required_symmetric,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                    "c".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: false,
+                ..Default::default()
+            }),
+            schema1 = EMPTY_DOCUMENT.clone(),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                    "c".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into(), "c".into()},
+                additional_properties: false,
+                ..Default::default()
+            }),
+        );
+        test_document_union!(
+            document_union_of_any_of_recursively_applies_document_union,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::AnyOf(set![
+                        Schema::Atomic(Atomic::Integer),
+                        Schema::Atomic(Atomic::Decimal),
+                    ]),
+                    "b".into() => Schema::AnyOf(set![
+                        Schema::Atomic(Atomic::Integer),
+                        Schema::Atomic(Atomic::Double),
+                    ]),
+                    "c".into() => Schema::Atomic(Atomic::Integer),
                     "d".into() => Schema::Atomic(Atomic::Double),
                 },
                 required: set! {"a".into()},
                 additional_properties: false,
                 ..Default::default()
             }),
-        ])
-    );
-    test_document_union!(
-        only_left_is_unstable_returns_right_with_additional_properties_and_unstable_true,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: true,
-            jaccard_index: None,
-            unstable: true,
-        }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            jaccard_index: None,
-            unstable: true,
-        }),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: false,
-            jaccard_index: None,
-            unstable: false,
-        }),
-    );
-    test_document_union!(
-        only_right_is_unstable_returns_left_with_additional_properties_and_unstable_true,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: true,
-            jaccard_index: None,
-            unstable: true,
-        }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            jaccard_index: None,
-            unstable: false,
-        }),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: false,
-            jaccard_index: None,
-            unstable: true,
-        }),
-    );
-    test_document_union!(
-        both_are_unstable_and_no_ji_returns_left_with_additional_properties_true,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: true,
-            jaccard_index: None,
-            unstable: true,
-        }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            jaccard_index: None,
-            unstable: true,
-        }),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: false,
-            jaccard_index: None,
-            unstable: true,
-        }),
-    );
-    test_document_union!(
-        both_are_unstable_and_only_left_has_ji_returns_left_with_additional_properties_true,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: true,
-            jaccard_index: Some(JaccardIndex::default()),
-            unstable: true,
-        }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            jaccard_index: Some(JaccardIndex::default()),
-            unstable: true,
-        }),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: false,
-            jaccard_index: None,
-            unstable: true,
-        }),
-    );
-    test_document_union!(
-        both_are_unstable_and_only_right_has_ji_returns_right_with_additional_properties_true,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: true,
-            jaccard_index: Some(JaccardIndex::default()),
-            unstable: true,
-        }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            jaccard_index: None,
-            unstable: true,
-        }),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: false,
-            jaccard_index: Some(JaccardIndex::default()),
-            unstable: true,
-        }),
-    );
-    test_document_union!(
-        both_are_unstable_and_have_ji_returns_schema_with_larger_avg_ji_with_additional_properties_true,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: true,
-            jaccard_index: Some(JaccardIndex {
-                avg_ji: 0.5,
-                num_unions: 5,
-                stability_limit: 0.8,
+            schema1 = Schema::AnyOf(set![
+                Schema::Document(Document {
+                    keys: map! {
+                        "a".into() => Schema::Atomic(Atomic::Integer),
+                        "b".into() => Schema::Atomic(Atomic::Integer),
+                    },
+                    required: set! {"a".into(), "b".into()},
+                    additional_properties: false,
+                    ..Default::default()
+                }),
+                Schema::Document(Document {
+                    keys: map! {
+                        "a".into() => Schema::Atomic(Atomic::Integer),
+                        "b".into() => Schema::Atomic(Atomic::Integer),
+                        "c".into() => Schema::Atomic(Atomic::Integer),
+                    },
+                    required: set! {"a".into(), "b".into()},
+                    additional_properties: false,
+                    ..Default::default()
+                })
+            ]),
+            schema2 = Schema::AnyOf(set![
+                Schema::Document(Document {
+                    keys: map! {
+                        "a".into() => Schema::Atomic(Atomic::Decimal),
+                        "b".into() => Schema::Atomic(Atomic::Double),
+                    },
+                    required: set! {"a".into()},
+                    additional_properties: false,
+                    ..Default::default()
+                }),
+                Schema::Document(Document {
+                    keys: map! {
+                        "a".into() => Schema::Atomic(Atomic::Decimal),
+                        "d".into() => Schema::Atomic(Atomic::Double),
+                    },
+                    required: set! {"a".into()},
+                    additional_properties: false,
+                    ..Default::default()
+                }),
+            ])
+        );
+    }
+
+    // The following tests focus primarily on the mechanics of unstable unions: picking a preferred
+    // document and using the preferred document's fields as the basis of the returned value. See
+    // the jaccard_test module for more detailed testing of the JaccardIndex values during unstable
+    // unions.
+    mod unstable {
+        use super::*;
+
+        test_document_union!(
+            when_only_one_is_unstable_result_prefers_stable_doc_properties,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: true,
+                jaccard_index: None,
+                unstable: true,
             }),
-            unstable: true,
-        }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            jaccard_index: Some(JaccardIndex {
-                avg_ji: 0.25,
-                num_unions: 5,
-                stability_limit: 0.8,
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: false,
             }),
-            unstable: true,
-        }),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: false,
-            jaccard_index: Some(JaccardIndex {
-                avg_ji: 0.5,
-                num_unions: 5,
-                stability_limit: 0.8,
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"b".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: true,
             }),
-            unstable: true,
-        }),
-    );
-    test_document_union!(
-        both_are_unstable_and_have_equal_ji_returns_left_with_additional_properties_true,
-        expected = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: true,
-            jaccard_index: Some(JaccardIndex::default()),
-            unstable: true,
-        }),
-        schema1 = Schema::Document(Document {
-            keys: map! {
-                "a".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"a".into()},
-            additional_properties: false,
-            jaccard_index: Some(JaccardIndex::default()),
-            unstable: true,
-        }),
-        schema2 = Schema::Document(Document {
-            keys: map! {
-                "b".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"b".into()},
-            additional_properties: false,
-            jaccard_index: Some(JaccardIndex::default()),
-            unstable: true,
-        }),
-    );
+        );
+        test_document_union!(
+            when_only_one_is_unstable_result_prefers_stable_doc_properties_order_does_not_matter,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: true,
+                jaccard_index: None,
+                unstable: true,
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: true,
+            }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"b".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: false,
+            }),
+        );
+        test_document_union!(
+            when_only_one_is_unstable_update_and_retain_only_stable_keys_and_overlapping_required,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::AnyOf(set! {
+                        Schema::Atomic(Atomic::Integer),
+                        Schema::Atomic(Atomic::String),
+                    }),
+                },
+                required: set! {"a".into()},
+                additional_properties: true,
+                jaccard_index: None,
+                unstable: true,
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: false,
+            }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::String),
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into(), "b".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: true,
+            }),
+        );
+        test_document_union!(
+            when_all_keys_overlap_only_set_additional_properties_true_if_pref_doc_already_does,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::AnyOf(set! {
+                        Schema::Atomic(Atomic::Integer),
+                        Schema::Atomic(Atomic::String),
+                    }),
+                },
+                required: set! {"a".into()},
+                additional_properties: true,
+                jaccard_index: None,
+                unstable: true,
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: true,
+            }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::String),
+                },
+                required: set! {"a".into()},
+                additional_properties: true,
+                jaccard_index: None,
+                unstable: false,
+            }),
+        );
+        test_document_union!(
+            both_are_unstable_and_no_ji_prefers_left,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: true,
+                jaccard_index: None,
+                unstable: true,
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: true,
+            }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"b".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: true,
+            }),
+        );
+        test_document_union!(
+            both_are_unstable_and_only_left_has_ji_prefers_left,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: true,
+                jaccard_index: Some(JaccardIndex::default()),
+                unstable: true,
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: Some(JaccardIndex::default()),
+                unstable: true,
+            }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"b".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: true,
+            }),
+        );
+        test_document_union!(
+            both_are_unstable_and_only_right_has_ji_prefers_right,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: true,
+                jaccard_index: Some(JaccardIndex::default()),
+                unstable: true,
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: None,
+                unstable: true,
+            }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"b".into()},
+                additional_properties: false,
+                jaccard_index: Some(JaccardIndex::default()),
+                unstable: true,
+            }),
+        );
+        test_document_union!(
+            both_are_unstable_and_have_ji_prefers_schema_with_larger_avg_ji_left,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: true,
+                jaccard_index: Some(JaccardIndex {
+                    // (.5 * 5 + .25 * 5) / 10
+                    avg_ji: 0.375,
+                    // 5 + 5
+                    num_unions: 10,
+                    stability_limit: 0.8,
+                }),
+                unstable: true,
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: Some(JaccardIndex {
+                    avg_ji: 0.5,
+                    num_unions: 5,
+                    stability_limit: 0.8,
+                }),
+                unstable: true,
+            }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"b".into()},
+                additional_properties: false,
+                jaccard_index: Some(JaccardIndex {
+                    avg_ji: 0.25,
+                    num_unions: 5,
+                    stability_limit: 0.8,
+                }),
+                unstable: true,
+            }),
+        );
+        test_document_union!(
+            both_are_unstable_and_have_ji_prefers_schema_with_larger_avg_ji_right,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: true,
+                jaccard_index: Some(JaccardIndex {
+                    // (.5 * 5 + .25 * 5) / 10
+                    avg_ji: 0.375,
+                    // 5 + 5
+                    num_unions: 10,
+                    stability_limit: 0.8,
+                }),
+                unstable: true,
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: Some(JaccardIndex {
+                    avg_ji: 0.25,
+                    num_unions: 5,
+                    stability_limit: 0.8,
+                }),
+                unstable: true,
+            }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"b".into()},
+                additional_properties: false,
+                jaccard_index: Some(JaccardIndex {
+                    avg_ji: 0.5,
+                    num_unions: 5,
+                    stability_limit: 0.8,
+                }),
+                unstable: true,
+            }),
+        );
+        test_document_union!(
+            both_are_unstable_and_have_equal_ji_prefers_left,
+            expected = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {},
+                additional_properties: true,
+                jaccard_index: Some(JaccardIndex::default()),
+                unstable: true,
+            }),
+            schema1 = Schema::Document(Document {
+                keys: map! {
+                    "a".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"a".into()},
+                additional_properties: false,
+                jaccard_index: Some(JaccardIndex::default()),
+                unstable: true,
+            }),
+            schema2 = Schema::Document(Document {
+                keys: map! {
+                    "b".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! {"b".into()},
+                additional_properties: false,
+                jaccard_index: Some(JaccardIndex::default()),
+                unstable: true,
+            }),
+        );
+    }
 }
 
 // +---------------------+
@@ -3395,8 +3521,9 @@ mod collision_check {
             the following conflicting field(s) to unique names: a\n\tCaused by:\n\tCannot \
             return non-namespaced result set due to field name conflict(s), schema \
             [Document(Document { keys: {\"a\": Atomic(Integer), \"c\": Atomic(Integer)}, \
-            required: {}, additional_properties: false }), Document(Document { keys: {\"a\": \
-            Atomic(Integer)}, required: {}, additional_properties: false })]".to_string())),
+            required: {}, additional_properties: false, unstable: false }), Document(Document \
+            { keys: {\"a\": Atomic(Integer)}, required: {}, additional_properties: false, \
+            unstable: false })]".to_string())),
         instances = {
         "schema" => A_C_DOCUMENT_SCHEMA.clone(),
         "schema_other" => A_DOCUMENT_SCHEMA.clone()
@@ -3409,9 +3536,9 @@ mod collision_check {
             the following conflicting field(s) to unique names: a, c\n\tCaused by:\n\tCannot \
             return non-namespaced result set due to field name conflict(s), schema \
             [Document(Document { keys: {\"a\": Atomic(Integer), \"c\": Atomic(Integer)}, \
-            required: {}, additional_properties: false }), Document(Document { keys: {\"a\": \
-            Atomic(Integer), \"c\": Atomic(Integer)}, required: {}, \
-            additional_properties: false })]".to_string())),
+            required: {}, additional_properties: false, unstable: false }), Document(Document { \
+            keys: {\"a\": Atomic(Integer), \"c\": Atomic(Integer)}, required: {}, \
+            additional_properties: false, unstable: false })]".to_string())),
         instances = {
             "schema" => A_C_DOCUMENT_SCHEMA.clone(),
             "schema_other" => A_C_DOCUMENT_SCHEMA.clone()
@@ -3424,9 +3551,10 @@ mod collision_check {
             the following conflicting field(s) to unique names: a, b, c\n\tCaused by:\n\tCannot \
             return non-namespaced result set due to field name conflict(s), schema \
             [Document(Document { keys: {\"a\": Atomic(Integer), \"b\": Atomic(Integer), \"c\": \
-            Atomic(Integer)}, required: {}, additional_properties: false }), Document(Document \
-            { keys: {\"a\": Atomic(Integer), \"b\": Atomic(Integer), \"c\": Atomic(Integer), \
-            \"d\": Atomic(Integer)}, required: {}, additional_properties: false })]".to_string())),
+            Atomic(Integer)}, required: {}, additional_properties: false, unstable: false }), \
+            Document(Document { keys: {\"a\": Atomic(Integer), \"b\": Atomic(Integer), \"c\": \
+            Atomic(Integer), \"d\": Atomic(Integer)}, required: {}, additional_properties: false, \
+            unstable: false })]".to_string())),
         instances = {
             "schema" => A_B_C_DOCUMENT_SCHEMA.clone(),
             "schema_other" => A_B_C_D_DOCUMENT_SCHEMA.clone()
@@ -3458,11 +3586,12 @@ mod collision_check {
             the following conflicting field(s) to unique names: a, c, b\n\tCaused by:\n\tCannot \
             return non-namespaced result set due to field name conflict(s), schema \
             [Document(Document { keys: {\"a\": Atomic(Integer), \"c\": Atomic(Integer)}, \
-            required: {}, additional_properties: false }), Document(Document { keys: {\"b\": \
-            Atomic(Integer)}, required: {}, additional_properties: false }), Document(Document \
-            { keys: {\"a\": Atomic(Integer), \"c\": Atomic(Integer)}, required: {}, \
-            additional_properties: false }), Document(Document { keys: {\"b\": Atomic(Integer)}, \
-            required: {}, additional_properties: false })]".to_string())),
+            required: {}, additional_properties: false, unstable: false }), Document(Document { \
+            keys: {\"b\": Atomic(Integer)}, required: {}, additional_properties: false, \
+            unstable: false }), Document(Document { keys: {\"a\": Atomic(Integer), \"c\": \
+            Atomic(Integer)}, required: {}, additional_properties: false, unstable: false }), \
+            Document(Document { keys: {\"b\": Atomic(Integer)}, required: {}, \
+            additional_properties: false, unstable: false })]".to_string())),
         instances = {
             "schema_1" => A_C_DOCUMENT_SCHEMA.clone(),
             "schema_2" => B_DOCUMENT_SCHEMA.clone(),

--- a/tests/spec_tests/query_tests/from_flatten.yml
+++ b/tests/spec_tests/query_tests/from_flatten.yml
@@ -78,7 +78,7 @@ tests:
   - description: error if schema's field paths cannot be exhaustively enumerated
     current_db: spec_query_flatten
     query: "SELECT * FROM FLATTEN(noSchemaInfo)"
-    algebrize_error: "cannot exhaustively enumerate all field paths in schema Document(Document { keys: {}, required: {}, additional_properties: true })"
+    algebrize_error: "cannot exhaustively enumerate all field paths in schema Document(Document { keys: {}, required: {}, additional_properties: true, unstable: false })"
 
   - description: error if naming collision MUST occur
     current_db: spec_query_flatten
@@ -88,7 +88,7 @@ tests:
   - description: error if naming collision MAY occur
     current_db: spec_query_flatten
     query: "SELECT * FROM FLATTEN(mayCollide)"
-    algebrize_error: 'cannot exhaustively enumerate all field paths in schema Document(Document { keys: {"_id": Atomic(Integer), "a": Document(Document { keys: {"b": Atomic(Integer)}, required: {"b"}, additional_properties: false })}, required: {"_id", "a"}, additional_properties: true })'
+    algebrize_error: 'cannot exhaustively enumerate all field paths in schema Document(Document { keys: {"_id": Atomic(Integer), "a": Document(Document { keys: {"b": Atomic(Integer)}, required: {"b"}, additional_properties: false, unstable: false })}, required: {"_id", "a"}, additional_properties: true, unstable: false })'
 
   - description: FLATTENing a FLATTENed datasource is allowed
     current_db: spec_query_flatten


### PR DESCRIPTION
This PR just introduces the new idea for updating the union algorithm to more elegantly and accurately handle unstable schemas. It still needs unit test updates, but I wanted to get this out there since I have tested it manually (notes [here](https://docs.google.com/document/d/1ONZzz0mnPwiUiTwylIjqkD4K9ib2ORr1Fa_-DNXH6Rk/edit?tab=t.0)).