### PR TITLE
SQL-3171: add release process for schema builder library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,11 +1216,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1347,6 +1349,7 @@ dependencies = [
  "hickory-proto",
  "idna",
  "ipnet",
+ "jni 0.22.4",
  "rand 0.10.1",
  "thiserror 2.0.17",
  "tinyvec",
@@ -1364,9 +1367,11 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
+ "jni 0.22.4",
  "once_cell",
  "prefix-trie",
  "rand 0.10.1",
+ "ring",
  "thiserror 2.0.17",
  "tinyvec",
  "tracing",
@@ -1385,12 +1390,15 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot 0.12.5",
  "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1791,6 +1799,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1852,7 +1863,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1860,10 +1871,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "js-sys"
@@ -2270,7 +2330,7 @@ dependencies = [
 name = "mongosqltranslate"
 version = "0.0.0"
 dependencies = [
- "jni",
+ "jni 0.21.1",
  "mongodb",
  "mongosql",
  "semver",
@@ -2300,6 +2360,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -2773,6 +2839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prefix-trie"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,12 +2854,6 @@ dependencies = [
  "ipnet",
  "num-traits",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -3210,7 +3276,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -3403,6 +3469,9 @@ dependencies = [
  "bson",
  "console_error_panic_hook",
  "futures",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lazy_static",
  "mongodb",
  "mongosql",
@@ -3678,6 +3747,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3877,7 +3962,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -3885,6 +3981,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4180,6 +4286,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1572,7 +1572,7 @@ buildvariants:
 
   - name: schema-builder-library
     display_name: "Schema Builder Library"
-    run_on: [rhel80-small]
+    run_on: [ubuntu2204-small]
     modules:
       - sql-engines-common-test-infra
     tasks:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1018,12 +1018,15 @@ tasks:
             --lib internal_integration_tests
             -- --test-threads=1
 
-  # SQL-3165: uncomment once BuilderOptions is generic over DataService
-  # - name: compile-schema-builder-library
-  #   commands:
-  #     - func: "install rust toolchain"
-  #     - func: "compile schema-builder-library"
-  #     - func: "upload schema-builder-library wasm"
+  - name: compile-schema-builder-library
+    commands:
+      - func: "install rust toolchain"
+      - func: "set and check packages version"
+        vars:
+          cargo_file: "schema-builder-library/Cargo.toml"
+          package_name: "schema-builder-library"
+      - func: "compile schema-builder-library"
+      - func: "upload schema-builder-library wasm"
 
   - name: release
     git_tag_only: true
@@ -1566,11 +1569,10 @@ buildvariants:
     tasks:
       - name: release
 
-  # SQL-3165: uncomment once BuilderOptions is generic over DataService
-  # - name: schema-builder-library
-  #   display_name: "Schema Builder Library"
-  #   run_on: [rhel80-small]
-  #   modules:
-  #     - sql-engines-common-test-infra
-  #   tasks:
-  #     - name: compile-schema-builder-library
+  - name: schema-builder-library
+    display_name: "Schema Builder Library"
+    run_on: [rhel80-small]
+    modules:
+      - sql-engines-common-test-infra
+    tasks:
+      - name: compile-schema-builder-library

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -168,21 +168,20 @@ functions:
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
           wasm-pack build schema-builder-library \
             --release \
-            --target nodejs \
             --no-default-features \
             --features wasm
           wasm-pack pack schema-builder-library
           # normalize the tgz filename so the s3 path is stable across version bumps
           mv schema-builder-library/pkg/schema-builder-library-*.tgz \
-             schema-builder-library/pkg/schema-builder-library-nodejs.tgz
+             schema-builder-library/pkg/schema-builder-library.tgz
 
   "upload schema-builder-library wasm":
     - *assume_role_cmd
     - command: s3.put
       params:
         <<: *evg_bucket_config
-        local_file: mongosql-rs/schema-builder-library/pkg/schema-builder-library-nodejs.tgz
-        remote_file: mongosql-rs/artifacts/${version_id}/${build_variant}/schema-builder-library-nodejs.tgz
+        local_file: mongosql-rs/schema-builder-library/pkg/schema-builder-library.tgz
+        remote_file: mongosql-rs/artifacts/${version_id}/${build_variant}/schema-builder-library.tgz
         permissions: public-read
         content_type: application/gzip
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -165,23 +165,26 @@ functions:
         working_dir: mongosql-rs
         script: |
           ${prepare_shell}
-          rustup target add wasm32-unknown-unknown
-          cargo build \
-            --target wasm32-unknown-unknown \
-            --package schema-builder-library \
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          wasm-pack build schema-builder-library \
             --release \
+            --target nodejs \
             --no-default-features \
-            --features=wasm
+            --features wasm
+          wasm-pack pack schema-builder-library
+          # normalize the tgz filename so the s3 path is stable across version bumps
+          mv schema-builder-library/pkg/schema-builder-library-*.tgz \
+             schema-builder-library/pkg/schema-builder-library-nodejs.tgz
 
   "upload schema-builder-library wasm":
     - *assume_role_cmd
     - command: s3.put
       params:
         <<: *evg_bucket_config
-        local_file: mongosql-rs/target/wasm32-unknown-unknown/release/schema_builder_library.wasm
-        remote_file: mongosql-rs/artifacts/${version_id}/${build_variant}/schema_builder_library.wasm
+        local_file: mongosql-rs/schema-builder-library/pkg/schema-builder-library-nodejs.tgz
+        remote_file: mongosql-rs/artifacts/${version_id}/${build_variant}/schema-builder-library-nodejs.tgz
         permissions: public-read
-        content_type: application/wasm
+        content_type: application/gzip
 
   # "libmongosqltranslate" is the name of the library we release for on-prem SQL.
   "compile libmongosqltranslate":

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -38,6 +38,7 @@ include:
   # https://jira.mongodb.org/browse/DEVPROD-12779
   # - filename: evergreen/grpc.yml
   - filename: evergreen/mongosqltranslate.yml
+  - filename: evergreen/schema-builder-library.yml
   - filename: evergreen/suite-tasks.yml
   - filename: evergreen/configs/benchmark_util.yml
     module: sql-engines-common-test-infra

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1577,3 +1577,5 @@ buildvariants:
       - sql-engines-common-test-infra
     tasks:
       - name: compile-schema-builder-library
+      - name: sign-schema-builder-library
+        run_on: ubuntu2204-large

--- a/evergreen/create-expansions.sh
+++ b/evergreen/create-expansions.sh
@@ -24,7 +24,7 @@ if [ "Windows_NT" = "$OS" ]; then
 fi
 export PATH="$GOROOT/bin:$PATH"
 if [[ "${triggered_by_git_tag}" != "" ]]; then
-    export release_version=$(echo ${triggered_by_git_tag} | sed -E 's/^(v|libv)//')
+    export release_version=$(echo ${triggered_by_git_tag} | sed -E 's/^(v|libv|sbl)//')
 else
     export release_version=snapshot
 fi

--- a/evergreen/schema-builder-library.yml
+++ b/evergreen/schema-builder-library.yml
@@ -16,42 +16,42 @@ functions:
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm
-        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm
-        remote_file: schema-builder-library/schema_builder_library-v${release_version}.wasm
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz
+        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz
         bucket: translators-connectors-releases
         permissions: public-read
-        content_type: application/wasm
-        display_name: schema_builder_library-v${release_version}.wasm
+        content_type: application/gzip
+        display_name: schema-builder-library-nodejs-v${release_version}.tgz
     # signature file
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm.sig
-        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm.sig
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz.sig
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz.sig
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm.sig
-        remote_file: schema-builder-library/schema_builder_library-v${release_version}.wasm.sig
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz.sig
+        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz.sig
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
-        display_name: schema_builder_library-v${release_version}.wasm.sig
+        display_name: schema-builder-library-nodejs-v${release_version}.tgz.sig
 
   "sign schema-builder-library":
     - *assume_role_cmd
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm
-        local_file: mongosql-rs/schema_builder_library.wasm
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz
+        local_file: mongosql-rs/schema-builder-library-nodejs.tgz
     - command: shell.exec
       type: system
       retry_on_failure: true
@@ -74,7 +74,7 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --yes -v --armor -o schema_builder_library.wasm.sig --detach-sign schema_builder_library.wasm"
+            /bin/bash -c "gpgloader && gpg --yes -v --armor -o schema-builder-library-nodejs.tgz.sig --detach-sign schema-builder-library-nodejs.tgz"
     - command: shell.exec
       type: system
       params:
@@ -90,12 +90,12 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --verify schema_builder_library.wasm.sig schema_builder_library.wasm"
+            /bin/bash -c "gpgloader && gpg --verify schema-builder-library-nodejs.tgz.sig schema-builder-library-nodejs.tgz"
     - command: s3.put
       params:
         <<: *evg_bucket_config
-        local_file: mongosql-rs/schema_builder_library.wasm.sig
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm.sig
+        local_file: mongosql-rs/schema-builder-library-nodejs.tgz.sig
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz.sig
         permissions: public-read
         content_type: application/octet-stream
 
@@ -110,11 +110,11 @@ functions:
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/papertrail/schema_builder_library-v${release_version}.wasm
-        remote_file: schema-builder-library/schema_builder_library-v${release_version}.wasm
+        local_file: mongosql-rs/papertrail/schema-builder-library-nodejs-v${release_version}.tgz
+        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz
         bucket: translators-connectors-releases
         permissions: public-read
-        content_type: application/wasm
+        content_type: application/gzip
     - command: papertrail.trace
       params:
         work_dir: mongosql-rs

--- a/evergreen/schema-builder-library.yml
+++ b/evergreen/schema-builder-library.yml
@@ -16,42 +16,42 @@ functions:
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz
-        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library.tgz
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library.tgz
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz
-        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library.tgz
+        remote_file: schema-builder-library/schema-builder-library-v${release_version}.tgz
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/gzip
-        display_name: schema-builder-library-nodejs-v${release_version}.tgz
+        display_name: schema-builder-library-v${release_version}.tgz
     # signature file
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz.sig
-        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz.sig
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library.tgz.sig
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library.tgz.sig
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz.sig
-        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz.sig
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library.tgz.sig
+        remote_file: schema-builder-library/schema-builder-library-v${release_version}.tgz.sig
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
-        display_name: schema-builder-library-nodejs-v${release_version}.tgz.sig
+        display_name: schema-builder-library-v${release_version}.tgz.sig
 
   "sign schema-builder-library":
     - *assume_role_cmd
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz
-        local_file: mongosql-rs/schema-builder-library-nodejs.tgz
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library.tgz
+        local_file: mongosql-rs/schema-builder-library.tgz
     - command: shell.exec
       type: system
       retry_on_failure: true
@@ -74,7 +74,7 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --yes -v --armor -o schema-builder-library-nodejs.tgz.sig --detach-sign schema-builder-library-nodejs.tgz"
+            /bin/bash -c "gpgloader && gpg --yes -v --armor -o schema-builder-library.tgz.sig --detach-sign schema-builder-library.tgz"
     - command: shell.exec
       type: system
       params:
@@ -90,12 +90,12 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --verify schema-builder-library-nodejs.tgz.sig schema-builder-library-nodejs.tgz"
+            /bin/bash -c "gpgloader && gpg --verify schema-builder-library.tgz.sig schema-builder-library.tgz"
     - command: s3.put
       params:
         <<: *evg_bucket_config
-        local_file: mongosql-rs/schema-builder-library-nodejs.tgz.sig
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz.sig
+        local_file: mongosql-rs/schema-builder-library.tgz.sig
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library.tgz.sig
         permissions: public-read
         content_type: application/octet-stream
 
@@ -110,8 +110,8 @@ functions:
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/papertrail/schema-builder-library-nodejs-v${release_version}.tgz
-        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz
+        local_file: mongosql-rs/papertrail/schema-builder-library-v${release_version}.tgz
+        remote_file: schema-builder-library/schema-builder-library-v${release_version}.tgz
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/gzip

--- a/evergreen/schema-builder-library.yml
+++ b/evergreen/schema-builder-library.yml
@@ -1,0 +1,162 @@
+variables:
+  - &assume_role_cmd
+    command: ec2.assume_role
+    params:
+      role_arn: ${assume_role_arn}
+      duration_seconds: 3600
+  - &evg_bucket_config
+    aws_key: ${AWS_ACCESS_KEY_ID}
+    aws_secret: ${AWS_SECRET_ACCESS_KEY}
+    aws_session_token: ${AWS_SESSION_TOKEN}
+    bucket: mciuploads
+
+functions:
+  "upload schema-builder-library release":
+    - *assume_role_cmd
+    - command: s3.get
+      params:
+        <<: *evg_bucket_config
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm
+        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm
+    - command: s3.put
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm
+        remote_file: schema-builder-library/schema_builder_library-v${release_version}.wasm
+        bucket: translators-connectors-releases
+        permissions: public-read
+        content_type: application/wasm
+        display_name: schema_builder_library-v${release_version}.wasm
+
+  "trace schema-builder-library artifacts":
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: mongosql-rs
+        script: |
+          mkdir -p papertrail
+    - command: s3.get
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongosql-rs/papertrail/schema_builder_library-v${release_version}.wasm
+        remote_file: schema-builder-library/schema_builder_library-v${release_version}.wasm
+        bucket: translators-connectors-releases
+        permissions: public-read
+        content_type: application/wasm
+    - command: papertrail.trace
+      params:
+        work_dir: mongosql-rs
+        key_id: ${mongosql_papertrail_id}
+        secret_key: ${mongosql_papertrail_key}
+        product: schema-builder-library
+        version: ${release_version}
+        filenames:
+          - papertrail/*
+
+tasks:
+  - name: schema-builder-library-release
+    git_tag_only: true
+    depends_on:
+      - name: compile-schema-builder-library
+        variant: "schema-builder-library"
+    commands:
+      - func: "upload schema-builder-library release"
+
+  - name: trace-schema-builder-library-artifacts
+    git_tag_only: true
+    depends_on:
+      - name: schema-builder-library-release
+    commands:
+      - func: "trace schema-builder-library artifacts"
+
+  - name: schema-builder-library-sbom
+    commands:
+      - func: "install rust toolchain"
+      - func: "set and check packages version"
+        vars:
+          cargo_file: "schema-builder-library/Cargo.toml"
+          package_name: "schema-builder-library"
+      - func: "generate SBOM"
+        vars:
+          project_folder: "schema-builder-library"
+      - func: "scan SBOM"
+        vars:
+          project_folder: "schema-builder-library"
+      - func: "augment SBOM"
+        vars:
+          project_folder: "schema-builder-library"
+
+  - name: schema-builder-library-static-code-analysis
+    commands:
+      - func: "generate static code analysis"
+
+  - name: schema-builder-library-ssdlc-artifacts-release
+    run_on: ubuntu2204-small
+    git_tag_only: true
+    depends_on:
+      - name: "schema-builder-library-release"
+        variant: "schema-builder-library-release"
+      - name: "schema-builder-library-sbom"
+        variant: "schema-builder-library-code-quality-security"
+      - name: "schema-builder-library-static-code-analysis"
+        variant: "schema-builder-library-code-quality-security"
+    exec_timeout_secs: 300 # 5m
+    commands:
+      - func: "publish static code analysis"
+        vars:
+          project_folder: "schema-builder-library"
+      - func: "publish augmented SBOM"
+        vars:
+          project_folder: "schema-builder-library"
+      - func: "generate compliance report"
+        vars:
+          project_folder: "schema-builder-library"
+      - func: "publish compliance report"
+        vars:
+          project_folder: "schema-builder-library"
+
+  - name: schema-builder-library-ssdlc-artifacts-snapshot
+    run_on: ubuntu2204-small
+    allow_for_git_tag: false
+    depends_on:
+      - name: "schema-builder-library-sbom"
+        variant: "schema-builder-library-code-quality-security"
+      - name: "schema-builder-library-static-code-analysis"
+        variant: "schema-builder-library-code-quality-security"
+    exec_timeout_secs: 300 # 5m
+    commands:
+      - func: "publish static code analysis"
+        vars:
+          project_folder: "schema-builder-library"
+      - func: "publish augmented SBOM"
+        vars:
+          project_folder: "schema-builder-library"
+      - func: "generate compliance report"
+        vars:
+          project_folder: "schema-builder-library"
+      - func: "publish compliance report"
+        vars:
+          project_folder: "schema-builder-library"
+
+buildvariants:
+  - name: schema-builder-library-release
+    display_name: "Schema Builder Library Release"
+    run_on: [ubuntu2004-large]
+    modules:
+      - sql-engines-common-test-infra
+    tasks:
+      - name: schema-builder-library-release
+      - name: trace-schema-builder-library-artifacts
+      - name: schema-builder-library-ssdlc-artifacts-release
+
+  - name: schema-builder-library-code-quality-security
+    display_name: "Schema Builder Library Code Quality and Security"
+    run_on: [ubuntu2204-small]
+    modules:
+      - sql-engines-common-test-infra
+    tasks:
+      - name: schema-builder-library-sbom
+      - name: schema-builder-library-static-code-analysis
+      - name: schema-builder-library-ssdlc-artifacts-snapshot

--- a/evergreen/schema-builder-library.yml
+++ b/evergreen/schema-builder-library.yml
@@ -133,6 +133,10 @@ tasks:
         variant: "schema-builder-library"
       - name: sign-schema-builder-library
         variant: "schema-builder-library"
+      - name: schema-builder-library-sbom
+        variant: "schema-builder-library-code-quality-security"
+      - name: schema-builder-library-static-code-analysis
+        variant: "schema-builder-library-code-quality-security"
     commands:
       - func: "upload schema-builder-library release"
 

--- a/evergreen/schema-builder-library.yml
+++ b/evergreen/schema-builder-library.yml
@@ -28,6 +28,76 @@ functions:
         permissions: public-read
         content_type: application/wasm
         display_name: schema_builder_library-v${release_version}.wasm
+    # signature file
+    - command: s3.get
+      params:
+        <<: *evg_bucket_config
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm.sig
+        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm.sig
+    - command: s3.put
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm.sig
+        remote_file: schema-builder-library/schema_builder_library-v${release_version}.wasm.sig
+        bucket: translators-connectors-releases
+        permissions: public-read
+        content_type: application/octet-stream
+        display_name: schema_builder_library-v${release_version}.wasm.sig
+
+  "sign schema-builder-library":
+    - *assume_role_cmd
+    - command: s3.get
+      params:
+        <<: *evg_bucket_config
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm
+        local_file: mongosql-rs/schema_builder_library.wasm
+    - command: shell.exec
+      type: system
+      retry_on_failure: true
+      params:
+        silent: true
+        script: |
+          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
+    - command: shell.exec
+      type: system
+      params:
+        silent: true
+        env:
+          GRS_CONFIG_USER1_USERNAME: "${garasign_username}"
+          GRS_CONFIG_USER1_PASSWORD: "${garasign_password}"
+        working_dir: mongosql-rs
+        script: |
+          docker run \
+            -e GRS_CONFIG_USER1_USERNAME \
+            -e GRS_CONFIG_USER1_PASSWORD \
+            --rm \
+            -v $(pwd):$(pwd) -w $(pwd) \
+            ${garasign_gpg_image} \
+            /bin/bash -c "gpgloader && gpg --yes -v --armor -o schema_builder_library.wasm.sig --detach-sign schema_builder_library.wasm"
+    - command: shell.exec
+      type: system
+      params:
+        silent: false
+        env:
+          GRS_CONFIG_USER1_USERNAME: "${garasign_username}"
+          GRS_CONFIG_USER1_PASSWORD: "${garasign_password}"
+        working_dir: mongosql-rs
+        script: |
+          docker run \
+            -e GRS_CONFIG_USER1_USERNAME \
+            -e GRS_CONFIG_USER1_PASSWORD \
+            --rm \
+            -v $(pwd):$(pwd) -w $(pwd) \
+            ${garasign_gpg_image} \
+            /bin/bash -c "gpgloader && gpg --verify schema_builder_library.wasm.sig schema_builder_library.wasm"
+    - command: s3.put
+      params:
+        <<: *evg_bucket_config
+        local_file: mongosql-rs/schema_builder_library.wasm.sig
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm.sig
+        permissions: public-read
+        content_type: application/octet-stream
 
   "trace schema-builder-library artifacts":
     - command: shell.exec
@@ -61,8 +131,18 @@ tasks:
     depends_on:
       - name: compile-schema-builder-library
         variant: "schema-builder-library"
+      - name: sign-schema-builder-library
+        variant: "schema-builder-library"
     commands:
       - func: "upload schema-builder-library release"
+
+  - name: sign-schema-builder-library
+    allowed_requesters: ["github_tag", "ad_hoc", "patch"]
+    depends_on:
+      - name: compile-schema-builder-library
+    commands:
+      - func: "sign schema-builder-library"
+        retry_on_failure: true
 
   - name: trace-schema-builder-library-artifacts
     git_tag_only: true

--- a/schema-builder-library/Cargo.toml
+++ b/schema-builder-library/Cargo.toml
@@ -33,6 +33,10 @@ wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4.67", optional = true } # Note, this shouldn't be necessary. See: https://github.com/wasm-bindgen/wasm-bindgen/issues/5104#issuecomment-4223185700
 serde-wasm-bindgen = { version = "0.6", optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
+# three transitive getrandom majors need their wasm backend opted in; features unify per-major
+getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"], optional = true }
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"], optional = true }
+getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"], optional = true }
 
 [dev-dependencies]
 tracing-test = "0.2"
@@ -46,6 +50,9 @@ wasm = [
     "dep:serde-wasm-bindgen",
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
+    "dep:getrandom_02",
+    "dep:getrandom_03",
+    "dep:getrandom_04",
     "dep:tokio",
     "tokio/sync",
     "tokio/macros",
@@ -58,5 +65,8 @@ expect_used = "deny"
 
 [package.metadata.cargo-machete]
 ignored = [
-    "wasm-bindgen-futures" # Note, this should be removed when the following is resolved: https://github.com/wasm-bindgen/wasm-bindgen/issues/5104#issuecomment-4223185700
+    "wasm-bindgen-futures", # Note, this should be removed when the following is resolved: https://github.com/wasm-bindgen/wasm-bindgen/issues/5104#issuecomment-4223185700
+    "getrandom_02",
+    "getrandom_03",
+    "getrandom_04",
 ]


### PR DESCRIPTION
adds ssdlc and release process for schema builder library, and enables tag triggered releases under `sblX.X.X`

Dry run found [here](https://spruce.corp.mongodb.com/version/6a1906a65d4a03000790442f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC): contains sbom, static analysis, compiled and signed wasm file. 

What is not tested here is the s3 process moving things from mciuploads to translators-connectors-releases. I could not get tag triggered releases working because (I think) the underlying changes were not yet on main. I have added it to the evergreen settings though, and plan to try it when this merges.