### PR TITLE
[SQL-3300] Introduce NOT and Field Access to match language optimizer

### DIFF
--- a/mongosql/src/mir/definitions.rs
+++ b/mongosql/src/mir/definitions.rs
@@ -1047,6 +1047,7 @@ pub struct MatchLanguageLogical {
 pub enum MatchLanguageLogicalOp {
     Or,
     And,
+    Not,
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/mongosql/src/mir/optimizer/rewrite_to_match_language/mod.rs
+++ b/mongosql/src/mir/optimizer/rewrite_to_match_language/mod.rs
@@ -192,10 +192,24 @@ impl MatchLanguageRewriterVisitor {
         match condition {
             Expression::Is(is) => Self::rewrite_is(is),
             Expression::Like(like) => Self::rewrite_like(like),
+            Expression::FieldAccess(fa) => fa.try_into().ok().map(|fp: FieldPath| {
+                MatchQuery::Comparison(MatchLanguageComparison {
+                    function: MatchLanguageComparisonOp::Eq,
+                    input: Some(fp),
+                    arg: LiteralValue::Boolean(true),
+                    cache: SchemaCache::new(),
+                })
+            }),
             Expression::ScalarFunction(sf) => match sf.function {
                 ScalarFunction::And => Self::rewrite_logical(MatchLanguageLogicalOp::And, sf.args),
                 ScalarFunction::Or => Self::rewrite_logical(MatchLanguageLogicalOp::Or, sf.args),
                 ScalarFunction::In | ScalarFunction::NotIn => Self::rewrite_in(&sf),
+                // NOT is unary; only rewrite when it has exactly one operand,
+                // otherwise leave it in $expr language rather than emit a
+                // Logical{Not} we can't faithfully translate.
+                ScalarFunction::Not if sf.args.len() == 1 => {
+                    Self::rewrite_logical(MatchLanguageLogicalOp::Not, sf.args)
+                }
                 _ => None,
             },
             // Note this relies on ConstantFolding to ensure that the a constant expression becomes

--- a/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
+++ b/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
@@ -519,7 +519,7 @@ test_rewrite_to_match_language!(
         op: MatchLanguageLogicalOp::Not,
         args: vec![MatchQuery::Comparison(MatchLanguageComparison {
             function: MatchLanguageComparisonOp::Eq,
-            input: Some(mir_field_path("foo", vec!["int"])),
+            input: Some(mir_field_path("foo", vec!["bool"])),
             arg: LiteralValue::Boolean(true),
             cache: SchemaCache::new(),
         })],

--- a/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
+++ b/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
@@ -172,7 +172,7 @@ fn comp_expr() -> Expression {
         ScalarFunction::Lt,
         vec![
             *mir_field_access("foo", "int", true),
-            Expression::Literal(LiteralValue::Integer(10)),
+            *mir_field_access("bar", "int", true),
         ],
     ))
 }

--- a/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
+++ b/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
@@ -598,21 +598,6 @@ test_rewrite_to_match_language!(
     input = filter_stage(*mir_field_access_multi_part("foo", vec!["a", "b"], true))
 );
 
-// A field access whose base is a scalar function (not a Reference) cannot be
-// converted to a FieldPath, so it stays in expr language.
-test_rewrite_to_match_language_no_op!(
-    field_access_not_convertible_to_field_path_is_noop,
-    filter_stage(Expression::FieldAccess(FieldAccess {
-        expr: Box::new(Expression::ScalarFunction(ScalarFunctionApplication {
-            function: ScalarFunction::Upper,
-            args: vec![*mir_field_access("foo", "str", true)],
-            is_nullable: true,
-        })),
-        field: "x".to_string(),
-        is_nullable: true,
-    }))
-);
-
 // A boolean field access composes inside a logical operation.
 test_rewrite_to_match_language!(
     rewrite_boolean_field_access_in_conjunction,

--- a/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
+++ b/mongosql/src/mir/optimizer/rewrite_to_match_language/test.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     schema::{Atomic, Document, Schema, SchemaEnvironment},
     set, unchecked_unique_linked_hash_map,
-    util::{mir_collection, mir_field_access, mir_field_path},
+    util::{mir_collection, mir_field_access, mir_field_access_multi_part, mir_field_path},
     SchemaCheckingMode,
 };
 use agg_ast::definitions::Namespace;
@@ -497,4 +497,160 @@ test_rewrite_to_match_language_no_op!(
         ],
         is_nullable: false,
     }))
