### PR TITLE
SQL-3286: Fix accumulator functions to return correct schemas

### DIFF
--- a/mongosql/src/algebrizer/test/aggregation/mod.rs
+++ b/mongosql/src/algebrizer/test/aggregation/mod.rs
@@ -1,10 +1,13 @@
 #[allow(unused_imports)]
 use crate::{
     ast, map, mir, multimap,
-    schema::{Atomic, Satisfaction, Schema, ANY_DOCUMENT, NUMERIC_OR_NULLISH},
+    schema::{
+        Atomic, Satisfaction, Schema, ANY_DOCUMENT, ANY_DOCUMENT_OR_NULLISH, NUMERIC_OR_NULLISH,
+    },
     test_algebrize, test_algebrize_expr_and_schema_check, unchecked_unique_linked_hash_map,
     usererror::UserError,
 };
+
 test_algebrize!(
     count_star,
     method = algebrize_aggregation,
@@ -497,7 +500,7 @@ test_algebrize_expr_and_schema_check!(
     method = algebrize_aggregation,
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "MergeDocuments",
-        required: ANY_DOCUMENT.clone().into(),
+        required: ANY_DOCUMENT_OR_NULLISH.clone().into(),
         found: Schema::Atomic(Atomic::String).into(),
     })),
     expected_error_code = 1002,

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -1616,10 +1616,7 @@ trait SqlFunction {
                     .unwrap_or_else(|| EMPTY_DOCUMENT.clone()),
                 Schema::Document(d) => Schema::Document(d),
                 Schema::Any => Schema::Document(Document::any()),
-                Schema::Unsat
-                | Schema::Missing
-                | Schema::Atomic(_)
-                | Schema::Array(_) => {
+                Schema::Unsat | Schema::Missing | Schema::Atomic(_) | Schema::Array(_) => {
                     unreachable!()
                 }
             })

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -1607,7 +1607,7 @@ trait SqlFunction {
         // union all AnyOf arg_schemas into union Document schemata
         arg_schemas
             .iter()
-            .filter(|s| state.check_satisfies(s, &ANY_DOCUMENT.clone()))
+            .filter(|s| state.check_satisfies(s, &ANY_DOCUMENT))
             .cloned()
             .map(|s| match s {
                 Schema::AnyOf(ao) => ao

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -8,9 +8,9 @@ use crate::{
     },
     schema::{
         Atomic, Document, ResultSet, Satisfaction, Schema, SchemaEnvironment, ANY_ARRAY,
-        ANY_ARRAY_OR_NULLISH, ANY_DOCUMENT, BOOLEAN_OR_NULLISH, DATE_OR_NULLISH, EMPTY_DOCUMENT,
-        INTEGER_LONG_OR_NULLISH, INTEGER_OR_NULLISH, NULLISH, NUMERIC, NUMERIC_OR_NULLISH,
-        STRING_OR_NULLISH,
+        ANY_ARRAY_OR_NULLISH, ANY_DOCUMENT, ANY_DOCUMENT_OR_NULLISH, BOOLEAN_OR_NULLISH,
+        DATE_OR_NULLISH, EMPTY_DOCUMENT, INTEGER_LONG_OR_NULLISH, INTEGER_OR_NULLISH, NULLISH,
+        NUMERIC, NUMERIC_OR_NULLISH, STRING_OR_NULLISH,
     },
     set,
     util::unique_linked_hash_map::UniqueLinkedHashMap,
@@ -934,14 +934,7 @@ impl AggregationFunction {
                 }
                 arg_schema.upconvert_missing_to_null()
             }
-            MergeDocuments => {
-                self.schema_check_fixed_args(
-                    state,
-                    from_ref(&arg_schema),
-                    from_ref(&ANY_DOCUMENT),
-                )?;
-                arg_schema
-            }
+            MergeDocuments => self.schema_check_merge_objects(state, from_ref(&arg_schema))?,
             Sum => self.get_arithmetic_schema(state, &[arg_schema])?,
         })
     }
@@ -1599,6 +1592,54 @@ trait SqlFunction {
         }
     }
 
