### PR TITLE
SQL-3034: Add spec test for GROUP BY specifying SELECT * behavior

### DIFF
--- a/tests/spec_tests/query_tests/group_by.yml
+++ b/tests/spec_tests/query_tests/group_by.yml
@@ -34,6 +34,14 @@ tests:
     should_compile: false
     algebrize_error: "group key at position 0 is not statically comparable to itself"
 
+  - description: Group keys are emitted under original datasource when SELECT * is used
+    query: "SELECT * FROM spec_query_group_by.bar AS bar GROUP BY a"
+    current_db: spec_query_group_by
+    result:
+      - { "bar": { "a": { "$numberInt": "1" } } }
+      - { "bar": { "a": { "$numberInt": "11" } } }
+      - { "bar": { "a": { "$numberInt": "111" } } }
+
   - description: GROUP BY keys may be table-qualified
     query: "SELECT * FROM spec_query_group_by.baz AS a GROUP by a.a.a AS a"
     current_db: spec_query_group_by


### PR DESCRIPTION
This PR adds a missing GROUP BY spec test to explicitly demonstrates where group keys are emitted when `SELECT *` is used. All existing GROUP BY spec tests use `SELECT VALUE` syntax, which results in the group keys being emitted under Bottom. This new test demonstrates how `SELECT *` and `GROUP BY` work together. See the ticket for more info.

This is a tech-debt ticket.