### PR TITLE
SQL-3289: Create new ast, mir, and air definitions for higher order function support

### DIFF
--- a/mongosql/src/air/definitions.rs
+++ b/mongosql/src/air/definitions.rs
@@ -231,6 +231,7 @@ pub enum Expression {
     SqlDivide(SqlDivide),
     Trim(Trim),
     Map(Map),
+    Filter(Filter),
     Reduce(Reduce),
     Subquery(Subquery),
     SubqueryComparison(SubqueryComparison),
@@ -704,6 +705,13 @@ pub struct Trim {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Map {
+    pub input: Box<Expression>,
+    pub as_name: Option<String>,
+    pub inside: Box<Expression>,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct Filter {
     pub input: Box<Expression>,
     pub as_name: Option<String>,
     pub inside: Box<Expression>,

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -1409,6 +1409,7 @@ impl<'a> Algebrizer<'a> {
             ast::Expression::Subquery(s) => self.algebrize_subquery(*s),
             ast::Expression::SubqueryComparison(s) => self.algebrize_subquery_comparison(s),
             ast::Expression::Exists(e) => self.algebrize_exists(*e),
+            ast::Expression::HigherOrderFunction(_) => unimplemented!("SQL-3293"),
         }
     }
 

--- a/mongosql/src/ast/definitions.rs
+++ b/mongosql/src/ast/definitions.rs
@@ -302,6 +302,7 @@ pub enum Expression {
     StringConstructor(String),
     Tuple(Vec<Expression>),
     TypeAssertion(TypeAssertionExpr),
+    HigherOrderFunction(HigherOrderFunctionExpr),
 }
 
 impl Expression {
@@ -955,6 +956,45 @@ pub enum Type {
     Time,
     Timestamp,
     Undefined,
+}
+
+#[derive(PartialEq, Debug, Clone, VariantCount)]
+pub enum HigherOrderFunctionExpr {
+  Map(MapExpr),
+  Filter(FilterExpr),
+  Reduce(ReduceExpr),
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct MapExpr {
+  pub array: Box<Expression>,
+  pub f: Box<FunctionArgument>,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct FilterExpr {
+  pub array: Box<Expression>,
+  pub f: Box<FunctionArgument>,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct ReduceExpr {
+  pub array: Box<Expression>,
+  pub init_value: Box<Expression>,
+  pub f: Box<FunctionArgument>,
+}
+
+#[derive(PartialEq, Debug, Clone, VariantCount)]
+pub enum FunctionArgument {
+  Expr(Expression),
+  NamedFunction(NamedFunction)
+}
+
+#[derive(PartialEq, Debug, Clone, VariantCount)]
+pub enum NamedFunction {
+  UnaryOp(UnaryOp),
+  BinaryOp(BinaryOp),
+  Function(FunctionName),
 }
 
 } // end of generate_visitors! block

--- a/mongosql/src/ast/pretty_print.rs
+++ b/mongosql/src/ast/pretty_print.rs
@@ -749,9 +749,21 @@ impl Expression {
             Access(a) => a.get_tier(),
             // formatting for all the following is handled specially and will never conditionally
             // wrap arguments in parentheses
-            Array(_) | Case(_) | Cast(_) | Document(_) | Exists(_) | Function(_) | Trim(_)
-            | DateFunction(_) | Extract(_) | Identifier(_) | Literal(_) | StringConstructor(_)
-            | Subquery(_) | Tuple(_) => Bottom,
+            Array(_)
+            | Case(_)
+            | Cast(_)
+            | Document(_)
+            | Exists(_)
+            | Function(_)
+            | Trim(_)
+            | DateFunction(_)
+            | Extract(_)
+            | Identifier(_)
+            | Literal(_)
+            | StringConstructor(_)
+            | Subquery(_)
+            | Tuple(_)
+            | HigherOrderFunction(_) => Bottom,
         }
     }
 }
@@ -817,6 +829,7 @@ impl PrettyPrint for Expression {
             Subquery(q) => Ok(format!("({})", q.pretty_print()?)),
             Exists(q) => Ok(format!("EXISTS({})", q.pretty_print()?)),
             SubqueryComparison(sc) => sc.pretty_print(),
+            HigherOrderFunction(hof) => hof.pretty_print(),
         }
     }
 }
@@ -1286,5 +1299,41 @@ impl PrettyPrint for ComparisonOp {
             ComparisonOp::Neq => "<>",
         }
         .to_string())
+    }
+}
+
+impl PrettyPrint for HigherOrderFunctionExpr {
+    fn pretty_print(&self) -> Result<String> {
+        Ok(match self {
+            HigherOrderFunctionExpr::Map(m) => {
+                format!("MAP({}, {})", m.array.pretty_print()?, m.f.pretty_print()?)
+            }
+            HigherOrderFunctionExpr::Filter(f) => {
+                format!(
+                    "FILTER({}, {})",
+                    f.array.pretty_print()?,
+                    f.f.pretty_print()?
+                )
+            }
+            HigherOrderFunctionExpr::Reduce(r) => {
+                format!(
+                    "REDUCE({}, {}, {})",
+                    r.array.pretty_print()?,
+                    r.init_value.pretty_print()?,
+                    r.f.pretty_print()?
+                )
+            }
+        })
+    }
+}
+
+impl PrettyPrint for FunctionArgument {
+    fn pretty_print(&self) -> Result<String> {
+        Ok(match self {
+            FunctionArgument::Expr(e) => e.pretty_print()?,
+            FunctionArgument::NamedFunction(NamedFunction::UnaryOp(u)) => u.pretty_print()?,
+            FunctionArgument::NamedFunction(NamedFunction::BinaryOp(b)) => b.pretty_print()?,
+            FunctionArgument::NamedFunction(NamedFunction::Function(f)) => f.pretty_print()?,
+        })
     }
 }

