### PR TITLE
SQL-3058: Update `enum-iterator` crate minimum to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,22 +971,22 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "0.7.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
 dependencies = [
  "enum-iterator-derive",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "0.7.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1347,6 +1347,7 @@ dependencies = [
  "hickory-proto",
  "idna",
  "ipnet",
+ "jni 0.22.4",
  "rand 0.10.1",
  "thiserror 2.0.17",
  "tinyvec",
@@ -1364,9 +1365,11 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
+ "jni 0.22.4",
  "once_cell",
  "prefix-trie",
  "rand 0.10.1",
+ "ring",
  "thiserror 2.0.17",
  "tinyvec",
  "tracing",
@@ -1385,12 +1388,15 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot 0.12.5",
  "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1791,6 +1797,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1852,7 +1861,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1860,10 +1869,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "js-sys"
@@ -2270,7 +2328,7 @@ dependencies = [
 name = "mongosqltranslate"
 version = "0.0.0"
 dependencies = [
- "jni",
+ "jni 0.21.1",
  "mongodb",
  "mongosql",
  "semver",
@@ -2300,6 +2358,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -2773,6 +2837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prefix-trie"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,12 +2852,6 @@ dependencies = [
  "ipnet",
  "num-traits",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -3210,7 +3274,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -3678,6 +3742,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3877,7 +3957,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -3885,6 +3976,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4180,6 +4281,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/mongosql/Cargo.toml
+++ b/mongosql/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["unbounded_depth"] }
 serde_yaml = { workspace = true }
 serde_stacker = { workspace = true }
-enum-iterator = "0.7.0"
+enum-iterator = "2.1.0"
 tailcall = "1.0.1"
 thiserror = { workspace = true }
 variant_count = "1.1.0"

--- a/mongosql/src/json_schema/mod.rs
+++ b/mongosql/src/json_schema/mod.rs
@@ -2,7 +2,7 @@
 mod test;
 
 use bson::{Bson, Document};
-use enum_iterator::IntoEnumIterator;
+use enum_iterator::Sequence;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
@@ -45,7 +45,7 @@ pub enum BsonType {
     Multiple(Vec<BsonTypeName>),
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, IntoEnumIterator, Copy, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Sequence, Copy, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum BsonTypeName {
     Object,

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -7,7 +7,7 @@ use crate::{
     schema::Schema::{AnyOf, Unsat},
     set,
 };
-use enum_iterator::IntoEnumIterator;
+use enum_iterator::{all, Sequence};
 use itertools::{Either, Itertools};
 use lazy_static::lazy_static;
 use std::collections::{HashMap, HashSet};
@@ -372,7 +372,7 @@ impl TryFrom<bson::Document> for Schema {
     }
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, IntoEnumIterator)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, Sequence)]
 pub enum Atomic {
     MinKey,
     Null,
@@ -776,7 +776,7 @@ impl TryFrom<Schema> for json_schema::Schema {
 lazy_static! {
     // The types represented by Schema::Any, unrolled into an AnyOf().
     pub static ref UNFOLDED_ANY: Schema = Schema::AnyOf(
-        Atomic::into_enum_iter() // All atomic schemas.
+        all::<Atomic>() // All atomic schemas.
             .map(Schema::Atomic)
             .chain(once(ANY_DOCUMENT.clone())) // Any document.
             .chain(once(ANY_ARRAY.clone())) // Any array.
@@ -1848,7 +1848,7 @@ impl TryFrom<json_schema::Schema> for Schema {
             } => {
                 let bson_type = bson_type.unwrap_or_else(|| {
                     json_schema::BsonType::Multiple(
-                        json_schema::BsonTypeName::into_enum_iter()
+                        all::<json_schema::BsonTypeName>()
                             .filter(|&t| t != json_schema::BsonTypeName::Undefined)
                             .collect(),
                     )


### PR DESCRIPTION
Updated enum-iterator version along with related changes needed for upgrade. 