+);
+
+test_rewrite_to_match_language!(
+    rewrite_boolean_field_access_to_equal_comparison,
+    expected = match_filter_stage(MatchQuery::Comparison(MatchLanguageComparison {
+        function: MatchLanguageComparisonOp::Eq,
+        input: Some(mir_field_path("is_active", vec!["bool"])),
+        arg: LiteralValue::Boolean(true),
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(*mir_field_access("is_active", "bool", true))
+);
+
+// NOT over a rewritable leaf (a bare boolean field access). This also pins the
+// expected unary shape of NOT: exactly one arg in, exactly one arg out.
+test_rewrite_to_match_language!(
+    rewrite_not_over_field_access,
+    expected = match_filter_stage(MatchQuery::Logical(MatchLanguageLogical {
+        op: MatchLanguageLogicalOp::Not,
+        args: vec![MatchQuery::Comparison(MatchLanguageComparison {
+            function: MatchLanguageComparisonOp::Eq,
+            input: Some(mir_field_path("foo", vec!["int"])),
+            arg: LiteralValue::Boolean(true),
+            cache: SchemaCache::new(),
+        })],
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::ScalarFunction(ScalarFunctionApplication::new(
+        ScalarFunction::Not,
+        vec![*mir_field_access("foo", "bool", true)],
+    )))
+);
+
+// NOT wrapping a nested logical operation.
+test_rewrite_to_match_language!(
+    rewrite_not_over_conjunction,
+    expected = match_filter_stage(MatchQuery::Logical(MatchLanguageLogical {
+        op: MatchLanguageLogicalOp::Not,
+        args: vec![MatchQuery::Logical(MatchLanguageLogical {
+            op: MatchLanguageLogicalOp::And,
+            args: vec![valid_match_like(), valid_match_is()],
+            cache: SchemaCache::new(),
+        })],
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::ScalarFunction(ScalarFunctionApplication::new(
+        ScalarFunction::Not,
+        vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![valid_like(), valid_is()],
+        ))],
+    )))
+);
+
+// Double negation exercises the recursion in rewrite_condition.
+test_rewrite_to_match_language!(
+    rewrite_nested_not,
+    expected = match_filter_stage(MatchQuery::Logical(MatchLanguageLogical {
+        op: MatchLanguageLogicalOp::Not,
+        args: vec![MatchQuery::Logical(MatchLanguageLogical {
+            op: MatchLanguageLogicalOp::Not,
+            args: vec![valid_match_is()],
+            cache: SchemaCache::new(),
+        })],
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::ScalarFunction(ScalarFunctionApplication::new(
+        ScalarFunction::Not,
+        vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Not,
+            vec![valid_is()],
+        ))],
+    )))
+);
+
+// The inner comparison is not rewritable, so the whole NOT stays in expr language.
+test_rewrite_to_match_language_no_op!(
+    cannot_rewrite_not_over_comparison,
+    filter_stage(Expression::ScalarFunction(ScalarFunctionApplication::new(
+        ScalarFunction::Not,
+        vec![comp_expr()],
+    )))
+);
+
+// A multi-hop boolean field access rewrites to an equality against `true`.
+test_rewrite_to_match_language!(
+    rewrite_multipart_boolean_field_access,
+    expected = match_filter_stage(MatchQuery::Comparison(MatchLanguageComparison {
+        function: MatchLanguageComparisonOp::Eq,
+        input: Some(mir_field_path("foo", vec!["a", "b"])),
+        arg: LiteralValue::Boolean(true),
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(*mir_field_access_multi_part("foo", vec!["a", "b"], true))
+);
+
+// A field access whose base is a scalar function (not a Reference) cannot be
+// converted to a FieldPath, so it stays in expr language.
+test_rewrite_to_match_language_no_op!(
+    field_access_not_convertible_to_field_path_is_noop,
+    filter_stage(Expression::FieldAccess(FieldAccess {
+        expr: Box::new(Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Upper,
+            args: vec![*mir_field_access("foo", "str", true)],
+            is_nullable: true,
+        })),
+        field: "x".to_string(),
+        is_nullable: true,
+    }))
+);
+
+// A boolean field access composes inside a logical operation.
+test_rewrite_to_match_language!(
+    rewrite_boolean_field_access_in_conjunction,
+    expected = match_filter_stage(MatchQuery::Logical(MatchLanguageLogical {
+        op: MatchLanguageLogicalOp::And,
+        args: vec![
+            MatchQuery::Comparison(MatchLanguageComparison {
+                function: MatchLanguageComparisonOp::Eq,
+                input: Some(mir_field_path("foo", vec!["int"])),
+                arg: LiteralValue::Boolean(true),
+                cache: SchemaCache::new(),
+            }),
+            valid_match_is(),
+        ],
+        cache: SchemaCache::new(),
+    })),
+    expected_changed = true,
+    input = filter_stage(Expression::ScalarFunction(ScalarFunctionApplication::new(
+        ScalarFunction::And,
+        vec![*mir_field_access("foo", "int", true), valid_is()],
+    )))
+);
+
+// NOT is unary; a zero-arg NOT fails the arity guard and stays in expr language.
+test_rewrite_to_match_language_no_op!(
+    cannot_rewrite_not_with_zero_args,
+    filter_stage(Expression::ScalarFunction(ScalarFunctionApplication::new(
+        ScalarFunction::Not,
+        vec![],
+    )))
+);
+
+// NOT is unary; a multi-arg NOT fails the arity guard and stays in expr language
+// rather than silently dropping the extra operand.
+test_rewrite_to_match_language_no_op!(
+    cannot_rewrite_not_with_multiple_args,
+    filter_stage(Expression::ScalarFunction(ScalarFunctionApplication::new(
+        ScalarFunction::Not,
+        vec![valid_is(), valid_like()],
+    )))
 );

--- a/mongosql/src/translator/match_query.rs
+++ b/mongosql/src/translator/match_query.rs
@@ -65,7 +65,7 @@ impl MqlTranslator {
             mir::MatchLanguageLogicalOp::Not => air::MatchQuery::Not(Box::new(
                 args.into_iter()
                     .next()
-                    .expect("NOT is unary by rewriter invariant"),
+                    .expect("NOT expects a single argument."),
             )),
         })
     }

--- a/mongosql/src/translator/match_query.rs
+++ b/mongosql/src/translator/match_query.rs
@@ -62,6 +62,11 @@ impl MqlTranslator {
         Ok(match l.op {
             mir::MatchLanguageLogicalOp::Or => air::MatchQuery::Or(args),
             mir::MatchLanguageLogicalOp::And => air::MatchQuery::And(args),
+            mir::MatchLanguageLogicalOp::Not => air::MatchQuery::Not(Box::new(
+                args.into_iter()
+                    .next()
+                    .expect("NOT is unary by rewriter invariant"),
+            )),
         })
     }
 

--- a/tests/spec_tests/query_tests/where.yml
+++ b/tests/spec_tests/query_tests/where.yml
@@ -41,13 +41,13 @@ tests:
       - {'items': {'_id': 0, 'foo_bar': 2}}
       - {'items': {'_id': 4, 'foo_bar': 2}}
   - description: WHERE with BOOLEAN field access
-    query: "SELECT * FROM [{'is_active': true, id: 1}, {'is_active': true, id: 2}, {'is_active': false, id: 3}] AS arr WHERE is_active"
+    query: "SELECT * FROM [{'is_active': true, 'id': 1}, {'is_active': true, 'id': 2}, {'is_active': false, 'id': 3}] AS arr WHERE is_active"
     current_db: test
     result:
       - {'arr': {'is_active': true, 'id': 1}}
       - {'arr': {'is_active': true, 'id': 2}}
   - description: WHERE with NEGATED BOOLEAN field access
-    query: "SELECT * FROM [{'is_active': true, id: 1}, {'is_active': true, id: 2}, {'is_active': false, id: 3}] AS arr WHERE NOT is_active"
+    query: "SELECT * FROM [{'is_active': true, 'id': 1}, {'is_active': true, 'id': 2}, {'is_active': false, 'id': 3}] AS arr WHERE NOT is_active"
     current_db: test
     result:
       - { 'arr': { 'is_active': false, 'id': 3 } }

--- a/tests/spec_tests/query_tests/where.yml
+++ b/tests/spec_tests/query_tests/where.yml
@@ -40,3 +40,14 @@ tests:
     result:
       - {'items': {'_id': 0, 'foo_bar': 2}}
       - {'items': {'_id': 4, 'foo_bar': 2}}
+  - description: WHERE with BOOLEAN field access
+    query: "SELECT * FROM [{'is_active': true, id: 1}, {'is_active': true, id: 2}, {'is_active': false, id: 3}] AS arr WHERE is_active"
+    current_db: test
+    result:
+      - {'arr': {'is_active': true, 'id': 1}}
+      - {'arr': {'is_active': true, 'id': 2}}
+  - description: WHERE with NEGATED BOOLEAN field access
+    query: "SELECT * FROM [{'is_active': true, id: 1}, {'is_active': true, id: 2}, {'is_active': false, id: 3}] AS arr WHERE NOT is_active"
+    current_db: test
+    result:
+      - { 'arr': { 'is_active': false, 'id': 3 } }

--- a/tests/spec_tests/query_tests/where.yml
+++ b/tests/spec_tests/query_tests/where.yml
@@ -40,12 +40,14 @@ tests:
     result:
       - {'items': {'_id': 0, 'foo_bar': 2}}
       - {'items': {'_id': 4, 'foo_bar': 2}}
+      -
   - description: WHERE with BOOLEAN field access
     query: "SELECT * FROM [{'is_active': true, 'id': 1}, {'is_active': true, 'id': 2}, {'is_active': false, 'id': 3}] AS arr WHERE is_active"
     current_db: test
     result:
       - {'arr': {'is_active': true, 'id': 1}}
       - {'arr': {'is_active': true, 'id': 2}}
+      -
   - description: WHERE with NEGATED BOOLEAN field access
     query: "SELECT * FROM [{'is_active': true, 'id': 1}, {'is_active': true, 'id': 2}, {'is_active': false, 'id': 3}] AS arr WHERE NOT is_active"
     current_db: test

--- a/tests/spec_tests/query_tests/where.yml
+++ b/tests/spec_tests/query_tests/where.yml
@@ -40,14 +40,14 @@ tests:
     result:
       - {'items': {'_id': 0, 'foo_bar': 2}}
       - {'items': {'_id': 4, 'foo_bar': 2}}
-      -
+
   - description: WHERE with BOOLEAN field access
     query: "SELECT * FROM [{'is_active': true, 'id': 1}, {'is_active': true, 'id': 2}, {'is_active': false, 'id': 3}] AS arr WHERE is_active"
     current_db: test
     result:
       - {'arr': {'is_active': true, 'id': 1}}
       - {'arr': {'is_active': true, 'id': 2}}
-      -
+
   - description: WHERE with NEGATED BOOLEAN field access
     query: "SELECT * FROM [{'is_active': true, 'id': 1}, {'is_active': true, 'id': 2}, {'is_active': false, 'id': 3}] AS arr WHERE NOT is_active"
     current_db: test


### PR DESCRIPTION
## Summary

This pull request extends the match_language_rewriter optimizer to support translating NOT and FieldAccesses into match language.

This means that field accesses can appear in match language:
```rust
./target/debug/mongosql-cli "SELECT * FROM foo WHERE is_active AND is_verified"

/// Generated Pipeline
[
    { "$match": { "is_active": { "$eq": true } } },
    { "$match": { "is_verified": { "$eq": true } } },
    { "$project": { "foo": "$$ROOT", "_id": 0 } },
]
```

And the NOT operator is also translated to match language.
```rust
 ./target/debug/mongosql-cli "SELECT * FROM foo WHERE NOT (is_active AND is_verified)"

/// Generated Pipeline
[
    { "$match": { "$nor": [{ "$and": [{ "is_active": { "$eq": true } }, { "is_verified": { "$eq": true } }] }] } },
    { "$project": { "foo": "$$ROOT", "_id": 0 } },
]
```

## Implementation

Implementation is mainly extending the match arms in the match language optimizer.

## Testing
Introduced new unit tests in the match language rewriter, and a spec query tests to validate that field accesses can be used in queries.