### PR TITLE
SQL-718: Re-enable skipped Double literal tests

### DIFF
--- a/tests/spec_tests/query_tests/literal.yml
+++ b/tests/spec_tests/query_tests/literal.yml
@@ -36,28 +36,24 @@ tests:
       - {'': {'_1': {'$date': '2012-01-01T10:10:10.000Z'}}}
 
   - description: Unsigned double literals (no exponent parts)
-    skip_reason: 'SQL-718: fix failing double tests'
     query: "SELECT VALUE {'_1': 0., '_2': 1., '_3': 0.123, '_4': 2.0, '_5': 3.4, '_6': 50.607, '_7': .1} FROM [{}] AS _dual"
     current_db: test
     result:
       - {'': {'_1': 0, '_2': 1, '_3': 0.123, '_4': 2.0, '_5': 3.4, '_6': 50.607, '_7': 0.1}}
 
   - description: Unsigned double literals (exponent parts)
-    skip_reason: 'SQL-718: fix failing double tests'
     query: "SELECT VALUE {'_1': 1e2, '_2': 2E3, '_3': 3.0e4, '_4': 4.567E22, '_5': 8.e23, '_6': 9.E2, '_7': .1e3, '_8': .2E3, '_9': 5e000, '_10': 10E00} FROM [{}] AS _dual"
     current_db: test
     result:
       - {'': {'_1': 100, '_2': 2000, '_3': 30000, '_4': 4.567e+22, '_5': 8e+23, '_6': 900, '_7': 100, '_8': 200, '_9': 5, '_10': 10}}
 
   - description: Signed double literals (no exponent parts)
-    skip_reason: 'SQL-718: fix failing double tests'
     query: "SELECT VALUE {'_1': -0., '_2': +0., '_3': -1., '_4': +1., '_5': -0.123, '_6': +0.123, '_7': -2.0, '_8': +2.0, '_9': -3.4, '_10': +3.4, '_11': -50.607, '_12': +50.607, '_13': -.1, '_14': +.1} FROM [{}] AS _dual"
     current_db: test
     result:
       - {'': {'_1': 0, '_2': 0, '_3': -1, '_4': 1, '_5': -0.123, '_6': 0.123, '_7': -2.0, '_8': 2.0, '_9': -3.4, '_10': 3.4, '_11': -50.607, '_12': 50.607, '_13': -.1, '_14': .1}}
 
   - description: Signed double literals (exponent parts)
-    skip_reason: 'SQL-718: fix failing double tests'
     query: "SELECT VALUE {'_1': -1e-2, '_2': -3.0e+4, '_3': -4.567e22, '_4': +8.e-23, '_5': +.1e+3, '_6': +5e00} FROM [{}] AS _dual"
     current_db: test
     result:


### PR DESCRIPTION
This PR removes `skip_reason: SQL-718` from the tests that were previously blocked on this ticket. The problem described by SQL-718 seems to have gone away: I tested locally and saw these tests pass, and tested on evergreen and saw these tests now pass ([patch](https://spruce.corp.mongodb.com/version/6a0c61ce9492350007d66e66/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)).

I've been looking through the backlog for SQL-3076 research and I've been lightly testing old tickets to see if they are still relevant. Some have been closable purely as "Gone Away" but this is the first that can go away with a small PR. I figured I'd just put it up for review.