--- a/mongosql/src/ast/pretty_print_fuzz_test.rs
+++ b/mongosql/src/ast/pretty_print_fuzz_test.rs
@@ -643,6 +643,9 @@ mod arbitrary {
                 20 => Self::StringConstructor(arbitrary_string(g)),
                 21 => Self::Tuple((1..4).map(|_| Self::arbitrary(nested_g)).collect()),
                 22 => Self::TypeAssertion(TypeAssertionExpr::arbitrary(nested_g)),
+                // TODO: SQL-3298: Replace `23 => TypeAssertion` with `23 => HigherOrderFunction`
+                23 => Self::TypeAssertion(TypeAssertionExpr::arbitrary(nested_g)),
+                // 23 => Self::HigherOrderFunction(HigherOrderFunctionExpr::arbitrary(nested_g)),
                 _ => panic!("missing Expression variant(s)"),
             }
         }
@@ -1213,6 +1216,51 @@ mod arbitrary {
                 21 => Self::Timestamp,
                 22 => Self::Undefined,
                 _ => panic!("missing Type variant(s)"),
+            }
+        }
+    }
+
+    impl Arbitrary for HigherOrderFunctionExpr {
+        fn arbitrary(g: &mut Gen) -> Self {
+            let rng = &(0..Self::VARIANT_COUNT).collect::<Vec<_>>();
+            match g.choose(rng).unwrap() {
+                0 => Self::Map(MapExpr {
+                    array: Box::new(Expression::arbitrary(g)),
+                    f: Box::new(FunctionArgument::arbitrary(g)),
+                }),
+                1 => Self::Filter(FilterExpr {
+                    array: Box::new(Expression::arbitrary(g)),
+                    f: Box::new(FunctionArgument::arbitrary(g)),
+                }),
+                2 => Self::Reduce(ReduceExpr {
+                    array: Box::new(Expression::arbitrary(g)),
+                    init_value: Box::new(Expression::arbitrary(g)),
+                    f: Box::new(FunctionArgument::arbitrary(g)),
+                }),
+                _ => panic!("missing HigherOrderFunction variant(s)"),
+            }
+        }
+    }
+
+    impl Arbitrary for FunctionArgument {
+        fn arbitrary(g: &mut Gen) -> Self {
+            let rng = &(0..Self::VARIANT_COUNT).collect::<Vec<_>>();
+            match g.choose(rng).unwrap() {
+                0 => Self::Expr(Expression::arbitrary(g)),
+                1 => Self::NamedFunction(NamedFunction::arbitrary(g)),
+                _ => panic!("missing FunctionArgument variant(s)"),
+            }
+        }
+    }
+
+    impl Arbitrary for NamedFunction {
+        fn arbitrary(g: &mut Gen) -> Self {
+            let rng = &(0..Self::VARIANT_COUNT).collect::<Vec<_>>();
+            match g.choose(rng).unwrap() {
+                0 => Self::UnaryOp(UnaryOp::arbitrary(g)),
+                1 => Self::BinaryOp(BinaryOp::arbitrary(g)),
+                2 => Self::Function(FunctionName::arbitrary(g)),
+                _ => panic!("missing NamedFunction variant(s)"),
             }
         }
     }

