### PR TITLE
SQL-3083: Fix inefficiency in match_null_filtering optimization

### DIFF
--- a/mongosql/src/mir/optimizer/match_null_filtering/mod.rs
+++ b/mongosql/src/mir/optimizer/match_null_filtering/mod.rs
@@ -293,22 +293,25 @@ impl Visitor for NullableFieldAccessGatherer {
             }
             Expression::FieldAccess(fa) => {
                 let scope = fa.scope_if_pure();
-                if self.is_collecting && scope == Some(self.scope) && fa.is_nullable {
-                    // Only store nullable "pure" fields in the map.
-                    match fa.to_string_if_pure() {
+                if self.is_collecting {
+                    match scope {
                         None => {
                             self.found_impure = true;
                         }
-                        Some(s) => {
-                            self.filter_fields.insert(s, fa.clone());
+                        Some(s) if s == self.scope && fa.is_nullable => {
+                            if let Some(key) = fa.to_string_if_pure() {
+                                // Only store nullable "pure" fields in the map.
+                                self.filter_fields.insert(key, fa.clone());
 
-                            // If this is a pure field access, mark is as not nullable
-                            // since it will be filtered for nullability before the
-                            // stage containing this access.
-                            let mut fa = fa.clone();
-                            fa.is_nullable = false;
-                            return Expression::FieldAccess(fa);
+                                // If this is a pure field access, mark it as not nullable
+                                // since it will be filtered for nullability before the
+                                // stage containing this access.
+                                let mut fa = fa.clone();
+                                fa.is_nullable = false;
+                                return Expression::FieldAccess(fa);
+                            }
                         }
+                        Some(_) => {}
                     }
                 }
 

--- a/mongosql/src/mir/optimizer/match_null_filtering/test.rs
+++ b/mongosql/src/mir/optimizer/match_null_filtering/test.rs
@@ -790,6 +790,65 @@ mod all_fields_always_nullable {
     );
 }
 
+mod impure_and_pure_field_access {
+    use super::*;
+    
+    test_match_null_filtering!(
+        impure_field_access_with_pure_nullable_field_does_not_flip_semantics,
+        expected = Stage::Filter(Filter {
+            source: Box::new(Stage::Filter(Filter {
+                source: mir_collection("db", "foo"),
+                condition: field_existence_expr("foo", vec!["b"], 0u16, vec![true]),
+                cache: SchemaCache::new(),
+            })),
+            condition: Expression::ScalarFunction(ScalarFunctionApplication {
+                function: ScalarFunction::Gt,
+                args: vec![
+                    Expression::FieldAccess(FieldAccess {
+                        expr: Box::new(Expression::ScalarFunction(ScalarFunctionApplication {
+                            function: ScalarFunction::Coalesce,
+                            args: vec![
+                                field_access_expr("foo", vec!["o1"], 0u16, vec![true]),
+                                field_access_expr("foo", vec!["o2"], 0u16, vec![true]),
+                            ],
+                            is_nullable: true,
+                        })),
+                        field: "a".to_string(),
+                        is_nullable: false,
+                    }),
+                    field_access_expr("foo", vec!["b"], 0u16, vec![false]),
+                ],
+                is_nullable: true,
+            }),
+            cache: SchemaCache::new(),
+        }),
+        expected_changed = true,
+        input = Stage::Filter(Filter {
+            source: mir_collection("db", "foo"),
+            condition: Expression::ScalarFunction(ScalarFunctionApplication {
+                function: ScalarFunction::Gt,
+                args: vec![
+                    Expression::FieldAccess(FieldAccess {
+                        expr: Box::new(Expression::ScalarFunction(ScalarFunctionApplication {
+                            function: ScalarFunction::Coalesce,
+                            args: vec![
+                                field_access_expr("foo", vec!["o1"], 0u16, vec![true]),
+                                field_access_expr("foo", vec!["o2"], 0u16, vec![true]),
+                            ],
+                            is_nullable: true,
+                        })),
+                        field: "a".to_string(),
+                        is_nullable: false,
+                    }),
+                    field_access_expr("foo", vec!["b"], 0u16, vec![true]),
+                ],
+                is_nullable: true,
+            }),
+            cache: SchemaCache::new(),
+        })
+    );
+}
+
 mod mixed_field_nullability {
 
     use super::*;

--- a/mongosql/src/mir/optimizer/match_null_filtering/test.rs
+++ b/mongosql/src/mir/optimizer/match_null_filtering/test.rs
@@ -792,7 +792,7 @@ mod all_fields_always_nullable {
 
 mod impure_and_pure_field_access {
     use super::*;
-    
+
     test_match_null_filtering!(
         impure_field_access_with_pure_nullable_field_does_not_flip_semantics,
         expected = Stage::Filter(Filter {

--- a/mongosql/src/mir/optimizer/match_null_filtering/test.rs
+++ b/mongosql/src/mir/optimizer/match_null_filtering/test.rs
@@ -793,6 +793,11 @@ mod all_fields_always_nullable {
 mod impure_and_pure_field_access {
     use super::*;
 
+    // We artificially set is_nullable to false for this FieldAccess even though that is not a
+    // realistic value for it. In a real query, this FieldAccess would be marked as is_nullable: true.
+    // However, this test aims to demonstrate that the mere presence of impure field paths results
+    // in semantics not being flipped for filtered expressions. Here, we add a null-filter for b,
+    // but still do not flip the is_nullable flag for the Gt since COALESCE(o1, o2).a is impure.
     test_match_null_filtering!(
         impure_field_access_with_pure_nullable_field_does_not_flip_semantics,
         expected = Stage::Filter(Filter {


### PR DESCRIPTION
Fix to allow `found_impure` flag to be set.  

Confirmed by running the schema manager using the test in the JIRA ticket, that the NullableSetter visitor is not entered. 

Added unit test. 

This looked to cover the issue with `Coalesce` so i did not add a separate case in `visit_expression()`. 