+    /// Schema checks the arguments to a $mergeObjects-backed function (the
+    /// scalar MergeObjects and the aggregation MergeDocuments) and returns the
+    /// resulting Document schema. Since $mergeObjects ignores nullish operands
+    /// and returns the empty document when all operands are nullish, the result
+    /// is always a Document.
+    #[allow(clippy::manual_try_fold)]
+    fn schema_check_merge_objects(
+        &self,
+        state: &SchemaInferenceState,
+        arg_schemas: &[Schema],
+    ) -> Result<Schema, Error> {
+        self.schema_check_variadic_args(state, arg_schemas, ANY_DOCUMENT_OR_NULLISH.clone())?;
+        // union all AnyOf arg_schemas into union Document schemata
+        arg_schemas
+            .iter()
+            .filter(|s| state.check_satisfies(s, &ANY_DOCUMENT.clone()))
+            .cloned()
+            .map(|s| match s {
+                Schema::AnyOf(ao) => ao
+                    .into_iter()
+                    .reduce(Schema::document_union)
+                    .unwrap_or_else(|| EMPTY_DOCUMENT.clone()),
+                Schema::Document(d) => Schema::Document(d),
+                Schema::Any => Schema::Document(Document::any()),
+                Schema::Unsat
+                | Schema::Missing
+                | Schema::Atomic(_)
+                | Schema::Array(_) => {
+                    unreachable!()
+                }
+            })
+            .fold(Ok(EMPTY_DOCUMENT.clone()), |acc, curr| {
+                let acc = acc?;
+                let sat = acc.has_overlapping_keys_with(&curr);
+                if sat != Satisfaction::Not {
+                    return Err(Error::CannotMergeObjects(acc.into(), curr.into(), sat));
+                }
+                if let (Schema::Document(mut d1), Schema::Document(d2)) = (acc, curr) {
+                    d1.keys.extend(d2.keys);
+                    d1.required.extend(d2.required);
+                    d1.additional_properties |= d2.additional_properties;
+                    Ok(Schema::Document(d1))
+                } else {
+                    unreachable!();
+                }
+            })
+    }
+
     /// as_str returns a static str representation for the SqlFunction.
     fn as_str(&self) -> &'static str;
 }
@@ -1856,48 +1897,6 @@ impl ScalarFunction {
             }
             MergeObjects => self.schema_check_merge_objects(state, arg_schemas),
         }
-    }
-
-    #[allow(clippy::manual_try_fold)]
-    fn schema_check_merge_objects(
-        &self,
-        state: &SchemaInferenceState,
-        arg_schemas: &[Schema],
-    ) -> Result<Schema, Error> {
-        self.schema_check_variadic_args(state, arg_schemas, ANY_DOCUMENT.clone())?;
-        // union all AnyOf arg_schemas into union Document schemata
-        arg_schemas
-            .iter()
-            .cloned()
-            .map(|s| match s {
-                Schema::AnyOf(ao) => ao
-                    .into_iter()
-                    .reduce(Schema::document_union)
-                    .unwrap_or_else(|| EMPTY_DOCUMENT.clone()),
-                Schema::Document(d) => Schema::Document(d),
-                Schema::Any
-                | Schema::Unsat
-                | Schema::Missing
-                | Schema::Atomic(_)
-                | Schema::Array(_) => {
-                    unreachable!()
-                }
-            })
-            .fold(Ok(EMPTY_DOCUMENT.clone()), |acc, curr| {
-                let acc = acc?;
-                let sat = acc.has_overlapping_keys_with(&curr);
-                if sat != Satisfaction::Not {
-                    return Err(Error::CannotMergeObjects(acc.into(), curr.into(), sat));
-                }
-                if let (Schema::Document(mut d1), Schema::Document(d2)) = (acc, curr) {
-                    d1.keys.extend(d2.keys);
-                    d1.required.extend(d2.required);
-                    d1.additional_properties |= d2.additional_properties;
-                    Ok(Schema::Document(d1))
-                } else {
-                    unreachable!();
-                }
-            })
     }
 
     /// Returns the string and/or null schema for the substring function.

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -924,7 +924,7 @@ impl AggregationFunction {
                 Schema::Atomic(Atomic::Integer),
                 Schema::Atomic(Atomic::Long)
             ]),