--- a/mongosql/src/ast/pretty_print_test.rs
+++ b/mongosql/src/ast/pretty_print_test.rs
@@ -1244,3 +1244,44 @@ mod precedence_tests {
         );
     }
 }
+
+// TODO: unskip as part of SQL-3298
+// mod higher_order_function {
+//     use super::*;
+//
+//     expression_printer_test!(
+//         map_with_expr_arg,
+//         expected = "MAP(a, this + 1)",
+//         input = "MAP(a, this+1)"
+//     );
+//
+//     expression_printer_test!(
+//         map_with_named_function_arg,
+//         expected = "MAP(a, LOWER)",
+//         input = "MAP(a, LOWER)"
+//     );
+//
+//     expression_printer_test!(
+//         filter_with_expr_arg,
+//         expected = "FILTER(a, this = 1)",
+//         input = "FILTER(a, this=1)"
+//     );
+//
+//     expression_printer_test!(
+//         filter_with_named_function_arg,
+//         expected = "FILTER(a, NOT)",
+//         input = "FILTER(a, NOT)"
+//     );
+//
+//     expression_printer_test!(
+//         reduce_with_expr_arg,
+//         expected = "REDUCE(a, 0, this + value)",
+//         input = "REDUCE(a, 0, this+value)"
+//     );
+//
+//     expression_printer_test!(
+//         reduce_with_named_function_arg,
+//         expected = "REDUCE(a, 1, *)",
+//         input = "REDUCE(a, 1, *)"
+//     );
+// }

