### PR TITLE
[SQL-3299] Support NOT in air Match Language definitions

### DIFF
--- a/mongosql/src/air/definitions.rs
+++ b/mongosql/src/air/definitions.rs
@@ -720,6 +720,7 @@ pub struct Reduce {
 pub enum MatchQuery {
     Or(Vec<MatchQuery>),
     And(Vec<MatchQuery>),
+    Not(Box<MatchQuery>),
     Type(MatchLanguageType),
     Regex(MatchLanguageRegex),
     ElemMatch(ElemMatch),

--- a/mongosql/src/codegen/match_query.rs
+++ b/mongosql/src/codegen/match_query.rs
@@ -63,7 +63,7 @@ impl MqlCodeGenerator {
     /// Codegens `$not` scoped to a field's operator expression (mirroring how `NotIn` wraps
     /// `$in`), since `$not` — unlike `$and`/`$or`/`$nor` — is not a valid top-level `$match`
     /// boolean operator.
-    /// For
+    /// $and and $or are translated to use $nor instead, since $not is not allowed in top level expressions.
     fn codegen_match_not(&self, inner: air::MatchQuery) -> Result<Bson> {
         match inner {
             // $not is not allowed in top level expressions, so we use the $nor operator instead for $and, and $or.
@@ -83,7 +83,10 @@ impl MqlCodeGenerator {
                 Ok(match inner_codegen {
                     // Field-scoped operator, e.g. {"age": {"$gt": 10}} -> {"age": {"$not": {"$gt": 10}}}
                     Bson::Document(doc) if doc.len() == 1 => {
-                        let (key, value) = doc.into_iter().next().expect("checked len == 1");
+                        let (key, value) = doc
+                            .into_iter()
+                            .next()
+                            .expect("Match document expected to have 1 key but had 0.");
                         match value {
                             Bson::Document(_) => bson!({ key: { "$not": value } }),
                             // Fieldless operator (e.g. a comparison nested inside $elemMatch, which has

--- a/mongosql/src/codegen/match_query.rs
+++ b/mongosql/src/codegen/match_query.rs
@@ -26,6 +26,7 @@ impl MqlCodeGenerator {
         match q {
             Or(v) => self.codegen_match_logical_operator("$or", v),
             And(v) => self.codegen_match_logical_operator("$and", v),
+            Not(inner) => self.codegen_match_logical_operator("$not", vec![*inner]),
             Type(t) => self.codegen_match_type(t),
             Regex(r) => self.codegen_match_regex(r),
             ElemMatch(em) => self.codegen_match_elem_match(em),

--- a/mongosql/src/codegen/match_query.rs
+++ b/mongosql/src/codegen/match_query.rs
@@ -26,7 +26,7 @@ impl MqlCodeGenerator {
         match q {
             Or(v) => self.codegen_match_logical_operator("$or", v),
             And(v) => self.codegen_match_logical_operator("$and", v),
-            Not(inner) => self.codegen_match_logical_operator("$not", vec![*inner]),
+            Not(inner) => self.codegen_match_not(*inner),
             Type(t) => self.codegen_match_type(t),
             Regex(r) => self.codegen_match_regex(r),
             ElemMatch(em) => self.codegen_match_elem_match(em),
@@ -58,6 +58,36 @@ impl MqlCodeGenerator {
                 }
             })),
         }
+    }
+
+    /// Codegens `$not` scoped to a field's operator expression (mirroring how `NotIn` wraps
+    /// `$in`), since `$not` — unlike `$and`/`$or`/`$nor` — is not a valid top-level `$match`
+    /// boolean operator.
+    fn codegen_match_not(&self, inner: air::MatchQuery) -> Result<Bson> {
+        let inner = self.codegen_match_query(inner)?;
+        Ok(match inner {
+            // Field-scoped operator, e.g. {"age": {"$gt": 10}} -> {"age": {"$not": {"$gt": 10}}}
+            Bson::Document(doc) if doc.len() == 1 => {
+                let (key, value) = doc.into_iter().next().expect("checked len == 1");
+                match value {
+                    Bson::Document(_) => bson!({ key: { "$not": value } }),
+                    // Fieldless operator (e.g. a comparison nested inside $elemMatch, which has
+                    // no field ref of its own), e.g. {"$gt": 10} -> {"$not": {"$gt": 10}}
+                    _ => bson!({ "$not": { key: value } }),
+                }
+            }
+            // Anything else. This covers two different situations:
+            // - A fieldless *multi*-key operator document, e.g. a $regex nested inside
+            //   $elemMatch (which has no field ref of its own) codegens to {"$regex": ..,
+            //   "$options": ..}; wrapping the whole thing correctly produces {"$not": {"$regex":
+            //   .., "$options": ..}} (see `fieldless_regex`).
+            // - A query that isn't a single field-scoped operator expression at all: $and/$or
+            //   (whose value is an array of conditions, see `not_and`/`not_or`) or the `False`
+            //   sentinel's {"_id": ..., "$expr": false} (see `constant_false`). These don't have
+            //   a single, fully-specified valid $match shape when negated, so wrapping the whole
+            //   document here is a safe placeholder.
+            bson => bson!({ "$not": bson }),
+        })
     }
 
     fn codegen_match_logical_operator(

--- a/mongosql/src/codegen/match_query.rs
+++ b/mongosql/src/codegen/match_query.rs
@@ -76,16 +76,7 @@ impl MqlCodeGenerator {
                     _ => bson!({ "$not": { key: value } }),
                 }
             }
-            // Anything else. This covers two different situations:
-            // - A fieldless *multi*-key operator document, e.g. a $regex nested inside
-            //   $elemMatch (which has no field ref of its own) codegens to {"$regex": ..,
-            //   "$options": ..}; wrapping the whole thing correctly produces {"$not": {"$regex":
-            //   .., "$options": ..}} (see `fieldless_regex`).
-            // - A query that isn't a single field-scoped operator expression at all: $and/$or
-            //   (whose value is an array of conditions, see `not_and`/`not_or`) or the `False`
-            //   sentinel's {"_id": ..., "$expr": false} (see `constant_false`). These don't have
-            //   a single, fully-specified valid $match shape when negated, so wrapping the whole
-            //   document here is a safe placeholder.
+            // Fieldless operator, e.g. {"$gt": 10} -> {"$not": {"$gt": 10}}
             bson => bson!({ "$not": bson }),
         })
     }

--- a/mongosql/src/codegen/match_query.rs
+++ b/mongosql/src/codegen/match_query.rs
@@ -63,22 +63,39 @@ impl MqlCodeGenerator {
     /// Codegens `$not` scoped to a field's operator expression (mirroring how `NotIn` wraps
     /// `$in`), since `$not` — unlike `$and`/`$or`/`$nor` — is not a valid top-level `$match`
     /// boolean operator.
+    /// For
     fn codegen_match_not(&self, inner: air::MatchQuery) -> Result<Bson> {
-        let inner = self.codegen_match_query(inner)?;
-        Ok(match inner {
-            // Field-scoped operator, e.g. {"age": {"$gt": 10}} -> {"age": {"$not": {"$gt": 10}}}
-            Bson::Document(doc) if doc.len() == 1 => {
-                let (key, value) = doc.into_iter().next().expect("checked len == 1");
-                match value {
-                    Bson::Document(_) => bson!({ key: { "$not": value } }),
-                    // Fieldless operator (e.g. a comparison nested inside $elemMatch, which has
-                    // no field ref of its own), e.g. {"$gt": 10} -> {"$not": {"$gt": 10}}
-                    _ => bson!({ "$not": { key: value } }),
-                }
+        match inner {
+            // $not is not allowed in top level expressions, so we use the $nor operator instead for $and, and $or.
+            // Output will look like
+            //
+            // $nor: [
+            //     { $and: [ ... ] }
+            // ]
+            //
+            // We can translate OR directly to $nor because it's the logical negation of OR.
+            air::MatchQuery::Or(v) => self.codegen_match_logical_operator("$nor", v),
+            air::MatchQuery::And(v) => {
+                self.codegen_match_logical_operator("$nor", vec![air::MatchQuery::And(v)])
             }
-            // Fieldless operator, e.g. {"$gt": 10} -> {"$not": {"$gt": 10}}
-            bson => bson!({ "$not": bson }),
-        })
+            _ => {
+                let inner_codegen = self.codegen_match_query(inner)?;
+                Ok(match inner_codegen {
+                    // Field-scoped operator, e.g. {"age": {"$gt": 10}} -> {"age": {"$not": {"$gt": 10}}}
+                    Bson::Document(doc) if doc.len() == 1 => {
+                        let (key, value) = doc.into_iter().next().expect("checked len == 1");
+                        match value {
+                            Bson::Document(_) => bson!({ key: { "$not": value } }),
+                            // Fieldless operator (e.g. a comparison nested inside $elemMatch, which has
+                            // no field ref of its own), e.g. {"$gt": 10} -> {"$not": {"$gt": 10}}
+                            _ => bson!({ "$not": { key: value } }),
+                        }
+                    }
+                    // Fieldless operator, e.g. {"$gt": 10} -> {"$not": {"$gt": 10}}
+                    bson => bson!({ "$not": bson }),
+                })
+            }
+        }
     }
 
     fn codegen_match_logical_operator(

--- a/mongosql/src/codegen/test/match_query.rs
+++ b/mongosql/src/codegen/test/match_query.rs
@@ -252,12 +252,12 @@ mod not {
     );
 
     test_codegen_match_query!(
-        binary_comparison,
-        expected = Ok(bson!({"$not": {"$gt": 10}})),
+        negate_binary_comparison,
+        expected = Ok(bson!({"x": {"$not": {"$gt": 10}}})),
         input = air::MatchQuery::Not(Box::new(air::MatchQuery::Comparison(
             air::MatchLanguageComparison {
                 function: air::MatchLanguageComparisonOp::Gt,
-                input: None,
+                input: Some("x".to_string().into()),
                 arg: air::LiteralValue::Integer(10),
             }
         )))

--- a/mongosql/src/codegen/test/match_query.rs
+++ b/mongosql/src/codegen/test/match_query.rs
@@ -214,6 +214,51 @@ mod match_constant_false {
     );
 }
 
+mod not {
+    test_codegen_match_query!(
+        single_comparison,
+        expected = Ok(bson!({"$not": [{"age": {"$gt": 10}}]})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::Comparison(
+            air::MatchLanguageComparison {
+                function: air::MatchLanguageComparisonOp::Gt,
+                input: Some("age".to_string().into()),
+                arg: air::LiteralValue::Integer(10),
+            }
+        )))
+    );
+
+    test_codegen_match_query!(
+        not_and,
+        expected =
+            Ok(bson!({"$not": [{"$and": [{"age": {"$gt": 10}}, {"name": {"$eq": "Alice"}}]}]})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::And(vec![
+            air::MatchQuery::Comparison(air::MatchLanguageComparison {
+                function: air::MatchLanguageComparisonOp::Gt,
+                input: Some("age".to_string().into()),
+                arg: air::LiteralValue::Integer(10),
+            }),
+            air::MatchQuery::Comparison(air::MatchLanguageComparison {
+                function: air::MatchLanguageComparisonOp::Eq,
+                input: Some("name".to_string().into()),
+                arg: air::LiteralValue::String("Alice".to_string()),
+            }),
+        ])))
+    );
+
+    // Double negation is structurally valid; simplification is the optimizer's responsibility.
+    test_codegen_match_query!(
+        nested_not,
+        expected = Ok(bson!({"$not": [{"$not": [{"age": {"$gt": 10}}]}]})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::Not(Box::new(
+            air::MatchQuery::Comparison(air::MatchLanguageComparison {
+                function: air::MatchLanguageComparisonOp::Gt,
+                input: Some("age".to_string().into()),
+                arg: air::LiteralValue::Integer(10),
+            })
+        ))))
+    );
+}
+
 mod in_op {
     test_codegen_match_query!(
         in_single,

--- a/mongosql/src/codegen/test/match_query.rs
+++ b/mongosql/src/codegen/test/match_query.rs
@@ -142,6 +142,26 @@ mod elem_match {
             })),
         })
     );
+
+    // A condition nested inside $elemMatch may itself be a Not, e.g. `{a: {$elemMatch: {$not:
+    // {$gt: 10}}}}`. The condition has no field ref of its own (the field is supplied by the
+    // enclosing $elemMatch), which is the fieldless scenario `not::fieldless_comparison`
+    // exercises directly on codegen_match_not; this test proves the full composition through
+    // codegen_match_elem_match.
+    test_codegen_match_query!(
+        not_condition,
+        expected = Ok(bson!({"a": {"$elemMatch": {"$not": {"$gt": 10}}}})),
+        input = air::MatchQuery::ElemMatch(air::ElemMatch {
+            input: "a".to_string().into(),
+            condition: Box::new(air::MatchQuery::Not(Box::new(air::MatchQuery::Comparison(
+                air::MatchLanguageComparison {
+                    function: air::MatchLanguageComparisonOp::Gt,
+                    input: None,
+                    arg: air::LiteralValue::Integer(10),
+                }
+            )))),
+        })
+    );
 }
 
 mod comp {
@@ -214,10 +234,14 @@ mod match_constant_false {
     );
 }
 
+// "$not" nests around the operator expression scoped to a field
+// In practice, the NotComparisonRewritePass optimizes out NOT expressions for comparisons, some of these
+// tests are illustrative, but not necessarily representative of what the optimizer will produce.
 mod not {
+
     test_codegen_match_query!(
         single_comparison,
-        expected = Ok(bson!({"$not": [{"age": {"$gt": 10}}]})),
+        expected = Ok(bson!({"age": {"$not": {"$gt": 10}}})),
         input = air::MatchQuery::Not(Box::new(air::MatchQuery::Comparison(
             air::MatchLanguageComparison {
                 function: air::MatchLanguageComparisonOp::Gt,
@@ -228,9 +252,22 @@ mod not {
     );
 
     test_codegen_match_query!(
+        binary_comparison,
+        expected = Ok(bson!({"$not": {"$gt": 10}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::Comparison(
+            air::MatchLanguageComparison {
+                function: air::MatchLanguageComparisonOp::Gt,
+                input: None,
+                arg: air::LiteralValue::Integer(10),
+            }
+        )))
+    );
+
+    // Negating an $and/$or that spans multiple different fields
+    test_codegen_match_query!(
         not_and,
         expected =
-            Ok(bson!({"$not": [{"$and": [{"age": {"$gt": 10}}, {"name": {"$eq": "Alice"}}]}]})),
+            Ok(bson!({"$not": {"$and": [{"age": {"$gt": 10}}, {"name": {"$eq": "Alice"}}]}})),
         input = air::MatchQuery::Not(Box::new(air::MatchQuery::And(vec![
             air::MatchQuery::Comparison(air::MatchLanguageComparison {
                 function: air::MatchLanguageComparisonOp::Gt,
@@ -248,7 +285,7 @@ mod not {
     // Double negation is structurally valid; simplification is the optimizer's responsibility.
     test_codegen_match_query!(
         nested_not,
-        expected = Ok(bson!({"$not": [{"$not": [{"age": {"$gt": 10}}]}]})),
+        expected = Ok(bson!({"age": {"$not": {"$not": {"$gt": 10}}}})),
         input = air::MatchQuery::Not(Box::new(air::MatchQuery::Not(Box::new(
             air::MatchQuery::Comparison(air::MatchLanguageComparison {
                 function: air::MatchLanguageComparisonOp::Gt,
@@ -256,6 +293,119 @@ mod not {
                 arg: air::LiteralValue::Integer(10),
             })
         ))))
+    );
+
+    // NOT (x IN (1, 2, 3))
+    test_codegen_match_query!(
+        in_op,
+        expected = Ok(bson!({"x": {"$not": {"$in": [1, 2, 3]}}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::In(air::MatchLanguageIn {
+            op: air::MatchLanguageInOp::In,
+            expression: air::FieldRef {
+                parent: None,
+                name: "x".to_string()
+            },
+            array_expression: vec![
+                air::LiteralValue::Integer(1),
+                air::LiteralValue::Integer(2),
+                air::LiteralValue::Integer(3),
+            ],
+        })))
+    );
+
+    // NOT (x NOT IN (1, 2, 3)): double negation composed from Not wrapping In's own NotIn
+    // form (which already codegens to "$not": {"$in": [...]}}).
+    test_codegen_match_query!(
+        not_in_op,
+        expected = Ok(bson!({"x": {"$not": {"$not": {"$in": [1, 2, 3]}}}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::In(air::MatchLanguageIn {
+            op: air::MatchLanguageInOp::NotIn,
+            expression: air::FieldRef {
+                parent: None,
+                name: "x".to_string()
+            },
+            array_expression: vec![
+                air::LiteralValue::Integer(1),
+                air::LiteralValue::Integer(2),
+                air::LiteralValue::Integer(3),
+            ],
+        })))
+    );
+
+    test_codegen_match_query!(
+        regex,
+        expected = Ok(bson!({"title": {"$not": {"$regex": "^T", "$options": ""}}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::Regex(air::MatchLanguageRegex {
+            input: Some("title".to_string().into()),
+            regex: "^T".into(),
+            options: "".into(),
+        })))
+    );
+
+    test_codegen_match_query!(
+        fieldless_regex,
+        expected = Ok(bson!({"$not": {"$regex": "^T", "$options": ""}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::Regex(air::MatchLanguageRegex {
+            input: None,
+            regex: "^T".into(),
+            options: "".into(),
+        })))
+    );
+
+    // Negating an $or that spans multiple different fields hits the same fallback path as
+    // not_and.
+    test_codegen_match_query!(
+        not_or,
+        expected = Ok(bson!({"$not": {"$or": [{"age": {"$gt": 10}}, {"name": {"$eq": "Alice"}}]}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::Or(vec![
+            air::MatchQuery::Comparison(air::MatchLanguageComparison {
+                function: air::MatchLanguageComparisonOp::Gt,
+                input: Some("age".to_string().into()),
+                arg: air::LiteralValue::Integer(10),
+            }),
+            air::MatchQuery::Comparison(air::MatchLanguageComparison {
+                function: air::MatchLanguageComparisonOp::Eq,
+                input: Some("name".to_string().into()),
+                arg: air::LiteralValue::String("Alice".to_string()),
+            }),
+        ])))
+    );
+
+    test_codegen_match_query!(
+        type_op,
+        expected = Ok(bson!({"a": {"$not": {"$exists": false}}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::Type(air::MatchLanguageType {
+            input: Some("a".to_string().into()),
+            target_type: air::TypeOrMissing::Missing,
+        })))
+    );
+
+    test_codegen_match_query!(
+        fieldless_type_op,
+        expected = Ok(bson!({"$not": {"$type": "number"}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::Type(air::MatchLanguageType {
+            input: None,
+            target_type: air::TypeOrMissing::Number,
+        })))
+    );
+
+    test_codegen_match_query!(
+        elem_match,
+        expected = Ok(bson!({"a": {"$not": {"$elemMatch": {"$gte": 1}}}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::ElemMatch(air::ElemMatch {
+            input: "a".to_string().into(),
+            condition: Box::new(air::MatchQuery::Comparison(air::MatchLanguageComparison {
+                function: air::MatchLanguageComparisonOp::Gte,
+                input: None,
+                arg: air::LiteralValue::Integer(1),
+            })),
+        })))
+    );
+
+    test_codegen_match_query!(
+        constant_false,
+        expected = Ok(bson!({"$not": {"_id": bson::Bson::MinKey, "$expr": false}})),
+        input = air::MatchQuery::Not(Box::new(air::MatchQuery::False))
     );
 }
 

--- a/mongosql/src/codegen/test/match_query.rs
+++ b/mongosql/src/codegen/test/match_query.rs
@@ -267,7 +267,7 @@ mod not {
     test_codegen_match_query!(
         not_and,
         expected =
-            Ok(bson!({"$not": {"$and": [{"age": {"$gt": 10}}, {"name": {"$eq": "Alice"}}]}})),
+            Ok(bson!({"$nor": [{"$and": [{"age": {"$gt": 10}}, {"name": {"$eq": "Alice"}}]}]})),
         input = air::MatchQuery::Not(Box::new(air::MatchQuery::And(vec![
             air::MatchQuery::Comparison(air::MatchLanguageComparison {
                 function: air::MatchLanguageComparisonOp::Gt,
@@ -356,7 +356,7 @@ mod not {
     // not_and.
     test_codegen_match_query!(
         not_or,
-        expected = Ok(bson!({"$not": {"$or": [{"age": {"$gt": 10}}, {"name": {"$eq": "Alice"}}]}})),
+        expected = Ok(bson!({"$nor": [{"age": {"$gt": 10}}, {"name": {"$eq": "Alice"}}]})),
         input = air::MatchQuery::Not(Box::new(air::MatchQuery::Or(vec![
             air::MatchQuery::Comparison(air::MatchLanguageComparison {
                 function: air::MatchLanguageComparisonOp::Gt,


### PR DESCRIPTION
## Summary

This PR updates the AIR directory to support the $not operator in Match Stages. 

## Changes

- Introduce a MatchQuery NOT to existing enums
- Wire MatchQuery::Not into a match arm in codegen module
- Unit tests

## Testing

Unit tests to validate that $not is generated from the MatchQuery::Not expression

## Notes

This is a partial implementation. Follow up PRs will wire together the rest of Mongosql so that we can translate $not from SQL all the way to match language. Expect followups that connect the MIR -> AIR stage.

The $not support is based on the documentation for the $not _expression_ operator rather than the query predicate. Documentation can be found here:
https://www.mongodb.com/docs/manual/reference/operator/aggregation/not/