-            First | Last => arg_schema,
+            First | Last => arg_schema.upconvert_missing_to_null(),
             Min | Max => {
                 if !state.check_self_comparable(&arg_schema) {
                     return Err(Error::AggregationArgumentMustBeSelfComparable(
@@ -932,7 +932,7 @@ impl AggregationFunction {
                         arg_schema.into(),
                     ));
                 }
-                arg_schema
+                arg_schema.upconvert_missing_to_null()
             }
             MergeDocuments => {
                 self.schema_check_fixed_args(

--- a/mongosql/src/mir/schema/test/expressions/aggregate.rs
+++ b/mongosql/src/mir/schema/test/expressions/aggregate.rs
@@ -533,7 +533,7 @@ mod merge_documents {
         schema_checking_mode = SchemaCheckingMode::Relaxed,
     );
 
-    // In relaxed mode, it is acceptable for the argument's schema can to only
+    // In relaxed mode, it is acceptable for the argument's schema to only
     // MAYBE be a document. As in, it may be nullish or possibly not a document.
     // $mergeObjects always produces a document, so the result must drop Missing
     // and remain a Document rather than upconverting Missing to Null.

--- a/mongosql/src/mir/schema/test/expressions/aggregate.rs
+++ b/mongosql/src/mir/schema/test/expressions/aggregate.rs
@@ -284,6 +284,36 @@ mod first {
             Schema::Atomic(Atomic::Long),
         ])},
     );
+
+    test_schema!(
+        first_upconverts_nested_missing_to_null,
+        expected = Ok(Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Null),
+        ])),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::First,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Missing,
+        ])},
+    );
+
+    test_schema!(
+        first_pure_missing_is_null,
+        expected = Ok(Schema::Atomic(Atomic::Null)),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::First,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::Missing},
+    );
 }
 
 mod last {
@@ -321,6 +351,36 @@ mod last {
             Schema::Atomic(Atomic::Integer),
             Schema::Atomic(Atomic::Long),
         ])},
+    );
+
+    test_schema!(
+        last_upconverts_nested_missing_to_null,
+        expected = Ok(Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Null),
+        ])),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::Last,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Missing,
+        ])},
+    );
+
+    test_schema!(
+        last_upconverts_missing_to_null,
+        expected = Ok(Schema::Atomic(Atomic::Null)),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::Last,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::Missing},
     );
 }
 
@@ -375,6 +435,36 @@ mod max {
             Schema::Atomic(Atomic::Integer),
             Schema::Atomic(Atomic::Long),
         ])},
+    );
+
+    test_schema!(
+        max_upconverts_nested_missing_to_null,
+        expected = Ok(Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Null),
+        ])),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::Max,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Missing,
+        ])},
+    );
+
+    test_schema!(
+        max_upconverts_missing_to_null,
+        expected = Ok(Schema::Atomic(Atomic::Null)),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::Max,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::Missing},
     );
 }
 
@@ -479,6 +569,36 @@ mod min {
             Schema::Atomic(Atomic::Integer),
             Schema::Atomic(Atomic::Long),
         ])},
+    );
+
+    test_schema!(
+        min_upconverts_nested_missing_to_null,
+        expected = Ok(Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Null),
+        ])),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::Min,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Missing,
+        ])},
+    );
+
+    test_schema!(
+        min_upconverts_missing_to_null,
+        expected = Ok(Schema::Atomic(Atomic::Null)),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::Min,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::Missing},
     );
 }
 