--- a/mongosql/src/codegen/expressions.rs
+++ b/mongosql/src/codegen/expressions.rs
@@ -32,6 +32,7 @@ impl MqlCodeGenerator {
             SqlDivide(sd) => self.codegen_sql_divide(sd),
             Trim(trim) => self.codegen_trim(trim),
             Map(m) => self.codegen_map(m),
+            Filter(_) => unimplemented!("SQL-3290"),
             Reduce(r) => self.codegen_reduce(r),
             Subquery(s) => self.codegen_subquery_expr(s),
             SubqueryComparison(sc) => self.codegen_subquery_comparison(sc),

--- a/mongosql/src/mir/definitions.rs
+++ b/mongosql/src/mir/definitions.rs
@@ -262,6 +262,8 @@ pub enum Expression {
     Subquery(SubqueryExpr),
     SubqueryComparison(SubqueryComparison),
     TypeAssertion(TypeAssertionExpr),
+    HigherOrderFunction(HigherOrderFunctionApplication),
+    Variable(Variable),
 
     // Special variants that only exists for optimization purposes;
     // these do not represent actual MongoSql constructs.
@@ -289,6 +291,10 @@ impl Expression {
             Expression::Subquery(x) => x.is_nullable,
             Expression::SubqueryComparison(x) => x.is_nullable,
             Expression::TypeAssertion(x) => x.expr.is_nullable(),
+            Expression::HigherOrderFunction(HigherOrderFunctionApplication::Map(x)) => x.is_nullable,
+            Expression::HigherOrderFunction(HigherOrderFunctionApplication::Filter(x)) => x.is_nullable,
+            Expression::HigherOrderFunction(HigherOrderFunctionApplication::Reduce(x)) => x.is_nullable,
+            Expression::Variable(x) => x.is_nullable,
         }
     }
 
@@ -301,6 +307,10 @@ impl Expression {
             Expression::SearchedCase(x) => x.is_nullable = value,
             Expression::SimpleCase(x) => x.is_nullable = value,
             Expression::SubqueryComparison(x) => x.is_nullable = value,
+            Expression::HigherOrderFunction(HigherOrderFunctionApplication::Map(x)) => x.is_nullable = value,
+            Expression::HigherOrderFunction(HigherOrderFunctionApplication::Filter(x)) => x.is_nullable = value,
+            Expression::HigherOrderFunction(HigherOrderFunctionApplication::Reduce(x)) => x.is_nullable = value,
+            Expression::Variable(x) => x.is_nullable = value,
             Expression::Array(_) => (),
             Expression::Document(_) => (),
             Expression::Exists(_) => (),
@@ -903,6 +913,45 @@ pub enum SubqueryComparisonOp {
 pub enum SubqueryModifier {
     Any,
     All,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum HigherOrderFunctionApplication {
+    Map(MapExpr),
+    Filter(FilterExpr),
+    Reduce(ReduceExpr),
+}
+
+#[derive(PartialEq, Debug, Clone, new)]
+pub struct MapExpr {
+    pub array: Box<Expression>,
+    pub f: Box<Expression>,
+    #[new(value = "true")]
+    pub is_nullable: bool,
+}
+
+#[derive(PartialEq, Debug, Clone, new)]
+pub struct FilterExpr {
+    pub array: Box<Expression>,
+    pub f: Box<Expression>,
+    #[new(value = "true")]
+    pub is_nullable: bool,
+}
+
+#[derive(PartialEq, Debug, Clone, new)]
+pub struct ReduceExpr {
+    pub array: Box<Expression>,
+    pub init_value: Box<Expression>,
+    pub f: Box<Expression>,
+    #[new(value = "true")]
+    pub is_nullable: bool,
+}
+
+#[derive(PartialEq, Debug, Clone, new)]
+pub struct Variable {
+    pub name: String,
+    #[new(value = "true")]
+    pub is_nullable: bool,
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -1003,6 +1003,8 @@ impl Visitor for ConstantFoldExprVisitor<'_> {
             Expression::SubqueryComparison(_) => (e, false),
             Expression::Subquery(_) => (e, false),
             Expression::TypeAssertion(_) => (e, false),
+            Expression::HigherOrderFunction(_) => (e, false),
+            Expression::Variable(_) => (e, false),
             Expression::MqlIntrinsicFieldExistence(f) => {
                 // Patrick: we clone in case somehow the field access is mutated into a non-field access by
                 // fold_field_access_expr. This would imply a bug in our code generation, *I

--- a/mongosql/src/mir/optimizer/util.rs
+++ b/mongosql/src/mir/optimizer/util.rs
@@ -37,6 +37,8 @@ impl Visitor for ContainsSubqueryVisitor {
             Expression::SearchedCase(e) => Expression::SearchedCase(e.walk(self)),
             Expression::SimpleCase(e) => Expression::SimpleCase(e.walk(self)),
             Expression::TypeAssertion(e) => Expression::TypeAssertion(e.walk(self)),
+            Expression::HigherOrderFunction(e) => Expression::HigherOrderFunction(e.walk(self)),
+            Expression::Variable(e) => Expression::Variable(e),
             Expression::MqlIntrinsicFieldExistence(e) => {
                 Expression::MqlIntrinsicFieldExistence(e.walk(self))
             }

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -1160,6 +1160,8 @@ impl Expression {
                     Satisfaction::Must => Ok(Schema::Atomic(Atomic::Null)),
                 }
             }
+            Expression::HigherOrderFunction(_) => unimplemented!("SQL-3292"),
+            Expression::Variable(_) => unimplemented!("SQL-3292"),
             Expression::MqlIntrinsicFieldExistence(_) => Ok(Schema::Atomic(Atomic::Boolean)),
         }
     }

--- a/mongosql/src/translator/expressions.rs
+++ b/mongosql/src/translator/expressions.rs
@@ -40,6 +40,8 @@ impl MqlTranslator {
                 self.translate_subquery_comparison(subquery_comparison)
             }
             mir::Expression::TypeAssertion(ta) => self.translate_expression(*ta.expr),
+            mir::Expression::HigherOrderFunction(_) => unimplemented!("SQL-3291"),
+            mir::Expression::Variable(_) => unimplemented!("SQL-3291"),
             mir::Expression::MqlIntrinsicFieldExistence(fa) => self.translate_field_existence(fa),
         }
     }


### PR DESCRIPTION
This PR adds the new `ast`, `mir`, and `air` structs and enums required to support higher order functions, as described by the [design doc](https://docs.google.com/document/d/15bcFJ1wH6BcQYem7slPP8eG142BSvmjY3UuTNve8r7I/edit?tab=t.0#heading=h.7rylvd32g5o9).

As noted in the design and ticket description, wherever these new structs/enums/variants required handling I either added `unimplemented!` panics or appropriate handling (where trivial). I left ticket numbers wherever relevant. None of these branches can be hit at this time since we do not support parsing these functions (yet) and do not generate them any other way.