### PR TITLE
SQL-3290: Implement codegen for Filter expression

### DIFF
--- a/mongosql/src/codegen/expressions.rs
+++ b/mongosql/src/codegen/expressions.rs
@@ -32,7 +32,7 @@ impl MqlCodeGenerator {
             SqlDivide(sd) => self.codegen_sql_divide(sd),
             Trim(trim) => self.codegen_trim(trim),
             Map(m) => self.codegen_map(m),
-            Filter(_) => unimplemented!("SQL-3290"),
+            Filter(f) => self.codegen_filter(f),
             Reduce(r) => self.codegen_reduce(r),
             Subquery(s) => self.codegen_subquery_expr(s),
             SubqueryComparison(sc) => self.codegen_subquery_comparison(sc),
@@ -377,6 +377,19 @@ impl MqlCodeGenerator {
         }
 
         Ok(bson!({"$map": doc}))
+    }
+
+    fn codegen_filter(&self, f: air::Filter) -> Result<Bson> {
+        let input = self.codegen_expression(*f.input)?;
+        let inside = self.codegen_expression(*f.inside)?;
+
+        let mut doc = doc! {"input": input, "cond": inside};
+
+        if let Some(as_name) = f.as_name {
+            doc.insert("as", as_name);
+        }
+
+        Ok(bson!({"$filter": doc}))
     }
 
     fn codegen_reduce(&self, reduce: air::Reduce) -> Result<Bson> {

--- a/mongosql/src/codegen/test/expressions.rs
+++ b/mongosql/src/codegen/test/expressions.rs
@@ -2032,6 +2032,35 @@ mod map {
     );
 }
 
+mod filter {
+    use crate::air::{Expression::*, Filter, LiteralValue};
+    use bson::bson;
+
+    test_codegen_expression!(
+        without_as,
+        expected = Ok(
+            bson!({ "$filter": {"input": {"$literal": "input"}, "cond": {"$literal": "inside"}}})
+        ),
+        input = Filter(Filter {
+            input: Box::new(Literal(LiteralValue::String("input".to_string()))),
+            as_name: None,
+            inside: Box::new(Literal(LiteralValue::String("inside".to_string()))),
+        })
+    );
+
+    test_codegen_expression!(
+        with_as,
+        expected = Ok(
+            bson!({ "$filter": {"input": {"$literal": "input"}, "cond": {"$literal": "inside"}, "as": "x"}})
+        ),
+        input = Filter(Filter {
+            input: Box::new(Literal(LiteralValue::String("input".to_string()))),
+            as_name: Some("x".to_string()),
+            inside: Box::new(Literal(LiteralValue::String("inside".to_string()))),
+        })
+    );
+}
+
 mod reduce {
     use crate::air::{Expression::*, LiteralValue, Reduce};
     use bson::bson;


### PR DESCRIPTION
This PR implements codegen for the new `air::Expression::Filter(air::Filter)` expression variant, according to the outline in the [design doc](https://docs.google.com/document/d/15bcFJ1wH6BcQYem7slPP8eG142BSvmjY3UuTNve8r7I/edit?tab=t.0#heading=h.3xabqtq2frly).