### PR TITLE
SQL-3291: Implement translation for HigherOrderFunction and Variable

### DIFF
--- a/mongosql/src/translator/expressions.rs
+++ b/mongosql/src/translator/expressions.rs
@@ -41,7 +41,7 @@ impl MqlTranslator {
             }
             mir::Expression::TypeAssertion(ta) => self.translate_expression(*ta.expr),
             mir::Expression::HigherOrderFunction(hof) => self.translate_higher_order_function(hof),
-            mir::Expression::Variable(_) => unimplemented!("SQL-3291"),
+            mir::Expression::Variable(v) => self.translate_variable(v),
             mir::Expression::MqlIntrinsicFieldExistence(fa) => self.translate_field_existence(fa),
         }
     }
@@ -534,6 +534,10 @@ impl MqlTranslator {
             init_value: Box::new(self.translate_expression(*r.init_value)?),
             inside: Box::new(self.translate_expression(*r.f)?),
         }))
+    }
+
+    fn translate_variable(&self, v: mir::Variable) -> Result<air::Expression> {
+        Ok(air::Expression::Variable(v.name.into()))
     }
 
     /// A FieldExistence is a special node that represents an existence assertion in a Match

--- a/mongosql/src/translator/expressions.rs
+++ b/mongosql/src/translator/expressions.rs
@@ -40,7 +40,7 @@ impl MqlTranslator {
                 self.translate_subquery_comparison(subquery_comparison)
             }
             mir::Expression::TypeAssertion(ta) => self.translate_expression(*ta.expr),
-            mir::Expression::HigherOrderFunction(_) => unimplemented!("SQL-3291"),
+            mir::Expression::HigherOrderFunction(hof) => self.translate_higher_order_function(hof),
             mir::Expression::Variable(_) => unimplemented!("SQL-3291"),
             mir::Expression::MqlIntrinsicFieldExistence(fa) => self.translate_field_existence(fa),
         }
@@ -499,6 +499,41 @@ impl MqlTranslator {
                 subquery: Box::new(subquery),
             },
         ))
+    }
+
+    fn translate_higher_order_function(
+        &self,
+        higher_order_function: mir::HigherOrderFunctionApplication,
+    ) -> Result<air::Expression> {
+        match higher_order_function {
+            mir::HigherOrderFunctionApplication::Map(m) => self.translate_map(m),
+            mir::HigherOrderFunctionApplication::Filter(f) => self.translate_filter_expr(f),
+            mir::HigherOrderFunctionApplication::Reduce(r) => self.translate_reduce(r),
+        }
+    }
+
+    fn translate_map(&self, m: mir::MapExpr) -> Result<air::Expression> {
+        Ok(air::Expression::Map(air::Map {
+            input: Box::new(self.translate_expression(*m.array)?),
+            as_name: None,
+            inside: Box::new(self.translate_expression(*m.f)?),
+        }))
+    }
+
+    fn translate_filter_expr(&self, f: mir::FilterExpr) -> Result<air::Expression> {
+        Ok(air::Expression::Filter(air::Filter {
+            input: Box::new(self.translate_expression(*f.array)?),
+            as_name: None,
+            inside: Box::new(self.translate_expression(*f.f)?),
+        }))
+    }
+
+    fn translate_reduce(&self, r: mir::ReduceExpr) -> Result<air::Expression> {
+        Ok(air::Expression::Reduce(air::Reduce {
+            input: Box::new(self.translate_expression(*r.array)?),
+            init_value: Box::new(self.translate_expression(*r.init_value)?),
+            inside: Box::new(self.translate_expression(*r.f)?),
+        }))
     }
 
     /// A FieldExistence is a special node that represents an existence assertion in a Match

--- a/mongosql/src/translator/test/expressions.rs
+++ b/mongosql/src/translator/test/expressions.rs
@@ -4611,12 +4611,12 @@ mod higher_order_function {
             as_name: None,
             inside: Box::new(air::Expression::Literal(air::LiteralValue::Integer(12))),
         })),
