### PR TITLE
SQL-3268: Migrate and update (NOT) IN tests for implicit type conversion of extended JSON strings

### DIFF
--- a/mongosql/src/codegen/expressions.rs
+++ b/mongosql/src/codegen/expressions.rs
@@ -67,6 +67,11 @@ impl MqlCodeGenerator {
             .into_iter()
             .map(|x| self.codegen_expression(x))
             .collect::<Result<Vec<_>>>()?;
+
+        if mql_op.op == air::MqlOperator::NotIn {
+            return Ok(bson::bson!({ "$not": [{ "$in": Bson::Array(ops) }] }))
+        }
+
         let operator = Self::to_mql_op(mql_op.op);
         Ok(bson::bson!({ operator: Bson::Array(ops) }))
     }

--- a/mongosql/src/codegen/expressions.rs
+++ b/mongosql/src/codegen/expressions.rs
@@ -69,7 +69,7 @@ impl MqlCodeGenerator {
             .collect::<Result<Vec<_>>>()?;
 
         if mql_op.op == air::MqlOperator::NotIn {
-            return Ok(bson::bson!({ "$not": [{ "$in": Bson::Array(ops) }] }))
+            return Ok(bson::bson!({ "$not": [{ "$in": Bson::Array(ops) }] }));
         }
 
         let operator = Self::to_mql_op(mql_op.op);

--- a/mongosql/src/codegen/test/expressions.rs
+++ b/mongosql/src/codegen/test/expressions.rs
@@ -1021,7 +1021,9 @@ mod mql_semantic_operator {
 
     test_codegen_expression!(
         not_in_op,
-        expected = Ok(bson!({ "$not": [{ "$in": [{ "$literal": 1}, [{ "$literal": 1 }, { "$literal": 2 }]]}]})),
+        expected = Ok(
+            bson!({ "$not": [{ "$in": [{ "$literal": 1}, [{ "$literal": 1 }, { "$literal": 2 }]]}]})
+        ),
         input = MqlSemanticOperator(MqlSemanticOperator {
             op: NotIn,
             args: vec![

--- a/mongosql/src/codegen/test/expressions.rs
+++ b/mongosql/src/codegen/test/expressions.rs
@@ -1021,7 +1021,7 @@ mod mql_semantic_operator {
 
     test_codegen_expression!(
         not_in_op,
-        expected = Ok(bson!({ "$nin": [{ "$literal": 1}, [{ "$literal": 1 }, { "$literal": 2 }]]})),
+        expected = Ok(bson!({ "$not": [{ "$in": [{ "$literal": 1}, [{ "$literal": 1 }, { "$literal": 2 }]]}]})),
         input = MqlSemanticOperator(MqlSemanticOperator {
             op: NotIn,
             args: vec![

--- a/testdata/e2e_tests/ext_json_implicit_type_conversion.yml
+++ b/testdata/e2e_tests/ext_json_implicit_type_conversion.yml
@@ -44,3 +44,22 @@ dataset:
           bsonType: 'date'
         symbol:
           bsonType: 'symbol'
+
+  - db: "e2e_ext_json"
+    collection:
+      name: "in_expressions"
+      docs:
+        - { '_id': 0, n: 1, m: 10 }
+        - { '_id': 1, n: 10, m: 20 }
+        - { '_id': 2, n: 20, m: 30 }
+    schema:
+      bsonType: "object"
+      required: [ '_id', 'n', 'm' ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        n:
+          bsonType: "int"
+        m:
+          bsonType: "int"

--- a/tests/e2e_tests/ext_json_implicit_type_conversion.yml
+++ b/tests/e2e_tests/ext_json_implicit_type_conversion.yml
@@ -2,7 +2,9 @@
 # spec, so these tests are in the e2e test suite instead of the spec test suite.
 # This feature is exhaustively unit tested, so this set of tests does not cover
 # all contexts where conversion happens. Instead, it covers end-to-end usage of
-# each supported BSON type encoded as extended JSON strings.
+# each supported BSON type encoded as extended JSON strings. It also covers the
+# IN and NOT IN operators since they apply implicit type conversion differently
+# than other operators.
 tests:
   - description: Strict extended JSON string not converted where string is expected
     current_db: e2e_ext_json
@@ -164,3 +166,35 @@ tests:
     query: "SELECT '{\"$dbPointer\": {\"$ref\": \"foo\", \"$id\": {\"$oid\": \"57e193d7a9cc81b4027498b5\"}}}'::!DBPOINTER AS dbp FROM [{}] as t"
     result:
       - { '': { 'dbp': { '$dbPointer': { '$ref': 'foo', '$id': { '$oid': '57e193d7a9cc81b4027498b5' } } } } }
+
+  - description: Extended JSON strings in RHS argument of IN operator converted when string is unexpected
+    current_db: e2e_ext_json
+    query: "SELECT n, n IN ('{\"$numberInt\": \"10\"}', '{\"$numberInt\": \"20\"}') AS v FROM in_expressions"
+    result:
+      - { '': { 'n': 1, 'v': false } }
+      - { '': { 'n': 10, 'v': true } }
+      - { '': { 'n': 20, 'v': true } }
+
+  - description: Extended JSON string as LHS of IN operator converted when string is unexpected
+    current_db: e2e_ext_json
+    query: "SELECT n, m, '{\"$numberInt\": \"10\"}' IN (n, m) AS v FROM in_expressions"
+    result:
+      - { '': { 'n': 1, 'm': 10, 'v': true } }
+      - { '': { 'n': 10, 'm': 20, 'v': true } }
+      - { '': { 'n': 20, 'm': 30, 'v': false } }
+
+  - description: Extended JSON strings in RHS argument of NOT IN operator converted when string is unexpected
+    current_db: e2e_ext_json
+    query: "SELECT n, n NOT IN ('{\"$numberInt\": \"10\"}', '{\"$numberInt\": \"20\"}') AS v FROM in_expressions"
+    result:
+      - { '': { 'n': 1, 'v': true } }
+      - { '': { 'n': 10, 'v': false } }
+      - { '': { 'n': 20, 'v': false } }
+
+  - description: Extended JSON string as LHS of NOT IN operator converted when string is unexpected
+    current_db: e2e_ext_json
+    query: "SELECT n, m, '{\"$numberInt\": \"10\"}' NOT IN (n, m) AS v FROM in_expressions"
+    result:
+      - { '': { 'n': 1, 'm': 10, 'v': false } }
+      - { '': { 'n': 10, 'm': 20, 'v': false } }
+      - { '': { 'n': 20, 'm': 30, 'v': true } }

--- a/tests/spec_tests/query_tests/scalar_functions.yml
+++ b/tests/spec_tests/query_tests/scalar_functions.yml
@@ -660,26 +660,12 @@ tests:
       - {'': {'a': 1, 's': 'hello'}}
       - {'': {'a': 2, 's': 'world'}}
 
-  - description: NOT IN operator with $numberInt encoded field correctness test
-    current_db: spec_query_scalar_functions
-    query: "SELECT _id, n FROM in_expressions WHERE n NOT IN (1, 2, 4, null)"
-    result:
-      - { '': { "_id": 5, "n": { "$numberInt": "10" } } }
-      - { '': { "_id": 6, "n": { "$numberInt": "20" } } }
-
   - description: IN operator with plain integer n field correctness test
     current_db: spec_query_scalar_functions
     query: "SELECT a, s, n FROM in_expressions AS c WHERE n IN (1, 2)"
     result:
       - {'': {'a': 1, 's': 'hello', 'n': 1}}
       - {'': {'a': 2, 's': 'world', 'n': 2}}
-
-  - description: IN operator with $numberInt encoded field correctness test
-    current_db: spec_query_scalar_functions
-    query: "SELECT n FROM in_expressions AS c WHERE n IN (10, 20)"
-    result:
-      - {'': {'n': { '$numberInt': '10' }}}
-      - {'': {'n': { '$numberInt': '20' }}}
 
   - description: IN operator with subquery correctness test
     current_db: spec_query_scalar_functions


### PR DESCRIPTION
This PR migrates the spec/query tests for `IN` and `NOT IN` that intended to cover implicit type conversion of extended JSON encoded strings into the e2e test suite, and updates those tests to cover the intended behavior on both sides of the operators. See the ticket for more info.

As part of this change, I realized that we were unconditionally codegenning `air::MqlOperator::NotIn` to `$nin`, which was invalid. I updated the `air::MqlOperator::NotIn` codepath to mimic what `air::SqlOperator::NotIn` does. That is, it now codegens as `{$not: {$in: ... }}` instead of `{$nin: ...}`. That was a quick drive-by fix! I considered filing a separate bug ticket, but I figured why block these new e2e tests on a bug ticket when it's just essentially a one-liner change.

This is a tech-debt ticket.