--- a/mongosql/src/mir/schema/test/expressions/aggregate.rs
+++ b/mongosql/src/mir/schema/test/expressions/aggregate.rs
@@ -307,7 +307,7 @@ mod first {
     );
 
     test_schema!(
-        first_pure_missing_is_null,
+        first_upconverts_missing_to_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = AggregationExpr::Function(AggregationFunctionApplication {
             function: AggregationFunction::First,

--- a/mongosql/src/mir/schema/test/expressions/aggregate.rs
+++ b/mongosql/src/mir/schema/test/expressions/aggregate.rs
@@ -2,7 +2,8 @@ use crate::{
     map,
     mir::{schema::Error as mir_error, *},
     schema::{
-        Atomic, Document, Satisfaction, Schema, ANY_DOCUMENT_OR_NULLISH, EMPTY_DOCUMENT, NUMERIC_OR_NULLISH,
+        Atomic, Document, Satisfaction, Schema, ANY_DOCUMENT_OR_NULLISH, EMPTY_DOCUMENT,
+        NUMERIC_OR_NULLISH,
     },
     set, test_schema,
 };

--- a/mongosql/src/mir/schema/test/expressions/aggregate.rs
+++ b/mongosql/src/mir/schema/test/expressions/aggregate.rs
@@ -1,7 +1,9 @@
 use crate::{
     map,
     mir::{schema::Error as mir_error, *},
-    schema::{Atomic, Document, Satisfaction, Schema, ANY_DOCUMENT, NUMERIC_OR_NULLISH},
+    schema::{
+        Atomic, Document, Satisfaction, Schema, ANY_DOCUMENT_OR_NULLISH, EMPTY_DOCUMENT, NUMERIC_OR_NULLISH,
+    },
     set, test_schema,
 };
 use std::sync::LazyLock;
@@ -476,7 +478,7 @@ mod merge_documents {
         expected_error_code = 1002,
         expected = Err(mir_error::SchemaChecking {
             name: "MergeDocuments",
-            required: ANY_DOCUMENT.clone().into(),
+            required: ANY_DOCUMENT_OR_NULLISH.clone().into(),
             found: Schema::AnyOf(set![
                 Schema::Atomic(Atomic::Integer),
                 Schema::Atomic(Atomic::String),
@@ -515,6 +517,67 @@ mod merge_documents {
         additional_properties: true,
         ..Default::default()
         })},
+    );
+
+    test_schema!(
+        mergedocuments_on_any,
+        expected = Ok(Schema::Document(Document::any())),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::MergeDocuments,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::Any},
+        schema_checking_mode = SchemaCheckingMode::Relaxed,
+    );
+
+    // In relaxed mode, it is acceptable for the argument's schema can to only
+    // MAYBE be a document. As in, it may be nullish or possibly not a document.
+    // $mergeObjects always produces a document, so the result must drop Missing
+    // and remain a Document rather than upconverting Missing to Null.
+    test_schema!(
+        mergedocuments_relaxed_drops_missing,
+        expected = Ok(EMPTY_DOCUMENT.clone()),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::MergeDocuments,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::AnyOf(set![
+            Schema::Document(Document {
+                keys: map!{"foo".into() => Schema::Atomic(Atomic::Integer)},
+                required: set!{},
+                additional_properties: true,
+                ..Default::default()
+            }),
+            Schema::Missing,
+        ])},
+        schema_checking_mode = SchemaCheckingMode::Relaxed,
+    );
+
+    // Likewise, a non-document atomic that only MAY be a document in
+    // relaxed mode must be dropped from the result, leaving a Document.
+    test_schema!(
+        mergedocuments_relaxed_drops_non_document,
+        expected = Ok(EMPTY_DOCUMENT.clone()),
+        input = AggregationExpr::Function(AggregationFunctionApplication {
+            function: AggregationFunction::MergeDocuments,
+            arg: Box::new(Expression::Reference(("bar", 0u16).into())),
+            distinct: false,
+            arg_is_possibly_doc: Satisfaction::Not,
+        }),
+        schema_env = map! {("bar", 0u16).into() => Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Document(Document {
+                keys: map!{"foo".into() => Schema::Atomic(Atomic::Integer)},
+                required: set!{},
+                additional_properties: true,
+                ..Default::default()
+            }),
+        ])},
+        schema_checking_mode = SchemaCheckingMode::Relaxed,
     );
 }
 