-        input = mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Map(mir::MapExpr::new(
-            Box::new(mir::Expression::Array(mir::ArrayExpr {
-                array: vec![],
-            })),
-            Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(12))),
-        ))),
+        input = mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Map(
+            mir::MapExpr::new(
+                Box::new(mir::Expression::Array(mir::ArrayExpr { array: vec![] })),
+                Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(12))),
+            )
+        )),
     );
 
     test_translate_expression!(
@@ -4626,12 +4626,12 @@ mod higher_order_function {
             as_name: None,
             inside: Box::new(air::Expression::Literal(air::LiteralValue::Boolean(true))),
         })),
-        input = mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr::new(
-            Box::new(mir::Expression::Array(mir::ArrayExpr {
-                array: vec![],
-            })),
-            Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
-        ))),
+        input = mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Filter(
+            mir::FilterExpr::new(
+                Box::new(mir::Expression::Array(mir::ArrayExpr { array: vec![] })),
+                Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
+            )
+        )),
     );
 
     test_translate_expression!(
@@ -4641,12 +4641,22 @@ mod higher_order_function {
             init_value: Box::new(air::Expression::Literal(air::LiteralValue::Integer(1))),
             inside: Box::new(air::Expression::Literal(air::LiteralValue::Integer(2))),
         })),
-        input = mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr::new(
-            Box::new(mir::Expression::Array(mir::ArrayExpr {
-                array: vec![],
-            })),
-            Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
-            Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(2))),
-        ))),
+        input = mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Reduce(
+            mir::ReduceExpr::new(
+                Box::new(mir::Expression::Array(mir::ArrayExpr { array: vec![] })),
+                Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(2))),
+            )
+        )),
+    );
+}
+
+mod variable {
+    use crate::{air, mir};
+
+    test_translate_expression!(
+        simple,
+        expected = Ok(air::Expression::Variable("this".to_string().into())),
+        input = mir::Expression::Variable(mir::Variable::new("this".to_string())),
     );
 }

--- a/mongosql/src/translator/test/expressions.rs
+++ b/mongosql/src/translator/test/expressions.rs
@@ -4600,3 +4600,53 @@ mod in_operator {
         },
     );
 }
+
+mod higher_order_function {
+    use crate::{air, mir};
+
+    test_translate_expression!(
+        map,
+        expected = Ok(air::Expression::Map(air::Map {
+            input: Box::new(air::Expression::Array(vec![])),
+            as_name: None,
+            inside: Box::new(air::Expression::Literal(air::LiteralValue::Integer(12))),
+        })),
+        input = mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Map(mir::MapExpr::new(
+            Box::new(mir::Expression::Array(mir::ArrayExpr {
+                array: vec![],
+            })),
+            Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(12))),
+        ))),
+    );
+
+    test_translate_expression!(
+        filter,
+        expected = Ok(air::Expression::Filter(air::Filter {
+            input: Box::new(air::Expression::Array(vec![])),
+            as_name: None,
+            inside: Box::new(air::Expression::Literal(air::LiteralValue::Boolean(true))),
+        })),
+        input = mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr::new(
+            Box::new(mir::Expression::Array(mir::ArrayExpr {
+                array: vec![],
+            })),
+            Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
+        ))),
+    );
+
+    test_translate_expression!(
+        reduce,
+        expected = Ok(air::Expression::Reduce(air::Reduce {
+            input: Box::new(air::Expression::Array(vec![])),
+            init_value: Box::new(air::Expression::Literal(air::LiteralValue::Integer(1))),
+            inside: Box::new(air::Expression::Literal(air::LiteralValue::Integer(2))),
+        })),
+        input = mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr::new(
+            Box::new(mir::Expression::Array(mir::ArrayExpr {
+                array: vec![],
+            })),
+            Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+            Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(2))),
+        ))),
+    );
+}


### PR DESCRIPTION
This PR implements translation for the new `mir::Expression::HigherOrderFunction` and `mir::Expression::Variable` expression variants into their corresponding `air::Expression` types, according to the outline in the [design doc](https://docs.google.com/document/d/15bcFJ1wH6BcQYem7slPP8eG142BSvmjY3UuTNve8r7I/edit?tab=t.0#heading=h.wnysykomkci3).