### PR TITLE
SQL-3178: Disable Q12 in TPCH monthly benchmark

### DIFF
--- a/benchmark/atlas_sql/normalized/workload_norm_sf0.1.yml
+++ b/benchmark/atlas_sql/normalized/workload_norm_sf0.1.yml
@@ -83,9 +83,13 @@ Actors:
   - LoadConfig:
       Path: ../phase_noop.yml
       Key: NoopPhase
+  # skip reason: SQL-3178 (OR de-optimization regression, query times out)
+  # - LoadConfig:
+  #     Path: phase/q19_normalized.yml
+  #     Key: q19_normalized
   - LoadConfig:
-      Path: phase/q19_normalized.yml
-      Key: q19_normalized
+      Path: ../phase_noop.yml
+      Key: NoopPhase
 
   # skip-reason: SQL-1906
   # - LoadConfig:

--- a/benchmark/atlas_sql/normalized/workload_norm_sf0.1.yml
+++ b/benchmark/atlas_sql/normalized/workload_norm_sf0.1.yml
@@ -53,9 +53,13 @@ Actors:
   - LoadConfig:
       Path: phase/q11_normalized.yml
       Key: q11_normalized
+  # skip reason: SQL-3178 (OR de-optimization regression, query times out)
+  # - LoadConfig:
+  #     Path: phase/q12_normalized.yml
+  #     Key: q12_normalized
   - LoadConfig:
-      Path: phase/q12_normalized.yml
-      Key: q12_normalized
+      Path: ../phase_noop.yml
+      Key: NoopPhase
   - LoadConfig:
       Path: phase/q13_normalized.yml
       Key: q13_normalized


### PR DESCRIPTION
Q12 times out due to the OR de-optimization regression (SQL-3118), consuming the entire 24h task budget and blocking all subsequent queries from running. Replace with NoopPhase to keep phase numbering intact.