--- a/mongosql/src/mir/schema/test/expressions/scalar_function.rs
+++ b/mongosql/src/mir/schema/test/expressions/scalar_function.rs
@@ -2,8 +2,8 @@ use crate::{
     map,
     mir::{schema::Error as mir_error, *},
     schema::{
-        Atomic, Document, Satisfaction, Schema, ANY_ARRAY, ANY_DOCUMENT, BOOLEAN_OR_NULLISH,
-        INTEGER_OR_NULLISH, NON_NULLISH, NUMERIC_OR_NULLISH, STRING_OR_NULLISH,
+        Atomic, Document, Satisfaction, Schema, ANY_ARRAY, ANY_DOCUMENT, ANY_DOCUMENT_OR_NULLISH,
+        BOOLEAN_OR_NULLISH, INTEGER_OR_NULLISH, NON_NULLISH, NUMERIC_OR_NULLISH, STRING_OR_NULLISH,
     },
     set, test_schema,
 };
@@ -2435,7 +2435,7 @@ mod merge_objects {
         expected_error_code = 1002,
         expected = Err(mir_error::SchemaChecking {
             name: "MergeObjects",
-            required: ANY_DOCUMENT.clone().into(),
+            required: ANY_DOCUMENT_OR_NULLISH.clone().into(),
             found: Schema::Atomic(Atomic::String).into(),
         }),
         input = Expression::ScalarFunction(ScalarFunctionApplication::new(

--- a/mongosql/src/schema/definitions.rs
+++ b/mongosql/src/schema/definitions.rs
@@ -839,6 +839,11 @@ lazy_static! {
         Schema::Atomic(Atomic::Null),
         Schema::Missing,
     ]);
+    pub static ref ANY_DOCUMENT_OR_NULLISH: Schema = Schema::AnyOf(set![
+        Schema::Document(Document::any()),
+        Schema::Atomic(Atomic::Null),
+        Schema::Missing,
+    ]);
     pub static ref BITS_APPLICABLE_OR_NULLISH: Schema = Schema::AnyOf(set![
         Schema::Atomic(Atomic::Integer),
         Schema::Atomic(Atomic::Long),

--- a/tests/spec_tests/type_constraint_tests/group_by.yml
+++ b/tests/spec_tests/type_constraint_tests/group_by.yml
@@ -57,13 +57,11 @@ tests:
 
   - description: MERGE_DOCUMENTS argument must be document
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MERGE_DOCUMENTS(arg1) AS merge"
-    skip_reason: "SQL-590: Support nullish document arguments"
     valid_types:
       - {"arg1": *document}
 
   - description: Distinct MERGE_DOCUMENTS argument must be document
     query: "SELECT * FROM foo GROUP BY NULL AS _groupKey1 AGGREGATE MERGE_DOCUMENTS(DISTINCT arg1) AS merge"
-    skip_reason: "SQL-590: Support nullish document arguments"
     valid_types:
       - {"arg1": *document}
 


### PR DESCRIPTION
This PR addresses the underlying bug that affected the query mentioned in the associated ticket. The ticket proposed a seemingly viable solution that proved to address a symptom rather than the cause. See the ticket for more details. Be sure to read the comments.

The issue is that several accumulator (aka `AggregateFunction`) expressions returned their `arg_schema` as their own schema. This was invalid for `FIRST`, `LAST`, `MIN`, and `MAX` since it allowed `Missing` to propagate through as a result of those accumulations. Those four always upconvert missing to null, so the schema code was updated accordingly. Additionally, I noticed that `MERGE_DOCUMENTS` was doing the same thing -- returning its `arg_schema` -- so I updated it to return the correct schema. In this case, that means it always returns a document (it never returns missing or even null, nullish arguments are simply ignored).

The scalar function `MERGE_OBJECTS` was already implemented correctly, so I refactored the code to reuse `MERGE_OBJECTS`'s schema implementation for `MERGE_DOCUMENTS`. As a drive-by, I also fixed it to allow for nullish arguments (this was required since I wanted to use the type-constraint spec tests to ensure the changes were valid but those tests were blocked on supporting nullish args). The nullish-args fix was trivial, as you'll see in the code and tests.

I elected to not add an e2e test for the query in the ticket, instead relying on unit tests to demonstrate this works as expected. I manually confirmed the query in the ticket now works. I can probably be convinced to add an e2e test if someone can come up with good motivation for why, but I personally could not justify one at this time.