### PR TITLE
SQL-3199: initial fix for test schema builder library integration

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1413,6 +1413,14 @@ buildvariants:
       - name: test-go
       - name: .standalone !.7.0 !.8.0 !.rapid !.latest
 
+  - name: rhel89
+    display_name: "RHEL 8.9"
+    run_on: [rhel8.9-large]
+    modules:
+      - sql-engines-common-test-infra
+    tasks:
+      - name: test-schema-builder-library-integration
+
   - name: ubuntu2204
     display_name: "MongoDB Integration Suite"
     tags: ["mongodb-suite-variant"]
@@ -1421,7 +1429,6 @@ buildvariants:
       - sql-engines-common-test-infra
     tasks:
       - name: .standalone
-      - name: test-schema-builder-library-integration
 
   - name: macos
     display_name: "macOS"


### PR DESCRIPTION
Puts test-schema-builder-library back onto the initial host. A successful patch can be found here: https://spruce.corp.mongodb.com/version/69e6bbd0c4efd70007233239/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The more permanent solution will be in common test infra. The data loader uses a single-threaded tokio executor (current_thread). It connects to MongoDB, then does synchronous file I/O to read the large test data (~4 min on Ubuntu). During that read, the executor is fully blocked and the driver's server monitor background tasks cannot run, causing it to time out and clear the connection pool. The permanent fix is to read files before connecting, so no connection is held during the blocking I/O.

I will create patches verifying this change still works on all existing waterfalls and put up a matching PR there.

