### PR TITLE
SQL-3312: Expand support for CAST constant folding

### DIFF
--- a/mongosql/src/mir/definitions.rs
+++ b/mongosql/src/mir/definitions.rs
@@ -380,7 +380,7 @@ pub enum LiteralValue {
     DbPointer(bson::DbPointer),
 }
 
-static DECIMAL_ZERO: LazyLock<bson::Decimal128> = LazyLock::new(|| "0.0".parse().unwrap());
+pub(crate) static DECIMAL_ZERO: LazyLock<bson::Decimal128> = LazyLock::new(|| "0.0".parse().unwrap());
 impl LiteralValue {
     pub fn is_falsy(&self) -> bool {
         match self {

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -1201,8 +1201,116 @@ impl ConstantFoldExprVisitor<'_> {
         }
     }
 
-    fn convert_to_datetime(_l: &LiteralValue) -> Option<Result<Expression, ()>> {
-        todo!()
+    fn convert_to_datetime(l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        match l {
+            // Null literal values are handled directly by the `fold_cast_expr` method. Here, we
+            // return None to indicate folding did not happen, but still could in `fold_cast_expr`.
+            LiteralValue::Null => None,
+
+            // Datetimes are trivially converted to themselves.
+            LiteralValue::DateTime(v) => Some(Ok(Expression::Literal(LiteralValue::DateTime(*v)))),
+
+            // Numbers may be converted to datetime by converting to long and then to datetime.
+            // Numbers that are out of range of i64 result in an error.
+            LiteralValue::Long(v) => Some(Ok(Expression::Literal(LiteralValue::DateTime(
+                bson::DateTime::from_millis(*v),
+            )))),
+            LiteralValue::Double(v) => {
+                // MongoDB truncates when converting a double to a date.
+                let truncated = v.trunc();
+                if truncated.is_finite()
+                    && truncated >= i64::MIN as f64
+                    && truncated <= i64::MAX as f64
+                {
+                    Some(Ok(Expression::Literal(LiteralValue::DateTime(
+                        bson::DateTime::from_millis(truncated as i64),
+                    ))))
+                } else {
+                    Some(Err(()))
+                }
+            }
+            LiteralValue::Decimal128(v) => {
+                // MongoDB truncates when converting a decimal to a date.
+                // Since we cannot operate on Decimal128 values directly, we convert to string and
+                // truncate by taking only the part before the decimal point.
+                let s = v.to_string();
+                let truncated = s.split('.').next().unwrap_or(&s);
+                Some(
+                    i64::from_str(&truncated)
+                        .map(|i| {
+                            Expression::Literal(LiteralValue::DateTime(
+                                bson::DateTime::from_millis(i),
+                            ))
+                        })
+                        .map_err(|_| ()),
+                )
+            }
+
+            // ObjectIds may be converted to datetime by getting the timestamp from the ObjectId.
+            LiteralValue::ObjectId(v) => Some(Ok(Expression::Literal(LiteralValue::DateTime(
+                v.timestamp(),
+            )))),
+
+            // Strings can be converted into the dates that correspond to the date string.
+            // Valid formats that MongoDB supports are:
+            //   - "2018-03-03"
+            //   - "2018-03-03T12:00:00Z"
+            //   - "2018-03-03T12:00:00+0500"
+            LiteralValue::String(v) => {
+                // Check if string ends with timezone offset: +HHMM or -HHMM
+                let has_timezone_offset = v.len() >= 5 && {
+                    let last_5 = &v[v.len() - 5..];
+                    let bytes = last_5.as_bytes();
+                    (bytes[0] == b'+' || bytes[0] == b'-')
+                        && bytes[1..].iter().all(|b| b.is_ascii_digit())
+                };
+
+                // If it ends with 'Z' or '+/-HHMM', we can attempt to parse it directly. That is,
+                // if it matches the format YYYY-MM-DD(T| )HH:mm:SS((.ms)?Z|(+|-)HHMM)?, where `?`
+                // denotes optional.
+                let chrono_dt: Option<chrono::DateTime<Utc>> =
+                    if v.ends_with('Z') || has_timezone_offset {
+                        v.parse().ok()
+                    } else if v.len() == 10 {
+                        // If it does not end with 'Z' or '+/-HHMM' and is length 10, we assume it
+                        // is in YYYY-MM-DD format. We append the T00:00:00Z time to the string so
+                        // that we can attempt to parse it into a chrono::DateTime<Utc>.
+                        let mut s = v.to_string();
+                        s.push_str("T00:00:00Z");
+                        s.parse().ok()
+                    } else {
+                        // If it does not end with 'Z' or '+/-HHMM' and is not length 10, we assume
+                        // it is in YYYY-MM-DD(T| )HH:mm:SS(.ms)? format. We append the 'Z' to the
+                        // string so we can attempt to parse it into a chrono::DateTime<Utc>.
+                        let mut s = v.to_string();
+                        s.push('Z');
+                        s.parse().ok()
+                    };
+
+                // We cannot guarantee our format here supports everything that MongoDB supports,
+                // so we instead fall back to the original cast expression when our attempt to
+                // create a Date fails, and allow MongoDB to succeed or fail as it will.
+                chrono_dt.map(|chrono_dt| {
+                    Ok(Expression::Literal(LiteralValue::DateTime(
+                        chrono_dt.into(),
+                    )))
+                })
+            }
+
+            // These types are not supported for conversion to int.
+            LiteralValue::Boolean(_)
+            | LiteralValue::Binary(_)
+            | LiteralValue::Integer(_)
+            | LiteralValue::JavaScriptCode(_)
+            | LiteralValue::JavaScriptCodeWithScope(_)
+            | LiteralValue::MaxKey
+            | LiteralValue::MinKey
+            | LiteralValue::RegularExpression(_)
+            | LiteralValue::Timestamp(_)
+            | LiteralValue::DbPointer(_)
+            | LiteralValue::Symbol(_)
+            | LiteralValue::Undefined => None,
+        }
     }
 
     fn convert_to_object_id(_l: &LiteralValue) -> Option<Result<Expression, ()>> {

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -1112,7 +1112,7 @@ impl ConstantFoldExprVisitor<'_> {
                 v.timestamp_millis() as f64,
             )))),
 
-            // These types are not supported for conversion to int.
+            // These types are not supported for conversion to double.
             LiteralValue::Binary(_)
             | LiteralValue::JavaScriptCode(_)
             | LiteralValue::JavaScriptCodeWithScope(_)
@@ -1186,7 +1186,7 @@ impl ConstantFoldExprVisitor<'_> {
                 v.timestamp_millis(),
             )))),
 
-            // These types are not supported for conversion to int.
+            // These types are not supported for conversion to long.
             LiteralValue::Binary(_)
             | LiteralValue::JavaScriptCode(_)
             | LiteralValue::JavaScriptCodeWithScope(_)
@@ -1297,7 +1297,7 @@ impl ConstantFoldExprVisitor<'_> {
                 })
             }
 
-            // These types are not supported for conversion to int.
+            // These types are not supported for conversion to datetime.
             LiteralValue::Boolean(_)
             | LiteralValue::Binary(_)
             | LiteralValue::Integer(_)
@@ -1313,8 +1313,40 @@ impl ConstantFoldExprVisitor<'_> {
         }
     }
 
-    fn convert_to_object_id(_l: &LiteralValue) -> Option<Result<Expression, ()>> {
-        todo!()
+    fn convert_to_object_id(l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        match l {
+            // Null literal values are handled directly by the `fold_cast_expr` method. Here, we
+            // return None to indicate folding did not happen, but still could in `fold_cast_expr`.
+            LiteralValue::Null => None,
+
+            // ObjectIds are trivially converted to themselves.
+            LiteralValue::ObjectId(v) => Some(Ok(Expression::Literal(LiteralValue::ObjectId(*v)))),
+
+            // Strings that are encoded as valid ObjectIds may be converted to ObjectIds.
+            LiteralValue::String(v) => Some(
+                ObjectId::parse_str(v)
+                    .map(|oid| Expression::Literal(LiteralValue::ObjectId(oid)))
+                    .map_err(|_| ()),
+            ),
+
+            // These types are not supported for conversion to ObjectId.
+            LiteralValue::Boolean(_)
+            | LiteralValue::Integer(_)
+            | LiteralValue::Long(_)
+            | LiteralValue::Double(_)
+            | LiteralValue::RegularExpression(_)
+            | LiteralValue::JavaScriptCode(_)
+            | LiteralValue::JavaScriptCodeWithScope(_)
+            | LiteralValue::Timestamp(_)
+            | LiteralValue::Binary(_)
+            | LiteralValue::DateTime(_)
+            | LiteralValue::Symbol(_)
+            | LiteralValue::Decimal128(_)
+            | LiteralValue::Undefined
+            | LiteralValue::MaxKey
+            | LiteralValue::MinKey
+            | LiteralValue::DbPointer(_) => None,
+        }
     }
 
     fn convert_to_string(_l: &LiteralValue) -> Option<Result<Expression, ()>> {

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -835,7 +835,24 @@ impl ConstantFoldExprVisitor<'_> {
             Type::Boolean => Self::convert_to_boolean(l),
             Type::Int32 => Self::convert_to_int(l),
             Type::Decimal128 => Self::convert_to_decimal(l),
-            _ => None,
+            Type::Double => Self::convert_to_double(l),
+            Type::Int64 => Self::convert_to_int(l),
+            Type::Datetime => Self::convert_to_datetime(l),
+            Type::ObjectId => Self::convert_to_object_id(l),
+            Type::String => Self::convert_to_string(l),
+            Type::Array
+            | Type::Document
+            | Type::BinData
+            | Type::DbPointer
+            | Type::Javascript
+            | Type::JavascriptWithScope
+            | Type::MaxKey
+            | Type::MinKey
+            | Type::Null
+            | Type::RegularExpression
+            | Type::Symbol
+            | Type::Timestamp
+            | Type::Undefined => None,
         }
     }
 
@@ -1027,6 +1044,103 @@ impl ConstantFoldExprVisitor<'_> {
                 .map(|dec| Expression::Literal(LiteralValue::Decimal128(dec)))
                 .map_err(|_| ()),
         )
+    }
+
+    fn convert_to_double(l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        match l {
+            // Null literal values are handled directly by the `fold_cast_expr` method. Here, we
+            // return None to indicate folding did not happen, but still could in `fold_cast_expr`.
+            LiteralValue::Null => None,
+
+            // False converts to 0, true converts to 1.
+            LiteralValue::Boolean(false) => {
+                Some(Ok(Expression::Literal(LiteralValue::Double(0.0))))
+            }
+            LiteralValue::Boolean(true) => Some(Ok(Expression::Literal(LiteralValue::Double(1.0)))),
+
+            // Doubles are trivially converted to themselves.
+            LiteralValue::Double(v) => Some(Ok(Expression::Literal(LiteralValue::Double(*v)))),
+
+            // Other numeric types may be converted to double if they are in range.
+            LiteralValue::Integer(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::Double(*v as f64))))
+            }
+            LiteralValue::Long(v) => {
+                // MongoDB's conversion of long to double can result in loss of precision, so we do
+                // the same by using Rust's `as f64` operation which also loses precision.
+                Some(Ok(Expression::Literal(LiteralValue::Double(*v as f64))))
+            }
+            LiteralValue::Decimal128(v) => {
+                // Since we cannot operate on Decimal128 values directly, we convert to string and
+                // parse as f64. When parsing an f64 value from a string, if the value exceeds the
+                // range of f64, the parse will result in f64::Inf or f64::NegInf. We check if the
+                // parsed value is finite and return an Err otherwise.
+                let s = v.to_string();
+                match f64::from_str(&s) {
+                    Ok(f) if f.is_finite() => {
+                        Some(Ok(Expression::Literal(LiteralValue::Double(f))))
+                    }
+                    _ => Some(Err(())),
+                }
+            }
+
+            // Strings may be converted to double if they represent numeric values in range. If they
+            // are non-numeric or are out of range conversion fails.
+            LiteralValue::String(v) => {
+                match v.to_ascii_lowercase().as_str() {
+                    // We manually check for "nan", "inf", and "-inf" since numbers that exceed the
+                    // bounds of f64 will be parsed into f64::Inf or f64::NegInf, which is not how
+                    // MongoDB behaves. By manually checking these 3 special values, we can still
+                    // leverage f64::from_str/f64::is_finite for values that are in-range.
+                    "nan" => Some(Ok(Expression::Literal(LiteralValue::Double(f64::NAN)))),
+                    "inf" => Some(Ok(Expression::Literal(LiteralValue::Double(f64::INFINITY)))),
+                    "-inf" => Some(Ok(Expression::Literal(LiteralValue::Double(
+                        f64::NEG_INFINITY,
+                    )))),
+                    v => match f64::from_str(v) {
+                        Ok(f) if f.is_finite() => {
+                            Some(Ok(Expression::Literal(LiteralValue::Double(f))))
+                        }
+                        _ => Some(Err(())),
+                    },
+                }
+            }
+
+            // Dates may be converted to double by converting the number of milliseconds since the
+            // epoch that corresponds to the date value to double.
+            LiteralValue::DateTime(v) => Some(Ok(Expression::Literal(LiteralValue::Double(
+                v.timestamp_millis() as f64,
+            )))),
+
+            // These types are not supported for conversion to int.
+            LiteralValue::Binary(_)
+            | LiteralValue::JavaScriptCode(_)
+            | LiteralValue::JavaScriptCodeWithScope(_)
+            | LiteralValue::MaxKey
+            | LiteralValue::MinKey
+            | LiteralValue::ObjectId(_)
+            | LiteralValue::RegularExpression(_)
+            | LiteralValue::Timestamp(_)
+            | LiteralValue::DbPointer(_)
+            | LiteralValue::Symbol(_)
+            | LiteralValue::Undefined => None,
+        }
+    }
+
+    fn convert_to_long(_l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        todo!()
+    }
+
+    fn convert_to_datetime(_l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        todo!()
+    }
+
+    fn convert_to_object_id(_l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        todo!()
+    }
+
+    fn convert_to_string(_l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        todo!()
     }
 
     fn convert_string_literal(s: &str, to: Type) -> Option<Result<Expression, ()>> {

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -819,20 +819,99 @@ impl ConstantFoldExprVisitor<'_> {
         }
     }
 
-    // Attempts to fold a Cast whose input is a constant literal into a literal of
-    // the target type.
-    //
-    // None means no conversion could occur (fall through to schema-based folding).
-    // Some(Err(())) means there was an opportunity for conversion but it statically
-    // fails; since it would also fail at runtime, we fold to the Cast's on_error.
-    // Some(Ok(_)) means we successfully converted a literal.
+    /// Attempts to fold a Cast whose input is a constant literal into a literal
+    /// of the target type.
+    ///
+    /// None means no conversion could occur (fall through to schema-based
+    /// folding).
+    ///
+    /// Some(Err(())) means there was an opportunity for conversion, but it
+    /// statically fails; since it would also fail at runtime, we fold to the
+    /// Cast's on_error.
+    ///
+    /// Some(Ok(_)) means we successfully converted a literal.
     fn convert_literal(l: &LiteralValue, to: Type) -> Option<Result<Expression, ()>> {
-        match l {
-            LiteralValue::String(s) => Self::convert_string_literal(s, to),
-            LiteralValue::Integer(i) => Self::convert_numerical_literal(*i, to),
-            LiteralValue::Long(l) => Self::convert_numerical_literal(*l, to),
-            LiteralValue::Double(d) => Self::convert_numerical_literal(*d, to),
+        match to {
+            Type::Boolean => Self::convert_to_boolean(l),
             _ => None,
+        }
+
+        // match l {
+        //     LiteralValue::String(s) => Self::convert_string_literal(s, to),
+        //     LiteralValue::Integer(i) => Self::convert_numerical_literal(*i, to),
+        //     LiteralValue::Long(l) => Self::convert_numerical_literal(*l, to),
+        //     LiteralValue::Double(d) => Self::convert_numerical_literal(*d, to),
+        //     _ => None,
+        // }
+    }
+
+    /// Attempts to fold a Cast whose input is a literal Array into a literal of
+    /// the target type. Pre-8.3 server versions only support converting arrays
+    /// to boolean (unconditionally `true`). In the future, we may expand this
+    /// method to support post-8.3 conversions.
+    ///
+    /// This function does not do array-to-array conversion as that is done more
+    /// efficiently directly in `fold_cast_expr`.
+    fn convert_literal_array(_: &ArrayExpr, to: Type) -> Option<Result<Expression, ()>> {
+        match to {
+            Type::Boolean => Some(Ok(Expression::Literal(LiteralValue::Boolean(true)))),
+            _ => None,
+        }
+    }
+
+    /// Attempts to fold a Cast whose input is a literal Document into a
+    /// literal of the target type. Pre-8.3 server versions only support
+    /// converting documents to boolean (unconditionally `true`). In the
+    /// future, we may expand this method to support post-8.3 conversions.
+    ///
+    /// This function does not do document-to-document conversion as that
+    /// is done more efficiently directly in `fold_cast_expr`.
+    fn convert_literal_document(_: &DocumentExpr, to: Type) -> Option<Result<Expression, ()>> {
+        match to {
+            Type::Boolean => Some(Ok(Expression::Literal(LiteralValue::Boolean(true)))),
+            _ => None,
+        }
+    }
+
+    fn convert_to_boolean(l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        match l {
+            // Null literal values are handled directly by the `fold_cast_expr` method. Here, we
+            // return None to indicate folding did not happen but could by other means.
+            LiteralValue::Null => None,
+
+            // Booleans are trivially converted to themselves.
+            LiteralValue::Boolean(v) => Some(Ok(Expression::Literal(LiteralValue::Boolean(*v)))),
+
+            // Numeric types are converted to true if non-zero, false otherwise.
+            LiteralValue::Integer(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::Boolean(*v != 0))))
+            }
+            LiteralValue::Long(v) => Some(Ok(Expression::Literal(LiteralValue::Boolean(*v != 0)))),
+            LiteralValue::Double(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::Boolean(*v != 0.0))))
+            }
+            LiteralValue::Decimal128(v) => Some(Ok(Expression::Literal(LiteralValue::Boolean(
+                v.ne(&DECIMAL_ZERO),
+            )))),
+
+            // These types are explicitly supported by MongoDB's `$convert` expression. They all
+            // unconditionally convert to true.
+            LiteralValue::Binary(_)
+            | LiteralValue::DateTime(_)
+            | LiteralValue::JavaScriptCode(_)
+            | LiteralValue::JavaScriptCodeWithScope(_)
+            | LiteralValue::MaxKey
+            | LiteralValue::MinKey
+            | LiteralValue::ObjectId(_)
+            | LiteralValue::RegularExpression(_)
+            | LiteralValue::String(_)
+            | LiteralValue::Timestamp(_) => {
+                Some(Ok(Expression::Literal(LiteralValue::Boolean(true))))
+            }
+
+            // These types are deprecated and their convert-to-bool behavior is no longer documented
+            // by MongoDB. Therefore, we do not attempt to fold them.
+            LiteralValue::DbPointer(_) | LiteralValue::Symbol(_) | LiteralValue::Undefined => None,
         }
     }
 
@@ -897,22 +976,28 @@ impl ConstantFoldExprVisitor<'_> {
     // Constant folds the cast expression
     fn fold_cast_expr(&mut self, cast_expr: CastExpr) -> (Expression, bool) {
         use crate::schema::{ANY_ARRAY, ANY_DOCUMENT};
+
         // If the input is a constant literal, attempt to fold the cast into a
         // literal of the target type. A static conversion failure folds to the
         // Cast's on_error, matching runtime CAST semantics.
-        if let Expression::Literal(ref l) = *cast_expr.expr {
-            match Self::convert_literal(l, cast_expr.to) {
-                Some(Ok(folded)) => return (folded, true),
-                Some(Err(())) => return (*cast_expr.on_error, true),
-                None => {}
-            }
+        let conversion_result = match cast_expr.expr.as_ref() {
+            Expression::Literal(ref l) => Self::convert_literal(l, cast_expr.to),
+            Expression::Array(ref a) => Self::convert_literal_array(a, cast_expr.to),
+            Expression::Document(ref d) => Self::convert_literal_document(d, cast_expr.to),
+            _ => None,
+        };
+
+        match conversion_result {
+            Some(Ok(folded)) => return (folded, true),
+            Some(Err(())) => return (*cast_expr.on_error, true),
+            None => {}
         }
+
         let schema = cast_expr.expr.schema(self.state);
-        if schema.is_err() {
+        let Ok(schema) = schema else {
             return (Expression::Cast(cast_expr), false);
-        }
+        };
         let target_schema = Schema::from(cast_expr.to);
-        let schema = schema.unwrap();
         let sat = schema.satisfies(&target_schema);
         if self.schema_is_exactly_nullish(schema) {
             (*cast_expr.on_null, true)

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -836,7 +836,7 @@ impl ConstantFoldExprVisitor<'_> {
             Type::Int32 => Self::convert_to_int(l),
             Type::Decimal128 => Self::convert_to_decimal(l),
             Type::Double => Self::convert_to_double(l),
-            Type::Int64 => Self::convert_to_int(l),
+            Type::Int64 => Self::convert_to_long(l),
             Type::Datetime => Self::convert_to_datetime(l),
             Type::ObjectId => Self::convert_to_object_id(l),
             Type::String => Self::convert_to_string(l),
@@ -1127,8 +1127,78 @@ impl ConstantFoldExprVisitor<'_> {
         }
     }
 
-    fn convert_to_long(_l: &LiteralValue) -> Option<Result<Expression, ()>> {
-        todo!()
+    fn convert_to_long(l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        match l {
+            // Null literal values are handled directly by the `fold_cast_expr` method. Here, we
+            // return None to indicate folding did not happen, but still could in `fold_cast_expr`.
+            LiteralValue::Null => None,
+
+            // False converts to 0, true converts to 1.
+            LiteralValue::Boolean(false) => Some(Ok(Expression::Literal(LiteralValue::Long(0)))),
+            LiteralValue::Boolean(true) => Some(Ok(Expression::Literal(LiteralValue::Long(1)))),
+
+            // Longs are trivially converted to themselves.
+            LiteralValue::Long(v) => Some(Ok(Expression::Literal(LiteralValue::Long(*v)))),
+
+            // Other numeric types may be converted to long if they are in range.
+            LiteralValue::Integer(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::Long(*v as i64))))
+            }
+            LiteralValue::Double(v) => {
+                // MongoDB truncates when converting a double to a long.
+                let truncated = v.trunc();
+                if truncated.is_finite()
+                    && truncated >= i64::MIN as f64
+                    && truncated <= i64::MAX as f64
+                {
+                    Some(Ok(Expression::Literal(LiteralValue::Long(
+                        truncated as i64,
+                    ))))
+                } else {
+                    Some(Err(()))
+                }
+            }
+            LiteralValue::Decimal128(v) => {
+                // MongoDB truncates when converting a decimal to a long.
+                // Since we cannot operate on Decimal128 values directly, we convert to string and
+                // truncate by taking only the part before the decimal point.
+                let s = v.to_string();
+                let truncated = s.split('.').next().unwrap_or(&s);
+                Some(
+                    i64::from_str(&truncated)
+                        .map(|i| Expression::Literal(LiteralValue::Long(i)))
+                        .map_err(|_| ()),
+                )
+            }
+
+            // Strings may be converted to long if they represent integral numeric values in range
+            // of i64. If they are non-numeric, contain floating point values, or are out of range,
+            // conversion fails.
+            LiteralValue::String(v) => Some(
+                i64::from_str(v)
+                    .map(|i| Expression::Literal(LiteralValue::Long(i)))
+                    .map_err(|_| ()),
+            ),
+
+            // Dates may be converted to long by getting the number of milliseconds since the
+            // epoch that corresponds to the date, which is already a long.
+            LiteralValue::DateTime(v) => Some(Ok(Expression::Literal(LiteralValue::Long(
+                v.timestamp_millis(),
+            )))),
+
+            // These types are not supported for conversion to int.
+            LiteralValue::Binary(_)
+            | LiteralValue::JavaScriptCode(_)
+            | LiteralValue::JavaScriptCodeWithScope(_)
+            | LiteralValue::MaxKey
+            | LiteralValue::MinKey
+            | LiteralValue::ObjectId(_)
+            | LiteralValue::RegularExpression(_)
+            | LiteralValue::Timestamp(_)
+            | LiteralValue::DbPointer(_)
+            | LiteralValue::Symbol(_)
+            | LiteralValue::Undefined => None,
+        }
     }
 
     fn convert_to_datetime(_l: &LiteralValue) -> Option<Result<Expression, ()>> {

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -966,7 +966,7 @@ impl ConstantFoldExprVisitor<'_> {
                 let s = v.to_string();
                 let truncated = s.split('.').next().unwrap_or(&s);
                 Some(
-                    i32::from_str(&truncated)
+                    i32::from_str(truncated)
                         .map(|i| Expression::Literal(LiteralValue::Integer(i)))
                         .map_err(|_| ()),
                 )
@@ -1165,7 +1165,7 @@ impl ConstantFoldExprVisitor<'_> {
                 let s = v.to_string();
                 let truncated = s.split('.').next().unwrap_or(&s);
                 Some(
-                    i64::from_str(&truncated)
+                    i64::from_str(truncated)
                         .map(|i| Expression::Literal(LiteralValue::Long(i)))
                         .map_err(|_| ()),
                 )
@@ -1236,7 +1236,7 @@ impl ConstantFoldExprVisitor<'_> {
                 let s = v.to_string();
                 let truncated = s.split('.').next().unwrap_or(&s);
                 Some(
-                    i64::from_str(&truncated)
+                    i64::from_str(truncated)
                         .map(|i| {
                             Expression::Literal(LiteralValue::DateTime(
                                 bson::DateTime::from_millis(i),

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -834,6 +834,7 @@ impl ConstantFoldExprVisitor<'_> {
         match to {
             Type::Boolean => Self::convert_to_boolean(l),
             Type::Int32 => Self::convert_to_int(l),
+            Type::Decimal128 => Self::convert_to_decimal(l),
             _ => None,
         }
     }
@@ -979,6 +980,55 @@ impl ConstantFoldExprVisitor<'_> {
         }
     }
 
+    fn convert_to_decimal(l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        let str_to_convert = match l {
+            // Null literal values are handled directly by the `fold_cast_expr` method. Here, we
+            // return None to indicate folding did not happen, but still could in `fold_cast_expr`.
+            LiteralValue::Null => return None,
+
+            // False converts to 0, true converts to 1.
+            LiteralValue::Boolean(false) => "0",
+            LiteralValue::Boolean(true) => "1",
+
+            // Numeric types convert to decimal without loss of precision.
+            LiteralValue::Integer(v) => &format!("{v}"),
+            LiteralValue::Long(v) => &format!("{v}"),
+            LiteralValue::Double(v) => &format!("{v}"),
+
+            // Decimal128s are trivially converted to themselves.
+            LiteralValue::Decimal128(v) => {
+                return Some(Ok(Expression::Literal(LiteralValue::Decimal128(*v))))
+            }
+
+            // Strings may be converted to decimal128 if they represent numeric values in range of
+            // decimal128. If they are non-numeric or are out of range, conversion fails.
+            LiteralValue::String(v) => v,
+
+            // Dates may be converted to decimal128 by converting the number of milliseconds since
+            // the epoch that corresponds to the date value to decimal128.
+            LiteralValue::DateTime(v) => &format!("{}", v.timestamp_millis()),
+
+            // These types are not supported for conversion to decimal128.
+            LiteralValue::Binary(_)
+            | LiteralValue::JavaScriptCode(_)
+            | LiteralValue::JavaScriptCodeWithScope(_)
+            | LiteralValue::MaxKey
+            | LiteralValue::MinKey
+            | LiteralValue::ObjectId(_)
+            | LiteralValue::RegularExpression(_)
+            | LiteralValue::Timestamp(_)
+            | LiteralValue::DbPointer(_)
+            | LiteralValue::Symbol(_)
+            | LiteralValue::Undefined => return None,
+        };
+
+        Some(
+            Decimal128::from_str(str_to_convert)
+                .map(|dec| Expression::Literal(LiteralValue::Decimal128(dec)))
+                .map_err(|_| ()),
+        )
+    }
+
     fn convert_string_literal(s: &str, to: Type) -> Option<Result<Expression, ()>> {
         match to {
             // We'll handle the no-op convert too. But we are not handling every possible case.
@@ -1014,22 +1064,6 @@ impl ConstantFoldExprVisitor<'_> {
                 let oid = ObjectId::parse_str(s).ok();
                 match oid {
                     Some(oid) => Some(Ok(Expression::Literal(LiteralValue::ObjectId(oid)))),
-                    None => Some(Err(())),
-                }
-            }
-            _ => None,
-        }
-    }
-
-    fn convert_numerical_literal<T: std::fmt::Display>(
-        i: T,
-        to: Type,
-    ) -> Option<Result<Expression, ()>> {
-        match to {
-            Type::Decimal128 => {
-                let dec = Decimal128::from_str(&format!("{i}")).ok();
-                match dec {
-                    Some(dec) => Some(Ok(Expression::Literal(LiteralValue::Decimal128(dec)))),
                     None => Some(Err(())),
                 }
             }

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -1349,49 +1349,52 @@ impl ConstantFoldExprVisitor<'_> {
         }
     }
 
-    fn convert_to_string(_l: &LiteralValue) -> Option<Result<Expression, ()>> {
-        todo!()
-    }
+    fn convert_to_string(l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        match l {
+            // Null literal values are handled directly by the `fold_cast_expr` method. Here, we
+            // return None to indicate folding did not happen, but still could in `fold_cast_expr`.
+            LiteralValue::Null => None,
 
-    fn convert_string_literal(s: &str, to: Type) -> Option<Result<Expression, ()>> {
-        match to {
-            // We'll handle the no-op convert too. But we are not handling every possible case.
-            // This is mostly used to easily test that we are properly recursing, but could offer
-            // some benefit.
-            Type::String => Some(Ok(Expression::Literal(LiteralValue::String(s.to_string())))),
-            Type::Datetime => {
-                // format YYYY-MM-DD(T| )HH:mm:SS(.ms)?Z?, where `?` denotes optional
-                let chrono_dt: Option<chrono::DateTime<Utc>> = if s.ends_with('Z') {
-                    s.parse().ok()
-                } else {
-                    let mut s = s.to_string();
-                    s.push('Z');
-                    s.parse().ok()
-                };
-                // We cannot guarantee our format here supports everything that MongoDB supports,
-                // so we instead fall back to the original cast expression when our attempt to
-                // create a Date fails, and allow MongoDB to succeed or fail as it will.
-                chrono_dt.map(|chrono_dt| {
-                    Ok(Expression::Literal(LiteralValue::DateTime(
-                        chrono_dt.into(),
-                    )))
-                })
+            // Strings are trivially converted to themselves.
+            LiteralValue::String(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::String(v.clone()))))
             }
-            Type::Decimal128 => {
-                let dec = Decimal128::from_str(s).ok();
-                match dec {
-                    Some(dec) => Some(Ok(Expression::Literal(LiteralValue::Decimal128(dec)))),
-                    None => Some(Err(())),
-                }
+
+            // A subset of types is supported by MongoDB pre-8.3, so we constrain ourselves to those
+            // types here.
+            LiteralValue::Boolean(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::String(v.to_string()))))
             }
-            Type::ObjectId => {
-                let oid = ObjectId::parse_str(s).ok();
-                match oid {
-                    Some(oid) => Some(Ok(Expression::Literal(LiteralValue::ObjectId(oid)))),
-                    None => Some(Err(())),
-                }
+            LiteralValue::Integer(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::String(v.to_string()))))
             }
-            _ => None,
+            LiteralValue::Long(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::String(v.to_string()))))
+            }
+            LiteralValue::Double(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::String(v.to_string()))))
+            }
+            LiteralValue::Decimal128(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::String(v.to_string()))))
+            }
+            LiteralValue::ObjectId(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::String(v.to_string()))))
+            }
+            LiteralValue::DateTime(v) => {
+                Some(Ok(Expression::Literal(LiteralValue::String(v.to_string()))))
+            }
+
+            // These types are not supported for conversion to string.
+            LiteralValue::RegularExpression(_)
+            | LiteralValue::JavaScriptCode(_)
+            | LiteralValue::JavaScriptCodeWithScope(_)
+            | LiteralValue::Timestamp(_)
+            | LiteralValue::Binary(_)
+            | LiteralValue::Symbol(_)
+            | LiteralValue::Undefined
+            | LiteralValue::MaxKey
+            | LiteralValue::MinKey
+            | LiteralValue::DbPointer(_) => None,
         }
     }
 

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -833,16 +833,9 @@ impl ConstantFoldExprVisitor<'_> {
     fn convert_literal(l: &LiteralValue, to: Type) -> Option<Result<Expression, ()>> {
         match to {
             Type::Boolean => Self::convert_to_boolean(l),
+            Type::Int32 => Self::convert_to_int(l),
             _ => None,
         }
-
-        // match l {
-        //     LiteralValue::String(s) => Self::convert_string_literal(s, to),
-        //     LiteralValue::Integer(i) => Self::convert_numerical_literal(*i, to),
-        //     LiteralValue::Long(l) => Self::convert_numerical_literal(*l, to),
-        //     LiteralValue::Double(d) => Self::convert_numerical_literal(*d, to),
-        //     _ => None,
-        // }
     }
 
     /// Attempts to fold a Cast whose input is a literal Array into a literal of
@@ -876,7 +869,7 @@ impl ConstantFoldExprVisitor<'_> {
     fn convert_to_boolean(l: &LiteralValue) -> Option<Result<Expression, ()>> {
         match l {
             // Null literal values are handled directly by the `fold_cast_expr` method. Here, we
-            // return None to indicate folding did not happen but could by other means.
+            // return None to indicate folding did not happen, but still could in `fold_cast_expr`.
             LiteralValue::Null => None,
 
             // Booleans are trivially converted to themselves.
@@ -912,6 +905,77 @@ impl ConstantFoldExprVisitor<'_> {
             // These types are deprecated and their convert-to-bool behavior is no longer documented
             // by MongoDB. Therefore, we do not attempt to fold them.
             LiteralValue::DbPointer(_) | LiteralValue::Symbol(_) | LiteralValue::Undefined => None,
+        }
+    }
+
+    fn convert_to_int(l: &LiteralValue) -> Option<Result<Expression, ()>> {
+        match l {
+            // Null literal values are handled directly by the `fold_cast_expr` method. Here, we
+            // return None to indicate folding did not happen, but still could in `fold_cast_expr`.
+            LiteralValue::Null => None,
+
+            // False converts to 0, true converts to 1.
+            LiteralValue::Boolean(false) => Some(Ok(Expression::Literal(LiteralValue::Integer(0)))),
+            LiteralValue::Boolean(true) => Some(Ok(Expression::Literal(LiteralValue::Integer(1)))),
+
+            // Integers are trivially converted to themselves.
+            LiteralValue::Integer(v) => Some(Ok(Expression::Literal(LiteralValue::Integer(*v)))),
+
+            // Other numeric types may be converted to int if they are in range.
+            LiteralValue::Long(v) => Some(
+                i32::try_from(*v)
+                    .map(|i| Expression::Literal(LiteralValue::Integer(i)))
+                    .map_err(|_| ()),
+            ),
+            LiteralValue::Double(v) => {
+                // MongoDB truncates when converting a double to an int.
+                let truncated = v.trunc();
+                if truncated.is_finite()
+                    && truncated >= i32::MIN as f64
+                    && truncated <= i32::MAX as f64
+                {
+                    Some(Ok(Expression::Literal(LiteralValue::Integer(
+                        truncated as i32,
+                    ))))
+                } else {
+                    Some(Err(()))
+                }
+            }
+            LiteralValue::Decimal128(v) => {
+                // MongoDB truncates when converting a decimal to an int.
+                // Since we cannot operate on Decimal128 values directly, we convert to string and
+                // truncate by taking only the part before the decimal point.
+                let s = v.to_string();
+                let truncated = s.split('.').next().unwrap_or(&s);
+                Some(
+                    i32::from_str(&truncated)
+                        .map(|i| Expression::Literal(LiteralValue::Integer(i)))
+                        .map_err(|_| ()),
+                )
+            }
+
+            // Strings may be converted to int if they represent integral numeric values in range of
+            // int32. If they are non-numeric, contain floating point values, or are out of range,
+            // conversion fails.
+            LiteralValue::String(v) => Some(
+                i32::from_str(v)
+                    .map(|i| Expression::Literal(LiteralValue::Integer(i)))
+                    .map_err(|_| ()),
+            ),
+
+            // These types are not supported for conversion to int.
+            LiteralValue::Binary(_)
+            | LiteralValue::DateTime(_)
+            | LiteralValue::JavaScriptCode(_)
+            | LiteralValue::JavaScriptCodeWithScope(_)
+            | LiteralValue::MaxKey
+            | LiteralValue::MinKey
+            | LiteralValue::ObjectId(_)
+            | LiteralValue::RegularExpression(_)
+            | LiteralValue::Timestamp(_)
+            | LiteralValue::DbPointer(_)
+            | LiteralValue::Symbol(_)
+            | LiteralValue::Undefined => None,
         }
     }
 

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -31,6 +31,9 @@ lazy_static! {
     static ref DEFAULT_CATALOG: Catalog = Catalog::default();
 }
 
+const MAX_F64_AS_STR: &str = "179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+const MIN_F64_AS_STR: &str = "-179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
 impl ConstantFoldExprVisitor<'_> {
     // Checks if a vector of expressions contains a null or missing expression
     fn has_null_arg(&self, args: &[Expression]) -> bool {
@@ -933,8 +936,9 @@ impl ConstantFoldExprVisitor<'_> {
             LiteralValue::Null => None,
 
             // False converts to 0, true converts to 1.
-            LiteralValue::Boolean(false) => Some(Ok(Expression::Literal(LiteralValue::Integer(0)))),
-            LiteralValue::Boolean(true) => Some(Ok(Expression::Literal(LiteralValue::Integer(1)))),
+            LiteralValue::Boolean(b) => {
+                Some(Ok(Expression::Literal(LiteralValue::Integer((*b).into()))))
+            }
 
             // Integers are trivially converted to themselves.
             LiteralValue::Integer(v) => Some(Ok(Expression::Literal(LiteralValue::Integer(*v)))),
@@ -1053,10 +1057,9 @@ impl ConstantFoldExprVisitor<'_> {
             LiteralValue::Null => None,
 
             // False converts to 0, true converts to 1.
-            LiteralValue::Boolean(false) => {
-                Some(Ok(Expression::Literal(LiteralValue::Double(0.0))))
+            LiteralValue::Boolean(b) => {
+                Some(Ok(Expression::Literal(LiteralValue::Double((*b).into()))))
             }
-            LiteralValue::Boolean(true) => Some(Ok(Expression::Literal(LiteralValue::Double(1.0)))),
 
             // Doubles are trivially converted to themselves.
             LiteralValue::Double(v) => Some(Ok(Expression::Literal(LiteralValue::Double(*v)))),
@@ -1099,7 +1102,18 @@ impl ConstantFoldExprVisitor<'_> {
                     )))),
                     v => match f64::from_str(v) {
                         Ok(f) if f.is_finite() => {
-                            Some(Ok(Expression::Literal(LiteralValue::Double(f))))
+                            // It is possible for a string to represent an f64 smaller than f64::MIN
+                            // or larger than f64::MAX, but for it to parse as f64::MIN or f64::MAX,
+                            // respectively. If this is the case, we should return an error since
+                            // MongoDB does not tolerate such values. (Note that we do the is_finite
+                            // check above because typically values out of range parse into +/-inf.)
+                            if (f == f64::MAX && v != MAX_F64_AS_STR)
+                                || (f == f64::MIN && v != MIN_F64_AS_STR)
+                            {
+                                Some(Err(()))
+                            } else {
+                                Some(Ok(Expression::Literal(LiteralValue::Double(f))))
+                            }
                         }
                         _ => Some(Err(())),
                     },
@@ -1134,8 +1148,9 @@ impl ConstantFoldExprVisitor<'_> {
             LiteralValue::Null => None,
 
             // False converts to 0, true converts to 1.
-            LiteralValue::Boolean(false) => Some(Ok(Expression::Literal(LiteralValue::Long(0)))),
-            LiteralValue::Boolean(true) => Some(Ok(Expression::Literal(LiteralValue::Long(1)))),
+            LiteralValue::Boolean(b) => {
+                Some(Ok(Expression::Literal(LiteralValue::Long((*b).into()))))
+            }
 
             // Longs are trivially converted to themselves.
             LiteralValue::Long(v) => Some(Ok(Expression::Literal(LiteralValue::Long(*v)))),

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -3134,7 +3134,7 @@ mod cast {
         }),
     );
 
-    // Regardless of target type, casting from an exactly nullish literal folds to the on_null
+    // Regardless of target type, casting from an exactly nullish expr folds to the on_null
     // branch
     test_constant_fold!(
         from_exactly_nullish_expr,

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -60,6 +60,10 @@ lazy_static! {
         let chrono_dt: chrono::DateTime<Utc> = "2014-01-01T08:15:39Z".parse().unwrap();
         chrono_dt.into()
     };
+    static ref DATE_WITH_TZ_OFFSET: bson::DateTime = {
+        let chrono_dt: chrono::DateTime<Utc> = "2018-03-03T12:00:00+0500".parse().unwrap();
+        chrono_dt.into()
+    };
     static ref DATE_WITHOUT_TIME: bson::DateTime = {
         let chrono_dt: chrono::DateTime<Utc> = "2014-01-01T00:00:00Z".parse().unwrap();
         chrono_dt.into()
@@ -5866,11 +5870,50 @@ mod cast {
         );
 
         test_constant_fold!(
+            from_string_with_date_with_timezone_offset,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![
+                    Expression::Literal(LiteralValue::DateTime(*DATE_WITH_TZ_OFFSET)),
+                    Expression::Literal(LiteralValue::DateTime(*DATE_WITH_TZ_OFFSET)),
+                ],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![
+                    Expression::Cast(CastExpr {
+                        expr: Expression::Literal(LiteralValue::String(
+                            "2018-03-03T12:00:00+0500".into()
+                        ))
+                        .into(),
+                        to: Type::Datetime,
+                        on_null: Expression::Literal(LiteralValue::Null).into(),
+                        on_error: Expression::Literal(LiteralValue::Null).into(),
+                        is_nullable: true,
+                    }),
+                    Expression::Cast(CastExpr {
+                        expr: Expression::Literal(LiteralValue::String(
+                            "2018-03-03 12:00:00+0500".into()
+                        ))
+                        .into(),
+                        to: Type::Datetime,
+                        on_null: Expression::Literal(LiteralValue::Null).into(),
+                        on_error: Expression::Literal(LiteralValue::Null).into(),
+                        is_nullable: true,
+                    }),
+                ],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
             from_string_with_date_without_time,
             expected = Stage::Array(ArraySource {
                 alias: "".into(),
                 array: vec![Expression::Literal(LiteralValue::DateTime(
-                    *DATE_WITHOUT_MS
+                    *DATE_WITHOUT_TIME
                 ))],
                 cache: SchemaCache::new(),
             }),

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -3112,80 +3112,63 @@ mod cast {
 
     use crate::schema::{Atomic, Schema, NULLISH};
 
+    macro_rules! test_constant_fold_cast_literal {
+        ($func_name:ident, expected_expr = $expected:expr, input_expr = $input:expr, input_to = $input_to:expr, $(schema_env = $schema_env:expr,)?) => {
+            test_constant_fold! {
+                $func_name,
+                expected = Stage::Array(ArraySource {
+                    alias: "".into(),
+                    array: vec![$expected],
+                    cache: SchemaCache::new(),
+                }),
+                expected_changed = true,
+                input = Stage::Array(ArraySource {
+                    alias: "".into(),
+                    array: vec![Expression::Cast(CastExpr {
+                        expr: $input.into(),
+                        to: $input_to,
+                        on_null: Expression::Literal(LiteralValue::String("null".into())).into(),
+                        on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
+                        is_nullable: false,
+                    })],
+                    cache: SchemaCache::new(),
+                }),
+                $(schema_env = $schema_env,)?
+            }
+        };
+    }
+
     // Regardless of target type, casting from null literal folds to the on_null branch
-    test_constant_fold!(
+    test_constant_fold_cast_literal!(
         from_null_literal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("null".into()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::Null).into(),
-                to: Type::Int32,
-                on_null: Expression::Literal(LiteralValue::String("null".into())).into(),
-                on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
+        expected_expr = Expression::Literal(LiteralValue::String("null".into())),
+        input_expr = Expression::Literal(LiteralValue::Null),
+        input_to = Type::Int32,
     );
 
     // Regardless of target type, casting from an exactly nullish expr folds to the on_null
     // branch
-    test_constant_fold!(
+    test_constant_fold_cast_literal!(
         from_exactly_nullish_expr,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("null".into()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Reference(("bar", 0u16).into()).into(),
-                to: Type::Int32,
-                on_null: Expression::Literal(LiteralValue::String("null".into())).into(),
-                on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
+        expected_expr = Expression::Literal(LiteralValue::String("null".into())),
+        input_expr = Expression::Reference(("bar", 0u16).into()),
+        input_to = Type::Int32,
         schema_env = map! {
             ("bar", 0u16).into() => NULLISH.clone(),
         },
     );
 
-    test_constant_fold!(
+    test_constant_fold_cast_literal!(
         valid_nested_casts,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Decimal128(*STRING_DEC))],
-            cache: SchemaCache::new(),
+        expected_expr = Expression::Literal(LiteralValue::Decimal128(*STRING_DEC)),
+        input_expr = Expression::Cast(CastExpr {
+            expr: Expression::Literal(LiteralValue::String("3.14159265".into())).into(),
+            to: Type::String,
+            on_null: Expression::Literal(LiteralValue::Null).into(),
+            on_error: Expression::Literal(LiteralValue::Null).into(),
+            is_nullable: true,
         }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("3.14159265".into())).into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })
-                .into(),
-                to: Type::Decimal128,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
+        input_to = Type::Decimal128,
     );
 
     test_constant_fold_no_op!(
@@ -3212,51 +3195,20 @@ mod cast {
     mod to_array {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_array,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Array(
-                    vec![Expression::Literal(LiteralValue::Boolean(true))].into()
-                )],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Array(
-                        vec![Expression::Literal(LiteralValue::Boolean(true))].into()
-                    )
-                    .into(),
-                    to: Type::Array,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr =
+                Expression::Array(vec![Expression::Literal(LiteralValue::Boolean(true))].into()),
+            input_expr =
+                Expression::Array(vec![Expression::Literal(LiteralValue::Boolean(true))].into()),
+            input_to = Type::Array,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_non_array,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String("error".into()))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Integer(0)).into(),
-                    to: Type::Array,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Integer(0)),
+            input_to = Type::Array,
         );
     }
 
@@ -3266,57 +3218,28 @@ mod cast {
     mod to_document {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_document,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Document(
-                    unchecked_unique_linked_hash_map! {
-                        "a".into() => Expression::Literal(LiteralValue::Integer(1))
-                    }
-                    .into()
-                )],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Document(
-                        unchecked_unique_linked_hash_map! {
-                            "a".into() => Expression::Literal(LiteralValue::Integer(1))
-                        }
-                        .into()
-                    )
-                    .into(),
-                    to: Type::Document,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Document(
+                unchecked_unique_linked_hash_map! {
+                    "a".into() => Expression::Literal(LiteralValue::Integer(1))
+                }
+                .into()
+            ),
+            input_expr = Expression::Document(
+                unchecked_unique_linked_hash_map! {
+                    "a".into() => Expression::Literal(LiteralValue::Integer(1))
+                }
+                .into()
+            ),
+            input_to = Type::Document,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_non_document,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String("error".into()))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Integer(0)).into(),
-                    to: Type::Document,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Integer(0)),
+            input_to = Type::Document,
         );
     }
 
@@ -3325,518 +3248,188 @@ mod cast {
     mod to_boolean {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_non_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Reference(("bar", 0u16).into())],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Reference(("bar", 0u16).into()).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Reference(("bar", 0u16).into()),
+            input_expr = Expression::Reference(("bar", 0u16).into()),
+            input_to = Type::Boolean,
             schema_env = map! {
                 ("bar", 0u16).into() => Schema::Atomic(Atomic::Boolean),
             },
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_array_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Array(ArrayExpr { array: vec![] }).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Array(ArrayExpr { array: vec![] }),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_bindata_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Binary(bson::Binary {
-                        bytes: vec![],
-                        subtype: bson::spec::BinarySubtype::Generic,
-                    }))
-                    .into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::Binary(bson::Binary {
+                bytes: vec![],
+                subtype: bson::spec::BinarySubtype::Generic,
+            })),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_true_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_false_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_date_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::DateTime(bson::DateTime::now())).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::DateTime(bson::DateTime::now())),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_zero_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str("0.0").unwrap()
-                    ))
-                    .into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("0.0").unwrap()
+            )),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_non_zero_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str("1.0").unwrap()
-                    ))
-                    .into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("1.0").unwrap()
+            )),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_document_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Document(DocumentExpr {
+                document: unchecked_unique_linked_hash_map! {},
             }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Document(DocumentExpr {
-                        document: unchecked_unique_linked_hash_map! {},
-                    })
-                    .into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_zero_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(0.0)).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_expr = Expression::Literal(LiteralValue::Double(0.0)),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_non_zero_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(1.0)).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::Double(1.0)),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_int_zero_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Integer(0)).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_expr = Expression::Literal(LiteralValue::Integer(0)),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_int_non_zero_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Integer(1)).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::Integer(1)),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_javascript_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::JavaScriptCode("".to_string())).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::JavaScriptCode("".to_string())),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_javascript_with_scope_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::JavaScriptCodeWithScope(
-                        bson::JavaScriptCodeWithScope {
-                            code: "".to_string(),
-                            scope: bson::Document::new(),
-                        }
-                    ))
-                    .into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::JavaScriptCodeWithScope(
+                bson::JavaScriptCodeWithScope {
+                    code: "".to_string(),
+                    scope: bson::Document::new(),
+                }
+            )),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_zero_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(0)).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_expr = Expression::Literal(LiteralValue::Long(0)),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_non_zero_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(1)).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::Long(1)),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_max_key_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::MaxKey).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::MaxKey),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_min_key_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::MinKey).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::MinKey),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_object_id_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::ObjectId(bson::oid::ObjectId::new()))
-                        .into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::ObjectId(bson::oid::ObjectId::new())),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_regex_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::RegularExpression(bson::Regex {
-                        pattern: "".to_string(),
-                        options: "".to_string(),
-                    }))
-                    .into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::RegularExpression(bson::Regex {
+                pattern: "".to_string(),
+                options: "".to_string(),
+            })),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("".to_string())).into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::String("".to_string())),
+            input_to = Type::Boolean,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_timestamp_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Timestamp(bson::Timestamp {
-                        time: 0,
-                        increment: 0,
-                    }))
-                    .into(),
-                    to: Type::Boolean,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_expr = Expression::Literal(LiteralValue::Timestamp(bson::Timestamp {
+                time: 0,
+                increment: 0,
+            })),
+            input_to = Type::Boolean,
         );
     }
 
@@ -3845,579 +3438,200 @@ mod cast {
     mod to_int {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_integer_non_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Reference(("bar", 0u16).into())],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Reference(("bar", 0u16).into()).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Reference(("bar", 0u16).into()),
+            input_expr = Expression::Reference(("bar", 0u16).into()),
+            input_to = Type::Int32,
             schema_env = map! {
                 ("bar", 0u16).into() => Schema::Atomic(Atomic::Integer),
             },
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_false_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(0))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(0)),
+            input_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_true_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(1))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(1)),
+            input_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_to = Type::Int32,
         );
 
         // In general, for Decimal and Double, $convert truncates. The truncated value must be
         // within the range of a 32-bit signed integer, otherwise the onError value is returned.
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(1))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str("1.2").unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(1)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("1.2").unwrap()
+            )),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_max_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(i32::MAX))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}.9", i32::MAX).as_str()).unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(i32::MAX)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}.9", i32::MAX).as_str()).unwrap()
+            )),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_min_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(i32::MIN))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}.9", i32::MIN).as_str()).unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(i32::MIN)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}.9", i32::MIN).as_str()).unwrap()
+            )),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_greater_than_max_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}", i32::MAX as i64 + 1i64).as_str())
-                            .unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}", i32::MAX as i64 + 1i64).as_str()).unwrap()
+            )),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_less_than_min_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}", i32::MIN as i64 - 1i64).as_str())
-                            .unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}", i32::MIN as i64 - 1i64).as_str()).unwrap()
+            )),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(1))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(1.2)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(1)),
+            input_expr = Expression::Literal(LiteralValue::Double(1.2)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_max_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(i32::MAX))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(i32::MAX as f64 + 0.9)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(i32::MAX)),
+            input_expr = Expression::Literal(LiteralValue::Double(i32::MAX as f64 + 0.9)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_min_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(i32::MIN))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(i32::MIN as f64 - 0.9)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(i32::MIN)),
+            input_expr = Expression::Literal(LiteralValue::Double(i32::MIN as f64 - 0.9)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_greater_than_max_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(i32::MAX as f64 + 1.0)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Double(i32::MAX as f64 + 1.0)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_less_than_min_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(i32::MIN as f64 - 1.0)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Double(i32::MIN as f64 - 1.0)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(5))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(5)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(5)),
+            input_expr = Expression::Literal(LiteralValue::Long(5)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_max_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(i32::MAX))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(i32::MAX as i64)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(i32::MAX)),
+            input_expr = Expression::Literal(LiteralValue::Long(i32::MAX as i64)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_min_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(i32::MIN))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(i32::MIN as i64)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(i32::MIN)),
+            input_expr = Expression::Literal(LiteralValue::Long(i32::MIN as i64)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_greater_than_max_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(i32::MAX as i64 + 1)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Long(i32::MAX as i64 + 1)),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_less_than_min_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(i32::MIN as i64 - 1)).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Long(i32::MIN as i64 - 1)),
+            input_to = Type::Int32,
         );
-        test_constant_fold!(
+
+        test_constant_fold_cast_literal!(
             from_string_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(5))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("5".to_string())).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(5)),
+            input_expr = Expression::Literal(LiteralValue::String("5".to_string())),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_max_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(i32::MAX))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(i32::MAX.to_string())).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(i32::MAX)),
+            input_expr = Expression::Literal(LiteralValue::String(i32::MAX.to_string())),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_min_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Integer(i32::MIN))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(i32::MIN.to_string())).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Integer(i32::MIN)),
+            input_expr = Expression::Literal(LiteralValue::String(i32::MIN.to_string())),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_greater_than_max_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(format!(
-                        "{}",
-                        i32::MAX as i64 + 1i64
-                    )))
-                    .into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String(format!(
+                "{}",
+                i32::MAX as i64 + 1i64
+            ))),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_less_than_min_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(format!(
-                        "{}",
-                        i32::MIN as i64 - 1i64
-                    )))
-                    .into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String(format!(
+                "{}",
+                i32::MIN as i64 - 1i64
+            ))),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_not_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("5.5".to_string())).into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String("5.5".to_string())),
+            input_to = Type::Int32,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_not_a_number_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("not a number".to_string()))
-                        .into(),
-                    to: Type::Int32,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String("not a number".to_string())),
+            input_to = Type::Int32,
         );
     }
 
@@ -4426,207 +3640,80 @@ mod cast {
     mod to_decimal {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_non_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Reference(("bar", 0u16).into())],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Reference(("bar", 0u16).into()).into(),
-                    to: Type::Decimal128,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Reference(("bar", 0u16).into()),
+            input_expr = Expression::Reference(("bar", 0u16).into()),
+            input_to = Type::Decimal128,
             schema_env = map! {
                 ("bar", 0u16).into() => Schema::Atomic(Atomic::Decimal),
             },
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_false_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Decimal128(
-                    bson::Decimal128::from_str("0").unwrap()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
-                    to: Type::Decimal128,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("0").unwrap()
+            )),
+            input_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_to = Type::Decimal128,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_true_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Decimal128(
-                    bson::Decimal128::from_str("1").unwrap()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                    to: Type::Decimal128,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("1").unwrap()
+            )),
+            input_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_to = Type::Decimal128,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Decimal128(*DOUBLE_DEC))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(std::f64::consts::PI)).into(),
-                    to: Type::Decimal128,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Decimal128(*DOUBLE_DEC)),
+            input_expr = Expression::Literal(LiteralValue::Double(std::f64::consts::PI)),
+            input_to = Type::Decimal128,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Decimal128(*INT_DEC))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Integer(3)).into(),
-                    to: Type::Decimal128,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Decimal128(*INT_DEC)),
+            input_expr = Expression::Literal(LiteralValue::Integer(3)),
+            input_to = Type::Decimal128,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Decimal128(*INT_DEC))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(3)).into(),
-                    to: Type::Decimal128,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Decimal128(*INT_DEC)),
+            input_expr = Expression::Literal(LiteralValue::Long(3)),
+            input_to = Type::Decimal128,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_valid_string_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Decimal128(*STRING_DEC))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("3.14159265".into())).into(),
-                    to: Type::Decimal128,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Decimal128(*STRING_DEC)),
+            input_expr = Expression::Literal(LiteralValue::String("3.14159265".into())),
+            input_to = Type::Decimal128,
         );
 
         // A string that cannot be parsed as a Decimal128 statically fails, so the cast
         // folds to its on_error branch.
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_invalid_string_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String("error".into()))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("hello".into())).into(),
-                    to: Type::Decimal128,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String("hello".into())),
+            input_to = Type::Decimal128,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_date_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Decimal128(
-                    bson::Decimal128::from_str("1522039108044").unwrap()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::DateTime(bson::DateTime::from_millis(
-                        1522039108044
-                    )))
-                    .into(),
-                    to: Type::Decimal128,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("1522039108044").unwrap()
+            )),
+            input_expr = Expression::Literal(LiteralValue::DateTime(bson::DateTime::from_millis(
+                1522039108044
+            ))),
+            input_to = Type::Decimal128,
         );
     }
 
@@ -4635,354 +3722,127 @@ mod cast {
     mod to_double {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_non_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Reference(("bar", 0u16).into())],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Reference(("bar", 0u16).into()).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Reference(("bar", 0u16).into()),
+            input_expr = Expression::Reference(("bar", 0u16).into()),
+            input_to = Type::Double,
             schema_env = map! {
                 ("bar", 0u16).into() => Schema::Atomic(Atomic::Double),
             },
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_false_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(0.0))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(0.0)),
+            input_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_true_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(1.0))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(1.0)),
+            input_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(1.2))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str("1.2").unwrap()
-                    ))
-                    .into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(1.2)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("1.2").unwrap()
+            )),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_max_f64_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(f64::MAX))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}", f64::MAX).as_str()).unwrap()
-                    ))
-                    .into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(f64::MAX)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}", f64::MAX).as_str()).unwrap()
+            )),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_min_f64_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(f64::MIN))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}", f64::MIN).as_str()).unwrap()
-                    ))
-                    .into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(f64::MIN)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}", f64::MIN).as_str()).unwrap()
+            )),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_greater_than_max_f64_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("1{}", f64::MAX).as_str()).unwrap()
-                    ))
-                    .into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("1{}", f64::MAX).as_str()).unwrap()
+            )),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_less_than_min_f64_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(
-                            format!("{}", f64::MIN).replacen('1', "2", 1).as_str()
-                        )
-                        .unwrap()
-                    ))
-                    .into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}", f64::MIN).replacen('1', "2", 1).as_str())
+                    .unwrap()
+            )),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(5.0))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Integer(5)).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(5.0)),
+            input_expr = Expression::Literal(LiteralValue::Integer(5)),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(10000.0))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(10000)).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(10000.0)),
+            input_expr = Expression::Literal(LiteralValue::Long(10000)),
+            input_to = Type::Double,
         );
 
         // MongoDB loses precision when converting from sufficiently large long values to double.
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_max_i64_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(i64::MAX as f64))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(i64::MAX)).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(i64::MAX as f64)),
+            input_expr = Expression::Literal(LiteralValue::Long(i64::MAX)),
+            input_to = Type::Double,
         );
 
         // MongoDB loses precision when converting from sufficiently large long values to double.
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_min_i64_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(i64::MIN as f64))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(i64::MIN)).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(i64::MIN as f64)),
+            input_expr = Expression::Literal(LiteralValue::Long(i64::MIN)),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(-5.5))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("-5.5".to_string())).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(-5.5)),
+            input_expr = Expression::Literal(LiteralValue::String("-5.5".to_string())),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_greater_than_max_f64_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(format!("1{}", f64::MAX)))
-                        .into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String(format!("1{}", f64::MAX))),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_less_than_min_f64_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(
-                        format!("{}", f64::MIN).replacen('1', "2", 1)
-                    ))
-                    .into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String(
+                format!("{}", f64::MIN).replacen('1', "2", 1)
+            )),
+            input_to = Type::Double,
         );
 
         // f64::NAN does not equal f64::NAN, so we can't use test_constant_fold! conveniently.
@@ -5038,115 +3898,41 @@ mod cast {
             assert!(folded_val.is_nan());
         }
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_inf_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(f64::INFINITY))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("inf".to_string())).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(f64::INFINITY)),
+            input_expr = Expression::Literal(LiteralValue::String("inf".to_string())),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_neg_inf_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(f64::NEG_INFINITY))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("-inf".to_string())).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(f64::NEG_INFINITY)),
+            input_expr = Expression::Literal(LiteralValue::String("-inf".to_string())),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_scientific_notation_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(50000000000.0))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("5e10".to_string())).into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(50000000000.0)),
+            input_expr = Expression::Literal(LiteralValue::String("5e10".to_string())),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_invalid_string_not_a_number_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("not a number".to_string()))
-                        .into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String("not a number".to_string())),
+            input_to = Type::Double,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_date_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Double(1522039108044.0))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::DateTime(bson::DateTime::from_millis(
-                        1522039108044
-                    )))
-                    .into(),
-                    to: Type::Double,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Double(1522039108044.0)),
+            input_expr = Expression::Literal(LiteralValue::DateTime(bson::DateTime::from_millis(
+                1522039108044
+            ))),
+            input_to = Type::Double,
         );
     }
 
@@ -5155,516 +3941,181 @@ mod cast {
     mod to_long {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_non_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Reference(("bar", 0u16).into())],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Reference(("bar", 0u16).into()).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Reference(("bar", 0u16).into()),
+            input_expr = Expression::Reference(("bar", 0u16).into()),
+            input_to = Type::Int64,
             schema_env = map! {
                 ("bar", 0u16).into() => Schema::Atomic(Atomic::Long),
             },
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_false_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(0))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(0)),
+            input_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_true_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(1))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(1)),
+            input_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_to = Type::Int64,
         );
 
         // In general, for Decimal and Double, $convert truncates. The truncated value must be
         // within the range of a 64-bit signed integer, otherwise the onError value is returned.
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(1))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str("1.2").unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(1)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("1.2").unwrap()
+            )),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_max_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(i64::MAX))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}.9", i64::MAX).as_str()).unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(i64::MAX)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}.9", i64::MAX).as_str()).unwrap()
+            )),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_min_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(i64::MIN))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}.9", i64::MIN).as_str()).unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(i64::MIN)),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}.9", i64::MIN).as_str()).unwrap()
+            )),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_greater_than_max_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}", i64::MAX as f64 + 1.0).as_str())
-                            .unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}", i64::MAX as f64 + 1.0).as_str()).unwrap()
+            )),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_less_than_min_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}", i64::MIN as f64 - 1.0).as_str())
-                            .unwrap()
-                    ))
-                    .into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str(format!("{}", i64::MIN as f64 - 1.0).as_str()).unwrap()
+            )),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(1))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(1.2)).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(1)),
+            input_expr = Expression::Literal(LiteralValue::Double(1.2)),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_max_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(i64::MAX))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(i64::MAX as f64 + 0.9)).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(i64::MAX)),
+            input_expr = Expression::Literal(LiteralValue::Double(i64::MAX as f64 + 0.9)),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_min_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(i64::MIN))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(i64::MIN as f64 - 0.9)).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(i64::MIN)),
+            input_expr = Expression::Literal(LiteralValue::Double(i64::MIN as f64 - 0.9)),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_greater_than_max_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(f64::MAX)).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Double(f64::MAX)),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_less_than_min_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(f64::MIN)).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::Double(f64::MIN)),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(5))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Integer(5)).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(5)),
+            input_expr = Expression::Literal(LiteralValue::Integer(5)),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(5))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("5".to_string())).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(5)),
+            input_expr = Expression::Literal(LiteralValue::String("5".to_string())),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_max_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(i64::MAX))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(i64::MAX.to_string())).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(i64::MAX)),
+            input_expr = Expression::Literal(LiteralValue::String(i64::MAX.to_string())),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_min_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(i64::MIN))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(i64::MIN.to_string())).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(i64::MIN)),
+            input_expr = Expression::Literal(LiteralValue::String(i64::MIN.to_string())),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_greater_than_max_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(format!(
-                        "{}",
-                        i64::MAX as f64 + 1.0
-                    )))
-                    .into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String(format!(
+                "{}",
+                i64::MAX as f64 + 1.0
+            ))),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_less_than_min_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(format!(
-                        "{}",
-                        i64::MIN as f64 - 1.0
-                    )))
-                    .into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String(format!(
+                "{}",
+                i64::MIN as f64 - 1.0
+            ))),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_not_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("5.5".to_string())).into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String("5.5".to_string())),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_not_a_number_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("not a number".to_string()))
-                        .into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String("not a number".to_string())),
+            input_to = Type::Int64,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_date_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::Long(1522039108044))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::DateTime(bson::DateTime::from_millis(
-                        1522039108044
-                    )))
-                    .into(),
-                    to: Type::Int64,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::Long(1522039108044)),
+            input_expr = Expression::Literal(LiteralValue::DateTime(bson::DateTime::from_millis(
+                1522039108044
+            ))),
+            input_to = Type::Int64,
         );
     }
 
@@ -5673,100 +4124,43 @@ mod cast {
     mod to_datetime {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_datetime_non_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Reference(("bar", 0u16).into())],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Reference(("bar", 0u16).into()).into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Reference(("bar", 0u16).into()),
+            input_expr = Expression::Reference(("bar", 0u16).into()),
+            input_to = Type::Datetime,
             schema_env = map! {
                 ("bar", 0u16).into() => Schema::Atomic(Atomic::Date),
             },
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::DateTime(
-                    bson::DateTime::from_millis(120000000000)
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(120000000000.5)).into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::DateTime(
+                bson::DateTime::from_millis(120000000000)
+            )),
+            input_expr = Expression::Literal(LiteralValue::Double(120000000000.5)),
+            input_to = Type::Datetime,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::DateTime(
-                    bson::DateTime::from_millis(1253372036000)
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str("1253372036000.50").unwrap()
-                    ))
-                    .into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::DateTime(
+                bson::DateTime::from_millis(1253372036000)
+            )),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("1253372036000.50").unwrap()
+            )),
+            input_to = Type::Datetime,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::DateTime(
-                    bson::DateTime::from_millis(1100000000000)
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(1100000000000)).into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::DateTime(
+                bson::DateTime::from_millis(1100000000000)
+            )),
+            input_expr = Expression::Literal(LiteralValue::Long(1100000000000)),
+            input_to = Type::Datetime,
         );
 
         test_constant_fold!(
@@ -5908,27 +4302,11 @@ mod cast {
             }),
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_with_date_without_time,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::DateTime(
-                    *DATE_WITHOUT_TIME
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("2014-01-01".into())).into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                }),],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::DateTime(*DATE_WITHOUT_TIME)),
+            input_expr = Expression::Literal(LiteralValue::String("2014-01-01".into())),
+            input_to = Type::Datetime,
         );
 
         // An unparseable date string cannot be folded and is left as a Cast, to be
@@ -5951,25 +4329,11 @@ mod cast {
             })
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_object_id_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::DateTime(OID.timestamp()))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::ObjectId(*OID)).into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::DateTime(OID.timestamp())),
+            input_expr = Expression::Literal(LiteralValue::ObjectId(*OID)),
+            input_to = Type::Datetime,
         );
     }
 
@@ -5978,80 +4342,32 @@ mod cast {
     mod to_object_id {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_object_id_non_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Reference(("bar", 0u16).into())],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Reference(("bar", 0u16).into()).into(),
-                    to: Type::ObjectId,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Reference(("bar", 0u16).into()),
+            input_expr = Expression::Reference(("bar", 0u16).into()),
+            input_to = Type::ObjectId,
             schema_env = map! {
                 ("bar", 0u16).into() => Schema::Atomic(Atomic::ObjectId),
             },
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_valid_string,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::ObjectId(*OID))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(
-                        "507f1f77bcf86cd799439011".into()
-                    ))
-                    .into(),
-                    to: Type::ObjectId,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::ObjectId(*OID)),
+            input_expr =
+                Expression::Literal(LiteralValue::String("507f1f77bcf86cd799439011".into())),
+            input_to = Type::ObjectId,
         );
 
         // A string that cannot be parsed as an ObjectId statically fails, so the cast
         // folds to its on_error branch.
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_invalid_string,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "error".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(
-                        "57f1f77bcf86cd799439011".into()
-                    ))
-                    .into(),
-                    to: Type::ObjectId,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr =
+                Expression::Literal(LiteralValue::String("57f1f77bcf86cd799439011".into())),
+            input_to = Type::ObjectId,
         );
     }
 
@@ -6060,209 +4376,74 @@ mod cast {
     mod to_string {
         use super::*;
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_string_non_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Reference(("bar", 0u16).into())],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Reference(("bar", 0u16).into()).into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Reference(("bar", 0u16).into()),
+            input_expr = Expression::Reference(("bar", 0u16).into()),
+            input_to = Type::String,
             schema_env = map! {
                 ("bar", 0u16).into() => Schema::Atomic(Atomic::String),
             },
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_false_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "false".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("false".to_string())),
+            input_expr = Expression::Literal(LiteralValue::Boolean(false)),
+            input_to = Type::String,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_boolean_true_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "true".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("true".to_string())),
+            input_expr = Expression::Literal(LiteralValue::Boolean(true)),
+            input_to = Type::String,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_date_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    DATE_WITH_MS.to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::DateTime(*DATE_WITH_MS)).into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String(DATE_WITH_MS.to_string())),
+            input_expr = Expression::Literal(LiteralValue::DateTime(*DATE_WITH_MS)),
+            input_to = Type::String,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_decimal_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String("1.2".to_string()))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str("1.2").unwrap()
-                    ))
-                    .into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("1.2".to_string())),
+            input_expr = Expression::Literal(LiteralValue::Decimal128(
+                bson::Decimal128::from_str("1.2").unwrap()
+            )),
+            input_to = Type::String,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_double_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String("2.5".to_string()))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(2.5)).into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("2.5".to_string())),
+            input_expr = Expression::Literal(LiteralValue::Double(2.5)),
+            input_to = Type::String,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_int_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String("2".to_string()))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Integer(2)).into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("2".to_string())),
+            input_expr = Expression::Literal(LiteralValue::Integer(2)),
+            input_to = Type::String,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_long_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "1000".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Long(1000)).into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String("1000".to_string())),
+            input_expr = Expression::Literal(LiteralValue::Long(1000)),
+            input_to = Type::String,
         );
 
-        test_constant_fold!(
+        test_constant_fold_cast_literal!(
             from_objectid_literal,
-            expected = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Literal(LiteralValue::String(
-                    "507f1f77bcf86cd799439011".to_string()
-                ))],
-                cache: SchemaCache::new(),
-            }),
-            expected_changed = true,
-            input = Stage::Array(ArraySource {
-                alias: "".into(),
-                array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::ObjectId(*OID)).into(),
-                    to: Type::String,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                })],
-                cache: SchemaCache::new(),
-            }),
+            expected_expr = Expression::Literal(LiteralValue::String(
+                "507f1f77bcf86cd799439011".to_string()
+            )),
+            input_expr = Expression::Literal(LiteralValue::ObjectId(*OID)),
+            input_to = Type::String,
         );
     }
 }

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -1,2495 +1,3105 @@
-mod constant_folding {
-    macro_rules! test_constant_fold {
-        ($func_name:ident, expected = $expected:expr, expected_changed = $expected_changed:expr, input = $input:expr,) => {
-            #[test]
-            fn $func_name() {
-                use crate::{
-                    catalog::Catalog,
-                    map,
-                    mir::{
-                        optimizer::constant_folding::ConstantFoldingOptimizer,
-                        schema::{SchemaCheckingMode, SchemaInferenceState},
-                    },
-                    schema::SchemaEnvironment,
-                };
-                let input = $input;
-                let expected = $expected;
+use chrono::Utc;
+use lazy_static::lazy_static;
+use std::str::FromStr;
 
-                let (actual, actual_changed) = ConstantFoldingOptimizer::fold_constants(
-                    input,
-                    &SchemaInferenceState::new(
-                        0,
-                        SchemaEnvironment::default(),
-                        &Catalog::default(),
-                        map! {},
-                        SchemaCheckingMode::Relaxed,
-                    ),
-                );
-                assert_eq!($expected_changed, actual_changed);
-                assert_eq!(expected, actual);
-            }
-        };
-    }
+use crate::{
+    mir::{binding_tuple::DatasourceName::Bottom, definitions::*, schema::SchemaCache},
+    unchecked_unique_linked_hash_map,
+};
 
-    macro_rules! test_constant_fold_no_op {
-        ($func_name:ident, $input:expr) => {
-            test_constant_fold! { $func_name, expected = $input, expected_changed = false, input = $input, }
-        };
-    }
+macro_rules! test_constant_fold {
+    ($func_name:ident, expected = $expected:expr, expected_changed = $expected_changed:expr, input = $input:expr,) => {
+        #[test]
+        fn $func_name() {
+            use crate::{
+                catalog::Catalog,
+                map,
+                mir::{
+                    optimizer::constant_folding::ConstantFoldingOptimizer,
+                    schema::{SchemaCheckingMode, SchemaInferenceState},
+                },
+                schema::SchemaEnvironment,
+            };
+            let input = $input;
+            let expected = $expected;
 
-    use crate::{
-        mir::{binding_tuple::DatasourceName::Bottom, definitions::*, schema::SchemaCache},
-        unchecked_unique_linked_hash_map,
+            let (actual, actual_changed) = ConstantFoldingOptimizer::fold_constants(
+                input,
+                &SchemaInferenceState::new(
+                    0,
+                    SchemaEnvironment::default(),
+                    &Catalog::default(),
+                    map! {},
+                    SchemaCheckingMode::Relaxed,
+                ),
+            );
+            assert_eq!($expected_changed, actual_changed);
+            assert_eq!(expected, actual);
+        }
     };
-    use chrono::Utc;
-    use lazy_static::lazy_static;
-    use std::str::FromStr;
+}
 
-    lazy_static! {
-        static ref OID: bson::oid::ObjectId =
-            bson::oid::ObjectId::parse_str("507f1f77bcf86cd799439011").unwrap();
-        static ref DATE_WITH_MS: bson::DateTime = {
-            let chrono_dt: chrono::DateTime<Utc> = "2014-01-01T08:15:39.736Z".parse().unwrap();
-            chrono_dt.into()
-        };
-        static ref DATE_WITHOUT_MS: bson::DateTime = {
-            let chrono_dt: chrono::DateTime<Utc> = "2014-01-01T08:15:39Z".parse().unwrap();
-            chrono_dt.into()
-        };
-        static ref INT_DEC: bson::Decimal128 = bson::Decimal128::from_str("3").unwrap();
-        static ref DOUBLE_DEC: bson::Decimal128 =
-            bson::Decimal128::from_str(&format!("{}", std::f64::consts::PI)).unwrap();
-        static ref STRING_DEC: bson::Decimal128 = bson::Decimal128::from_str("3.14159265").unwrap();
-    }
+macro_rules! test_constant_fold_no_op {
+    ($func_name:ident, $input:expr) => {
+        test_constant_fold! { $func_name, expected = $input, expected_changed = false, input = $input, }
+    };
+}
 
-    fn test_source() -> Stage {
-        Stage::Collection(Collection {
-            db: "test".into(),
-            collection: "foo".into(),
-            cache: SchemaCache::new(),
-        })
-    }
+lazy_static! {
+    static ref OID: bson::oid::ObjectId =
+        bson::oid::ObjectId::parse_str("507f1f77bcf86cd799439011").unwrap();
+    static ref DATE_WITH_MS: bson::DateTime = {
+        let chrono_dt: chrono::DateTime<Utc> = "2014-01-01T08:15:39.736Z".parse().unwrap();
+        chrono_dt.into()
+    };
+    static ref DATE_WITHOUT_MS: bson::DateTime = {
+        let chrono_dt: chrono::DateTime<Utc> = "2014-01-01T08:15:39Z".parse().unwrap();
+        chrono_dt.into()
+    };
+    static ref INT_DEC: bson::Decimal128 = bson::Decimal128::from_str("3").unwrap();
+    static ref DOUBLE_DEC: bson::Decimal128 =
+        bson::Decimal128::from_str(&format!("{}", std::f64::consts::PI)).unwrap();
+    static ref STRING_DEC: bson::Decimal128 = bson::Decimal128::from_str("3.14159265").unwrap();
+}
 
-    test_constant_fold_no_op!(
-        literal,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(1))],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        or_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Or,
-                vec![
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                    Expression::Literal(LiteralValue::Boolean(false))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        and_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::And,
-                vec![
-                    Expression::Literal(LiteralValue::Boolean(true)),
-                    Expression::Literal(LiteralValue::Boolean(true))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        true_and_nulls_is_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::And,
-                vec![
-                    Expression::Literal(LiteralValue::Boolean(true)),
-                    Expression::Literal(LiteralValue::Boolean(true)),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Null),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        null_and_null_is_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::And,
-                vec![
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Null),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        true_and_nulls_and_ref_is_null_and_ref,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::And,
-                vec![
-                    Expression::Reference(("foo", 1u16).into()),
-                    Expression::Literal(LiteralValue::Null),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::And,
-                vec![
-                    Expression::Literal(LiteralValue::Boolean(true)),
-                    Expression::Literal(LiteralValue::Boolean(true)),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Reference(("foo", 1u16).into())
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        false_or_nulls_or_ref_is_null_or_ref,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Or,
-                vec![
-                    Expression::Reference(("foo", 1u16).into()),
-                    Expression::Literal(LiteralValue::Null),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Or,
-                vec![
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Reference(("foo", 1u16).into())
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    #[test]
-    fn null_or_null_is_null() {
-        use crate::{
-            catalog::Catalog,
-            map,
-            mir::{
-                optimizer::constant_folding::ConstantFoldingOptimizer,
-                schema::{SchemaCheckingMode, SchemaInferenceState},
-            },
-            schema::SchemaEnvironment,
-        };
-        let input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Or,
-                vec![
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Null),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        });
-        let expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        });
-        let (actual, actual_changed) = ConstantFoldingOptimizer::fold_constants(
-            input,
-            &SchemaInferenceState::new(
-                0,
-                SchemaEnvironment::default(),
-                &Catalog::default(),
-                map! {},
-                SchemaCheckingMode::Relaxed,
-            ),
-        );
-        assert!(actual_changed);
-        assert_eq!(expected, actual);
-    }
-    test_constant_fold!(
-        false_or_nulls_is_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Or,
-                vec![
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        or_with_true_literal_is_true,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Or,
-                vec![
-                    Expression::Literal(LiteralValue::Boolean(true)),
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Reference(("foo", 1u16).into())
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        or_empty,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Or,
-                vec![],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        and_with_false_literal_is_false,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::And,
-                vec![
-                    Expression::Literal(LiteralValue::Boolean(true)),
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Reference(("foo", 1u16).into())
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        and_empty,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::And,
-                vec![],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        null_or_ref_reorder_does_not_count_as_change,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Or,
-                vec![
-                    Expression::Reference(("foo", 1u16).into()),
-                    Expression::Literal(LiteralValue::Null),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold_no_op!(
-        null_and_ref_reorder_does_not_count_as_change,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::And,
-                vec![
-                    Expression::Reference(("foo", 1u16).into()),
-                    Expression::Literal(LiteralValue::Null),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        add_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(3))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Add,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(1)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        add_empty,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(0))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Add,
-                vec![],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        add_to_zero_is_zero,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Long(0))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Add,
-                args: vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(-1)),
-                    Expression::Literal(LiteralValue::Long(1)),
-                    Expression::Literal(LiteralValue::Long(-1)),
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        add_constant_ref_is_constant_ref,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Add,
-                vec![
-                    Expression::Literal(LiteralValue::Double(3.0)),
-                    Expression::Reference(("a", 0u16).into()),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Add,
-                vec![
-                    Expression::Literal(LiteralValue::Double(1.0)),
-                    Expression::Literal(LiteralValue::Double(1.0)),
-                    Expression::Literal(LiteralValue::Double(1.0)),
-                    Expression::Reference(("a", 0u16).into()),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        add_zero_ref_is_ref,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Reference(("a", 0u16).into())],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Add,
-                args: vec![
-                    Expression::Literal(LiteralValue::Integer(-1)),
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Reference(("a", 0u16).into()),
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        mul_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Long(8))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Mul,
-                vec![
-                    Expression::Literal(LiteralValue::Long(2)),
-                    Expression::Literal(LiteralValue::Long(2)),
-                    Expression::Literal(LiteralValue::Long(2)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        mul_empty,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(1))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Mul,
-                vec![],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        mul_to_one_is_one,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Double(1.0))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Mul,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Double(0.5)),
-                    Expression::Literal(LiteralValue::Double(2.0)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        mul_one_ref_is_ref,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Reference(("a", 0u16).into())],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Mul,
-                vec![
-                    Expression::Literal(LiteralValue::Double(2.0)),
-                    Expression::Literal(LiteralValue::Double(0.5)),
-                    Expression::Reference(("a", 0u16).into()),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        arithmetic_null_arg,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Add,
-                args: vec![
-                    Expression::ScalarFunction(ScalarFunctionApplication::new(
-                        ScalarFunction::Mul,
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Long(2)),
-                            Expression::Literal(LiteralValue::Double(2.0)),
-                            Expression::Literal(LiteralValue::Null),
-                        ],
-                    )),
-                    Expression::Reference(("a", 0u16).into()),
-                ],
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        add_different_num_types,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Add,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(2)),
-                    Expression::Literal(LiteralValue::Long(4)),
-                    Expression::Literal(LiteralValue::Double(6.0))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Add,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Long(2)),
-                    Expression::Literal(LiteralValue::Long(2)),
-                    Expression::Literal(LiteralValue::Double(3.0)),
-                    Expression::Literal(LiteralValue::Double(3.0))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        mul_different_num_types,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Mul,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(4)),
-                    Expression::Literal(LiteralValue::Long(9)),
-                    Expression::Literal(LiteralValue::Double(16.0))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Mul,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(2)),
-                    Expression::Literal(LiteralValue::Integer(2)),
-                    Expression::Literal(LiteralValue::Long(3)),
-                    Expression::Literal(LiteralValue::Long(3)),
-                    Expression::Literal(LiteralValue::Double(4.0)),
-                    Expression::Literal(LiteralValue::Double(4.0))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        sub_ref_by_zero_is_ref,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Reference(("a", 0u16).into())],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Sub,
-                vec![
-                    Expression::Reference(("a", 0u16).into()),
-                    Expression::Literal(LiteralValue::Long(0))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        sub_null_is_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Sub,
-                vec![
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Long(2))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        sub_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::Literal(LiteralValue::Integer(0)),
-                    Expression::Literal(LiteralValue::Long(-1)),
-                    Expression::Literal(LiteralValue::Double(2.0)),
-                ]
-                .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::ScalarFunction(ScalarFunctionApplication::new(
-                        ScalarFunction::Sub,
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(2))
-                        ],
-                    )),
-                    Expression::ScalarFunction(ScalarFunctionApplication::new(
-                        ScalarFunction::Sub,
-                        vec![
-                            Expression::Literal(LiteralValue::Long(1)),
-                            Expression::Literal(LiteralValue::Long(2))
-                        ],
-                    )),
-                    Expression::ScalarFunction(ScalarFunctionApplication::new(
-                        ScalarFunction::Sub,
-                        vec![
-                            Expression::Literal(LiteralValue::Double(3.0)),
-                            Expression::Literal(LiteralValue::Double(1.0))
-                        ],
-                    )),
-                ]
-                .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        div_zero_is_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Div,
-                vec![
-                    Expression::Reference(("a", 0u16).into()),
-                    Expression::Literal(LiteralValue::Long(0))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        div_null_is_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Div,
-                vec![
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Long(2))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        div_ref_by_one_is_ref,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Reference(("a", 0u16).into())],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Div,
-                vec![
-                    Expression::Reference(("a", 0u16).into()),
-                    Expression::Literal(LiteralValue::Long(1))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        div_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Long(-1)),
-                    Expression::Literal(LiteralValue::Double(2.0)),
-                ]
-                .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::ScalarFunction(ScalarFunctionApplication::new(
-                        ScalarFunction::Div,
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(2))
-                        ],
-                    )),
-                    Expression::ScalarFunction(ScalarFunctionApplication {
-                        function: ScalarFunction::Div,
-                        args: vec![
-                            Expression::Literal(LiteralValue::Long(-2)),
-                            Expression::Literal(LiteralValue::Long(2))
-                        ],
-                        is_nullable: false,
-                    }),
-                    Expression::ScalarFunction(ScalarFunctionApplication::new(
-                        ScalarFunction::Div,
-                        vec![
-                            Expression::Literal(LiteralValue::Double(2.0)),
-                            Expression::Literal(LiteralValue::Double(1.0))
-                        ],
-                    )),
-                ]
-                .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_less_than,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Lt,
-                vec![
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                    Expression::Literal(LiteralValue::Boolean(true)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_not_less_than,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Lt,
-                vec![
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                    Expression::Literal(LiteralValue::Boolean(false)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_less_than_equal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Lte,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(0)),
-                    Expression::Literal(LiteralValue::Integer(0)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_not_less_than_equal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Lte,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(0)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_greater_than,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Gt,
-                vec![
-                    Expression::Literal(LiteralValue::Long(1)),
-                    Expression::Literal(LiteralValue::Long(0)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_not_greater_than,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Gt,
-                vec![
-                    Expression::Literal(LiteralValue::Long(0)),
-                    Expression::Literal(LiteralValue::Long(0)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_greater_than_equal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Gte,
-                vec![
-                    Expression::Literal(LiteralValue::Double(1.0)),
-                    Expression::Literal(LiteralValue::Double(1.0)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_not_greater_than_equal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Gte,
-                vec![
-                    Expression::Literal(LiteralValue::Double(0.0)),
-                    Expression::Literal(LiteralValue::Double(1.0)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_equal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Eq,
-                vec![
-                    Expression::Literal(LiteralValue::Long(1)),
-                    Expression::Literal(LiteralValue::Long(1)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_not_equal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Eq,
-                vec![
-                    Expression::Literal(LiteralValue::Long(0)),
-                    Expression::Literal(LiteralValue::Long(1)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_nequal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Neq,
-                vec![
-                    Expression::Literal(LiteralValue::Long(0)),
-                    Expression::Literal(LiteralValue::Long(1)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_not_nequal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Neq,
-                vec![
-                    Expression::Literal(LiteralValue::Long(1)),
-                    Expression::Literal(LiteralValue::Long(1)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        compare_different_datatypes,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Neq,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Long(1)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        compare_null_is_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Lte,
-                vec![
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Long(1)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_between,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Between,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(0)),
-                    Expression::Literal(LiteralValue::Integer(2)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_not_between,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Between,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(2)),
-                    Expression::Reference(("foo", 1u16).into())
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        fold_comparison_nested,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Eq,
-                args: vec![
-                    Expression::ScalarFunction(ScalarFunctionApplication::new(
-                        ScalarFunction::Lt,
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                        ],
-                    )),
-                    Expression::Literal(LiteralValue::Boolean(true)),
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        fold_between_args,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Between,
-                args: vec![
-                    Expression::Reference(("foo", 1u16).into()),
-                    Expression::Literal(LiteralValue::Integer(0)),
-                    Expression::Literal(LiteralValue::Integer(3)),
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Between,
-                args: vec![
-                    Expression::Reference(("foo", 1u16).into()),
-                    Expression::ScalarFunction(ScalarFunctionApplication {
-                        function: ScalarFunction::Add,
-                        args: vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(-1)),
-                        ],
-                        is_nullable: false,
-                    }),
-                    Expression::ScalarFunction(ScalarFunctionApplication::new(
-                        ScalarFunction::Add,
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                        ],
-                    )),
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        pos_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(2))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Pos,
-                vec![Expression::Literal(LiteralValue::Integer(2))],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        neg_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(-2))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Neg,
-                vec![Expression::Literal(LiteralValue::Integer(2))],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        not_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Not,
-                vec![Expression::Literal(LiteralValue::Boolean(true))],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        upper_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "AABBCC".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Upper,
-                vec![Expression::Literal(LiteralValue::String(
-                    "aaBBcC".to_string()
-                )),],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        lower_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "aabbcc".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Lower,
-                vec![Expression::Literal(LiteralValue::String(
-                    "aaBBcC".to_string()
-                )),],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        lower_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Lower,
-                vec![Expression::Literal(LiteralValue::Null),],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        btrim_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "AABBCC".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::BTrim,
-                vec![
-                    Expression::Literal(LiteralValue::String("a".to_string())),
-                    Expression::Literal(LiteralValue::String("aAABBCCa".to_string()))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        ltrim_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "AABBCCa".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::LTrim,
-                vec![
-                    Expression::Literal(LiteralValue::String("a".to_string())),
-                    Expression::Literal(LiteralValue::String("aAABBCCa".to_string()))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        rtrim_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "aAABBCC".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::RTrim,
-                vec![
-                    Expression::Literal(LiteralValue::String("a".to_string())),
-                    Expression::Literal(LiteralValue::String("aAABBCCa".to_string()))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        btrim_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::BTrim,
-                vec![
-                    Expression::Literal(LiteralValue::String("a".to_string())),
-                    Expression::Literal(LiteralValue::Null)
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        substring_nested,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "hello".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Substring,
-                args: vec![
-                    Expression::Literal(LiteralValue::String("hello world".to_string())),
-                    Expression::Literal(LiteralValue::Integer(0)),
-                    Expression::ScalarFunction(ScalarFunctionApplication::new(
-                        ScalarFunction::Add,
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3)),
-                        ],
-                    ))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        substring_multi_codepoint_char,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "🇷🇺ááá".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Substring,
-                args: vec![
-                    Expression::Literal(LiteralValue::String("ááá🇷🇺ááá".to_string())),
-                    Expression::Literal(LiteralValue::Integer(6)),
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        substring_negative_length,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "world".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Substring,
-                args: vec![
-                    Expression::Literal(LiteralValue::String("hello world".to_string())),
-                    Expression::Literal(LiteralValue::Integer(6)),
-                    Expression::Literal(LiteralValue::Integer(-1)),
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        substring_negative_start_with_smaller_length,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("".to_string()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Substring,
-                args: vec![
-                    Expression::Literal(LiteralValue::String("hello world".to_string())),
-                    Expression::Literal(LiteralValue::Integer(-6)),
-                    Expression::Literal(LiteralValue::Integer(5)),
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        substring_negative_start_with_larger_length,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "hello".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Substring,
-                args: vec![
-                    Expression::Literal(LiteralValue::String("hello world".to_string())),
-                    Expression::Literal(LiteralValue::Integer(-6)),
-                    Expression::Literal(LiteralValue::Integer(11)),
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        substring_start_larger_than_string_length,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("".to_string()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Substring,
-                vec![
-                    Expression::Literal(LiteralValue::String("hello world".to_string())),
-                    Expression::Literal(LiteralValue::Integer(20)),
-                    Expression::Literal(LiteralValue::Integer(4)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        substring_end_larger_than_string_length,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "world".to_string()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Substring,
-                vec![
-                    Expression::Literal(LiteralValue::String("hello world".to_string())),
-                    Expression::Literal(LiteralValue::Integer(6)),
-                    Expression::Literal(LiteralValue::Integer(20)),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        substring_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Substring,
-                vec![
-                    Expression::Literal(LiteralValue::String("hello world".to_string())),
-                    Expression::Literal(LiteralValue::Integer(6)),
-                    Expression::Literal(LiteralValue::Null),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        concat_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
+fn test_source() -> Stage {
+    Stage::Collection(Collection {
+        db: "test".into(),
+        collection: "foo".into(),
+        cache: SchemaCache::new(),
+    })
+}
+
+test_constant_fold_no_op!(
+    literal,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(1))],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    or_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Or,
+            vec![
+                Expression::Literal(LiteralValue::Boolean(false)),
+                Expression::Literal(LiteralValue::Boolean(false))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    and_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![
+                Expression::Literal(LiteralValue::Boolean(true)),
+                Expression::Literal(LiteralValue::Boolean(true))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    true_and_nulls_is_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![
+                Expression::Literal(LiteralValue::Boolean(true)),
+                Expression::Literal(LiteralValue::Boolean(true)),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Null),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    null_and_null_is_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Null),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    true_and_nulls_and_ref_is_null_and_ref,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![
+                Expression::Reference(("foo", 1u16).into()),
+                Expression::Literal(LiteralValue::Null),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![
+                Expression::Literal(LiteralValue::Boolean(true)),
+                Expression::Literal(LiteralValue::Boolean(true)),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Reference(("foo", 1u16).into())
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    false_or_nulls_or_ref_is_null_or_ref,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Or,
+            vec![
+                Expression::Reference(("foo", 1u16).into()),
+                Expression::Literal(LiteralValue::Null),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Or,
+            vec![
+                Expression::Literal(LiteralValue::Boolean(false)),
+                Expression::Literal(LiteralValue::Boolean(false)),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Reference(("foo", 1u16).into())
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+#[test]
+fn null_or_null_is_null() {
+    use crate::{
+        catalog::Catalog,
+        map,
+        mir::{
+            optimizer::constant_folding::ConstantFoldingOptimizer,
+            schema::{SchemaCheckingMode, SchemaInferenceState},
+        },
+        schema::SchemaEnvironment,
+    };
+    let input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Or,
+            vec![
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Null),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    });
+    let expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    });
+    let (actual, actual_changed) = ConstantFoldingOptimizer::fold_constants(
+        input,
+        &SchemaInferenceState::new(
+            0,
+            SchemaEnvironment::default(),
+            &Catalog::default(),
+            map! {},
+            SchemaCheckingMode::Relaxed,
+        ),
+    );
+    assert!(actual_changed);
+    assert_eq!(expected, actual);
+}
+test_constant_fold!(
+    false_or_nulls_is_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Or,
+            vec![
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Boolean(false)),
+                Expression::Literal(LiteralValue::Boolean(false)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    or_with_true_literal_is_true,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Or,
+            vec![
+                Expression::Literal(LiteralValue::Boolean(true)),
+                Expression::Literal(LiteralValue::Boolean(false)),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Reference(("foo", 1u16).into())
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    or_empty,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Or,
+            vec![],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    and_with_false_literal_is_false,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![
+                Expression::Literal(LiteralValue::Boolean(true)),
+                Expression::Literal(LiteralValue::Boolean(false)),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Reference(("foo", 1u16).into())
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    and_empty,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    null_or_ref_reorder_does_not_count_as_change,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Or,
+            vec![
+                Expression::Reference(("foo", 1u16).into()),
+                Expression::Literal(LiteralValue::Null),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold_no_op!(
+    null_and_ref_reorder_does_not_count_as_change,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![
+                Expression::Reference(("foo", 1u16).into()),
+                Expression::Literal(LiteralValue::Null),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    add_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(3))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Add,
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(1)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    add_empty,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(0))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Add,
+            vec![],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    add_to_zero_is_zero,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Long(0))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Add,
+            args: vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(-1)),
+                Expression::Literal(LiteralValue::Long(1)),
+                Expression::Literal(LiteralValue::Long(-1)),
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    add_constant_ref_is_constant_ref,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Add,
+            vec![
+                Expression::Literal(LiteralValue::Double(3.0)),
+                Expression::Reference(("a", 0u16).into()),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Add,
+            vec![
+                Expression::Literal(LiteralValue::Double(1.0)),
+                Expression::Literal(LiteralValue::Double(1.0)),
+                Expression::Literal(LiteralValue::Double(1.0)),
+                Expression::Reference(("a", 0u16).into()),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    add_zero_ref_is_ref,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Reference(("a", 0u16).into())],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Add,
+            args: vec![
+                Expression::Literal(LiteralValue::Integer(-1)),
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Reference(("a", 0u16).into()),
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    mul_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Long(8))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Mul,
+            vec![
+                Expression::Literal(LiteralValue::Long(2)),
+                Expression::Literal(LiteralValue::Long(2)),
+                Expression::Literal(LiteralValue::Long(2)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    mul_empty,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(1))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Mul,
+            vec![],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    mul_to_one_is_one,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Double(1.0))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Mul,
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Double(0.5)),
+                Expression::Literal(LiteralValue::Double(2.0)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    mul_one_ref_is_ref,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Reference(("a", 0u16).into())],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Mul,
+            vec![
+                Expression::Literal(LiteralValue::Double(2.0)),
+                Expression::Literal(LiteralValue::Double(0.5)),
+                Expression::Reference(("a", 0u16).into()),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    arithmetic_null_arg,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Add,
+            args: vec![
+                Expression::ScalarFunction(ScalarFunctionApplication::new(
+                    ScalarFunction::Mul,
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Long(2)),
+                        Expression::Literal(LiteralValue::Double(2.0)),
+                        Expression::Literal(LiteralValue::Null),
+                    ],
+                )),
+                Expression::Reference(("a", 0u16).into()),
+            ],
+            is_nullable: true,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    add_different_num_types,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Add,
+            vec![
+                Expression::Literal(LiteralValue::Integer(2)),
+                Expression::Literal(LiteralValue::Long(4)),
+                Expression::Literal(LiteralValue::Double(6.0))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Add,
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Long(2)),
+                Expression::Literal(LiteralValue::Long(2)),
+                Expression::Literal(LiteralValue::Double(3.0)),
+                Expression::Literal(LiteralValue::Double(3.0))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    mul_different_num_types,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Mul,
+            vec![
+                Expression::Literal(LiteralValue::Integer(4)),
+                Expression::Literal(LiteralValue::Long(9)),
+                Expression::Literal(LiteralValue::Double(16.0))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Mul,
+            vec![
+                Expression::Literal(LiteralValue::Integer(2)),
+                Expression::Literal(LiteralValue::Integer(2)),
+                Expression::Literal(LiteralValue::Long(3)),
+                Expression::Literal(LiteralValue::Long(3)),
+                Expression::Literal(LiteralValue::Double(4.0)),
+                Expression::Literal(LiteralValue::Double(4.0))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    sub_ref_by_zero_is_ref,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Reference(("a", 0u16).into())],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Sub,
+            vec![
+                Expression::Reference(("a", 0u16).into()),
+                Expression::Literal(LiteralValue::Long(0))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    sub_null_is_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Sub,
+            vec![
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Long(2))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    sub_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::Literal(LiteralValue::Integer(0)),
+                Expression::Literal(LiteralValue::Long(-1)),
+                Expression::Literal(LiteralValue::Double(2.0)),
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::ScalarFunction(ScalarFunctionApplication::new(
+                    ScalarFunction::Sub,
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(2))
+                    ],
+                )),
+                Expression::ScalarFunction(ScalarFunctionApplication::new(
+                    ScalarFunction::Sub,
+                    vec![
+                        Expression::Literal(LiteralValue::Long(1)),
+                        Expression::Literal(LiteralValue::Long(2))
+                    ],
+                )),
+                Expression::ScalarFunction(ScalarFunctionApplication::new(
+                    ScalarFunction::Sub,
+                    vec![
+                        Expression::Literal(LiteralValue::Double(3.0)),
+                        Expression::Literal(LiteralValue::Double(1.0))
+                    ],
+                )),
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    div_zero_is_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Div,
+            vec![
+                Expression::Reference(("a", 0u16).into()),
+                Expression::Literal(LiteralValue::Long(0))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    div_null_is_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Div,
+            vec![
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Long(2))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    div_ref_by_one_is_ref,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Reference(("a", 0u16).into())],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Div,
+            vec![
+                Expression::Reference(("a", 0u16).into()),
+                Expression::Literal(LiteralValue::Long(1))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    div_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Long(-1)),
+                Expression::Literal(LiteralValue::Double(2.0)),
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::ScalarFunction(ScalarFunctionApplication::new(
+                    ScalarFunction::Div,
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(2))
+                    ],
+                )),
+                Expression::ScalarFunction(ScalarFunctionApplication {
+                    function: ScalarFunction::Div,
+                    args: vec![
+                        Expression::Literal(LiteralValue::Long(-2)),
+                        Expression::Literal(LiteralValue::Long(2))
+                    ],
+                    is_nullable: false,
+                }),
+                Expression::ScalarFunction(ScalarFunctionApplication::new(
+                    ScalarFunction::Div,
+                    vec![
+                        Expression::Literal(LiteralValue::Double(2.0)),
+                        Expression::Literal(LiteralValue::Double(1.0))
+                    ],
+                )),
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_less_than,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Lt,
+            vec![
+                Expression::Literal(LiteralValue::Boolean(false)),
+                Expression::Literal(LiteralValue::Boolean(true)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_not_less_than,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Lt,
+            vec![
+                Expression::Literal(LiteralValue::Boolean(false)),
+                Expression::Literal(LiteralValue::Boolean(false)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_less_than_equal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Lte,
+            vec![
+                Expression::Literal(LiteralValue::Integer(0)),
+                Expression::Literal(LiteralValue::Integer(0)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_not_less_than_equal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Lte,
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(0)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_greater_than,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Gt,
+            vec![
+                Expression::Literal(LiteralValue::Long(1)),
+                Expression::Literal(LiteralValue::Long(0)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_not_greater_than,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Gt,
+            vec![
+                Expression::Literal(LiteralValue::Long(0)),
+                Expression::Literal(LiteralValue::Long(0)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_greater_than_equal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Gte,
+            vec![
+                Expression::Literal(LiteralValue::Double(1.0)),
+                Expression::Literal(LiteralValue::Double(1.0)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_not_greater_than_equal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Gte,
+            vec![
+                Expression::Literal(LiteralValue::Double(0.0)),
+                Expression::Literal(LiteralValue::Double(1.0)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_equal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Eq,
+            vec![
+                Expression::Literal(LiteralValue::Long(1)),
+                Expression::Literal(LiteralValue::Long(1)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_not_equal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Eq,
+            vec![
+                Expression::Literal(LiteralValue::Long(0)),
+                Expression::Literal(LiteralValue::Long(1)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_nequal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Neq,
+            vec![
+                Expression::Literal(LiteralValue::Long(0)),
+                Expression::Literal(LiteralValue::Long(1)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_not_nequal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Neq,
+            vec![
+                Expression::Literal(LiteralValue::Long(1)),
+                Expression::Literal(LiteralValue::Long(1)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    compare_different_datatypes,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Neq,
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Long(1)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    compare_null_is_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Lte,
+            vec![
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Long(1)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_between,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Between,
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(0)),
+                Expression::Literal(LiteralValue::Integer(2)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_not_between,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Between,
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(2)),
+                Expression::Reference(("foo", 1u16).into())
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    fold_comparison_nested,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Eq,
+            args: vec![
+                Expression::ScalarFunction(ScalarFunctionApplication::new(
+                    ScalarFunction::Lt,
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                    ],
+                )),
+                Expression::Literal(LiteralValue::Boolean(true)),
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    fold_between_args,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Between,
+            args: vec![
+                Expression::Reference(("foo", 1u16).into()),
+                Expression::Literal(LiteralValue::Integer(0)),
+                Expression::Literal(LiteralValue::Integer(3)),
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Between,
+            args: vec![
+                Expression::Reference(("foo", 1u16).into()),
+                Expression::ScalarFunction(ScalarFunctionApplication {
+                    function: ScalarFunction::Add,
+                    args: vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(-1)),
+                    ],
+                    is_nullable: false,
+                }),
+                Expression::ScalarFunction(ScalarFunctionApplication::new(
+                    ScalarFunction::Add,
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                    ],
+                )),
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    pos_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(2))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Pos,
+            vec![Expression::Literal(LiteralValue::Integer(2))],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    neg_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(-2))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Neg,
+            vec![Expression::Literal(LiteralValue::Integer(2))],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    not_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Not,
+            vec![Expression::Literal(LiteralValue::Boolean(true))],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    upper_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "AABBCC".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Upper,
+            vec![Expression::Literal(LiteralValue::String(
+                "aaBBcC".to_string()
+            )),],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    lower_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "aabbcc".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Lower,
+            vec![Expression::Literal(LiteralValue::String(
+                "aaBBcC".to_string()
+            )),],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    lower_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Lower,
+            vec![Expression::Literal(LiteralValue::Null),],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    btrim_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "AABBCC".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::BTrim,
+            vec![
+                Expression::Literal(LiteralValue::String("a".to_string())),
+                Expression::Literal(LiteralValue::String("aAABBCCa".to_string()))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    ltrim_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "AABBCCa".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::LTrim,
+            vec![
+                Expression::Literal(LiteralValue::String("a".to_string())),
+                Expression::Literal(LiteralValue::String("aAABBCCa".to_string()))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    rtrim_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "aAABBCC".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::RTrim,
+            vec![
+                Expression::Literal(LiteralValue::String("a".to_string())),
+                Expression::Literal(LiteralValue::String("aAABBCCa".to_string()))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    btrim_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::BTrim,
+            vec![
+                Expression::Literal(LiteralValue::String("a".to_string())),
+                Expression::Literal(LiteralValue::Null)
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    substring_nested,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "hello".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Substring,
+            args: vec![
+                Expression::Literal(LiteralValue::String("hello world".to_string())),
+                Expression::Literal(LiteralValue::Integer(0)),
+                Expression::ScalarFunction(ScalarFunctionApplication::new(
+                    ScalarFunction::Add,
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3)),
+                    ],
+                ))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    substring_multi_codepoint_char,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "🇷🇺ááá".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Substring,
+            args: vec![
+                Expression::Literal(LiteralValue::String("ááá🇷🇺ááá".to_string())),
+                Expression::Literal(LiteralValue::Integer(6)),
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    substring_negative_length,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "world".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Substring,
+            args: vec![
+                Expression::Literal(LiteralValue::String("hello world".to_string())),
+                Expression::Literal(LiteralValue::Integer(6)),
+                Expression::Literal(LiteralValue::Integer(-1)),
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    substring_negative_start_with_smaller_length,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String("".to_string()))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Substring,
+            args: vec![
+                Expression::Literal(LiteralValue::String("hello world".to_string())),
+                Expression::Literal(LiteralValue::Integer(-6)),
+                Expression::Literal(LiteralValue::Integer(5)),
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    substring_negative_start_with_larger_length,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "hello".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Substring,
+            args: vec![
+                Expression::Literal(LiteralValue::String("hello world".to_string())),
+                Expression::Literal(LiteralValue::Integer(-6)),
+                Expression::Literal(LiteralValue::Integer(11)),
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    substring_start_larger_than_string_length,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String("".to_string()))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Substring,
+            vec![
+                Expression::Literal(LiteralValue::String("hello world".to_string())),
+                Expression::Literal(LiteralValue::Integer(20)),
+                Expression::Literal(LiteralValue::Integer(4)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    substring_end_larger_than_string_length,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "world".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Substring,
+            vec![
+                Expression::Literal(LiteralValue::String("hello world".to_string())),
+                Expression::Literal(LiteralValue::Integer(6)),
+                Expression::Literal(LiteralValue::Integer(20)),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    substring_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Substring,
+            vec![
+                Expression::Literal(LiteralValue::String("hello world".to_string())),
+                Expression::Literal(LiteralValue::Integer(6)),
+                Expression::Literal(LiteralValue::Null),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    concat_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "hello world".to_string()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Concat,
+            vec![
+                Expression::Literal(LiteralValue::String("hello ".to_string())),
+                Expression::Literal(LiteralValue::String("world".to_string())),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    concat_with_ref,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Concat,
+            vec![
+                Expression::Literal(LiteralValue::String("hello world".to_string())),
+                Expression::Reference(("a", 0u16).into()),
+                Expression::Literal(LiteralValue::String("hello world2".to_string())),
+                Expression::Reference(("a", 0u16).into()),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Concat,
+            vec![
+                Expression::Literal(LiteralValue::String("hello ".to_string())),
+                Expression::Literal(LiteralValue::String("world".to_string())),
+                Expression::Reference(("a", 0u16).into()),
+                Expression::Literal(LiteralValue::String("hello ".to_string())),
+                Expression::Literal(LiteralValue::String("world2".to_string())),
+                Expression::Reference(("a", 0u16).into()),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    concat_empty,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String("".to_string()))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Concat,
+            vec![],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    concat_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Concat,
+            vec![
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::String("hello".to_string())),
+                Expression::Literal(LiteralValue::String("world".to_string()))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    char_length_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(11))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::CharLength,
+            vec![Expression::Literal(LiteralValue::String(
                 "hello world".to_string()
             ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Concat,
-                vec![
-                    Expression::Literal(LiteralValue::String("hello ".to_string())),
-                    Expression::Literal(LiteralValue::String("world".to_string())),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        concat_with_ref,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Concat,
-                vec![
-                    Expression::Literal(LiteralValue::String("hello world".to_string())),
-                    Expression::Reference(("a", 0u16).into()),
-                    Expression::Literal(LiteralValue::String("hello world2".to_string())),
-                    Expression::Reference(("a", 0u16).into()),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Concat,
-                vec![
-                    Expression::Literal(LiteralValue::String("hello ".to_string())),
-                    Expression::Literal(LiteralValue::String("world".to_string())),
-                    Expression::Reference(("a", 0u16).into()),
-                    Expression::Literal(LiteralValue::String("hello ".to_string())),
-                    Expression::Literal(LiteralValue::String("world2".to_string())),
-                    Expression::Reference(("a", 0u16).into()),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        concat_empty,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("".to_string()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Concat,
-                vec![],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        concat_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Concat,
-                vec![
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::String("hello".to_string())),
-                    Expression::Literal(LiteralValue::String("world".to_string()))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        char_length_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(11))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::CharLength,
-                vec![Expression::Literal(LiteralValue::String(
-                    "hello world".to_string()
-                ))],
+        )),],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    char_length_multi_codepoint,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(14))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::CharLength,
+            args: vec![Expression::Literal(LiteralValue::String(
+                "ááá🇷🇺ááá".to_string()
             )),],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        char_length_multi_codepoint,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(14))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::CharLength,
-                args: vec![Expression::Literal(LiteralValue::String(
-                    "ááá🇷🇺ááá".to_string()
-                )),],
-                is_nullable: false,
-            }),],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        octet_length_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(11))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::OctetLength,
-                vec![Expression::Literal(LiteralValue::String(
-                    "hello world".to_string()
-                )),],
+            is_nullable: false,
+        }),],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    octet_length_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(11))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::OctetLength,
+            vec![Expression::Literal(LiteralValue::String(
+                "hello world".to_string()
             )),],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        octet_length_multi_codepoint,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(26))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::OctetLength,
-                args: vec![Expression::Literal(LiteralValue::String(
-                    "ááá🇷🇺ááá".to_string()
-                )),],
-                is_nullable: false,
-            }),],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        bit_length_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(88))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::BitLength,
-                vec![Expression::Literal(LiteralValue::String(
-                    "hello world".to_string()
-                )),],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        bit_length_multi_codepoint,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(208))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::BitLength,
-                args: vec![Expression::Literal(LiteralValue::String(
-                    "ááá🇷🇺ááá".to_string()
-                )),],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        array_size_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(2))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Size,
-                args: vec![Expression::Array(
+        )),],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    octet_length_multi_codepoint,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(26))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::OctetLength,
+            args: vec![Expression::Literal(LiteralValue::String(
+                "ááá🇷🇺ááá".to_string()
+            )),],
+            is_nullable: false,
+        }),],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    bit_length_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(88))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::BitLength,
+            vec![Expression::Literal(LiteralValue::String(
+                "hello world".to_string()
+            )),],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    bit_length_multi_codepoint,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(208))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::BitLength,
+            args: vec![Expression::Literal(LiteralValue::String(
+                "ááá🇷🇺ááá".to_string()
+            )),],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    array_size_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(2))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Size,
+            args: vec![Expression::Array(
+                vec![
+                    Expression::Literal(LiteralValue::Integer(0)),
+                    Expression::Literal(LiteralValue::Integer(0))
+                ]
+                .into()
+            )],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    array_size_empty,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(0))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Size,
+            args: vec![Expression::Array(vec![].into())],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    coalesce_empty,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Coalesce,
+            vec![],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    coalesce_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(0))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Coalesce,
+            vec![
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Integer(0)),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Integer(1))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    coalesce_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Coalesce,
+            vec![
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Null),
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    merge_objects_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Document(
+            unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
+            "b".into() => Expression::Literal(LiteralValue::Integer(0)),
+            "c".into() => Expression::Literal(LiteralValue::Integer(2))}
+        .into())],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::MergeObjects,
+            args: vec![
+                Expression::Document(
+                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
+                    "b".into() => Expression::Literal(LiteralValue::Integer(1))}
+                .into()),
+                Expression::Document(
+                    unchecked_unique_linked_hash_map! {"b".into() => Expression::Literal(LiteralValue::Integer(0)),
+                    "c".into() => Expression::Literal(LiteralValue::Integer(2))}
+                .into())
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    merge_objects_reference,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::MergeObjects,
+            args: vec![
+                Expression::Document(
+                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
+                    "b".into() => Expression::Literal(LiteralValue::Integer(1))}
+                .into()),
+                Expression::Reference(("a", 0u16).into())
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    merge_objects_empty,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Document(
+            unchecked_unique_linked_hash_map! {}.into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::MergeObjects,
+            vec![],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    merge_objects_combine_early_docs,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::MergeObjects,
+            args: vec![
+                Expression::Document(
+                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
+                    "b".into() => Expression::Literal(LiteralValue::Integer(0)),
+                    "c".into() => Expression::Literal(LiteralValue::Integer(2))}
+                .into()),
+                Expression::Reference(("a", 0u16).into())
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::MergeObjects,
+            args: vec![
+                Expression::Document(
+                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
+                    "b".into() => Expression::Literal(LiteralValue::Integer(1))}
+                .into()),
+                Expression::Document(
+                    unchecked_unique_linked_hash_map! {"b".into() => Expression::Literal(LiteralValue::Integer(0)),
+                    "c".into() => Expression::Literal(LiteralValue::Integer(2))}
+                .into()),
+                Expression::Reference(("a", 0u16).into())
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    null_if_args_equal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::NullIf,
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(1))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    null_if_args_unequal,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(1))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::NullIf,
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(2))
+            ],
+        ))],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    computed_field_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(2))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::ComputedFieldAccess,
+            args: vec![
+                Expression::Document(
+                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(2))}
+                .into()),
+                Expression::Literal(LiteralValue::String("a".into()))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    computed_field_missing,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::ComputedFieldAccess,
+            args: vec![
+                Expression::Document(
+                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(2))}
+                .into()),
+                Expression::Literal(LiteralValue::String("b".into()))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    slice_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![Expression::Literal(LiteralValue::Integer(2))].into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
                     vec![
-                        Expression::Literal(LiteralValue::Integer(0)),
-                        Expression::Literal(LiteralValue::Integer(0))
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
                     ]
                     .into()
-                )],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        array_size_empty,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(0))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Size,
-                args: vec![Expression::Array(vec![].into())],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        coalesce_empty,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Coalesce,
-                vec![],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        coalesce_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(0))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Coalesce,
+                ),
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(1))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Null),
+                Expression::Literal(LiteralValue::Integer(1))
+            ],
+            is_nullable: true,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_negative_length_no_start,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::Literal(LiteralValue::Integer(2)),
+                Expression::Literal(LiteralValue::Integer(3))
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Integer(-2))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_positive_length_no_start,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(2))
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Integer(2))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_negative_start_within_array,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![Expression::Literal(LiteralValue::Integer(2))].into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Integer(-2)),
+                Expression::Literal(LiteralValue::Integer(1))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_negative_start_outside_array,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(2))
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Integer(-5)),
+                Expression::Literal(LiteralValue::Integer(2))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_negative_len_longer_than_array,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(2)),
+                Expression::Literal(LiteralValue::Integer(3))
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Integer(-5))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_positive_len_longer_than_array,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::Literal(LiteralValue::Integer(2)),
+                Expression::Literal(LiteralValue::Integer(3))
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(5))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_positive_len_longer_than_array_no_start,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(
+            vec![
+                Expression::Literal(LiteralValue::Integer(1)),
+                Expression::Literal(LiteralValue::Integer(2)),
+                Expression::Literal(LiteralValue::Integer(3))
+            ]
+            .into()
+        )],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Integer(5))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_start_larger_than_array,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Array(vec![].into())],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Integer(5)),
+                Expression::Literal(LiteralValue::Integer(1))
+            ],
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    slice_with_pos_neg_length_is_null,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Null)],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
+            function: ScalarFunction::Slice,
+            args: vec![
+                Expression::Array(
+                    vec![
+                        Expression::Literal(LiteralValue::Integer(1)),
+                        Expression::Literal(LiteralValue::Integer(2)),
+                        Expression::Literal(LiteralValue::Integer(3))
+                    ]
+                    .into()
+                ),
+                Expression::Literal(LiteralValue::Integer(5)),
+                Expression::Literal(LiteralValue::Integer(-1))
+            ],
+            is_nullable: false,
+        }),],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_expr_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Is(IsExpr {
+            expr: Expression::Literal(LiteralValue::Integer(1)).into(),
+            target_type: TypeOrMissing::Type(Type::Int32),
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_expr_false,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Is(IsExpr {
+            expr: Expression::Literal(LiteralValue::String("a".into())).into(),
+            target_type: TypeOrMissing::Type(Type::Double),
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    is_expr_number,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Is(IsExpr {
+            expr: Expression::Literal(LiteralValue::Double(1.0)).into(),
+            target_type: TypeOrMissing::Number,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    is_expr_null,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Is(IsExpr {
+            expr: Expression::Literal(LiteralValue::Double(1.0)).into(),
+            target_type: TypeOrMissing::Type(Type::Null),
+        })],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    is_expr_nested,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Is(IsExpr {
+            expr: Expression::ScalarFunction(ScalarFunctionApplication::new(
+                ScalarFunction::Concat,
                 vec![
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Integer(0)),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Integer(1))
+                    Expression::Literal(LiteralValue::String("hello ".to_string())),
+                    Expression::Literal(LiteralValue::String("world".to_string())),
                 ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        coalesce_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::Coalesce,
-                vec![
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Null),
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        merge_objects_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Document(
-                unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
-                "b".into() => Expression::Literal(LiteralValue::Integer(0)),
-                "c".into() => Expression::Literal(LiteralValue::Integer(2))}
-            .into())],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::MergeObjects,
-                args: vec![
-                    Expression::Document(
-                        unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
-                        "b".into() => Expression::Literal(LiteralValue::Integer(1))}
-                    .into()),
-                    Expression::Document(
-                        unchecked_unique_linked_hash_map! {"b".into() => Expression::Literal(LiteralValue::Integer(0)),
-                        "c".into() => Expression::Literal(LiteralValue::Integer(2))}
-                    .into())
-                ],
+            ))
+            .into(),
+            target_type: TypeOrMissing::Type(Type::String),
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    simple_case_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String("then 2".into()))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SimpleCase(SimpleCaseExpr {
+            expr: Expression::Literal(LiteralValue::Integer(2)).into(),
+            when_branch: vec![
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(3)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(2)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 2".into())).into(),
+                    is_nullable: false,
+                }
+            ],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    simple_case_ref_ahead,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SimpleCase(SimpleCaseExpr {
+            expr: Expression::Literal(LiteralValue::Integer(2)).into(),
+            when_branch: vec![
+                WhenBranch {
+                    when: Expression::Reference(("a", 0u16).into()).into(),
+                    then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(2)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 2".into())).into(),
+                    is_nullable: false,
+                }
+            ],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    simple_case_prune_false,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SimpleCase(SimpleCaseExpr {
+            expr: Expression::Literal(LiteralValue::Integer(2)).into(),
+            when_branch: vec![WhenBranch {
+                when: Expression::Reference(("a", 0u16).into()).into(),
+                then: Expression::Literal(LiteralValue::String("then a".into())).into(),
                 is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        merge_objects_reference,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::MergeObjects,
-                args: vec![
-                    Expression::Document(
-                        unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
-                        "b".into() => Expression::Literal(LiteralValue::Integer(1))}
-                    .into()),
-                    Expression::Reference(("a", 0u16).into())
-                ],
+            },],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SimpleCase(SimpleCaseExpr {
+            expr: Expression::Literal(LiteralValue::Integer(2)).into(),
+            when_branch: vec![
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(3)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Reference(("a", 0u16).into()).into(),
+                    then: Expression::Literal(LiteralValue::String("then a".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(4)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
+                    is_nullable: false,
+                },
+            ],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    simple_case_else,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String("else".into()))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SimpleCase(SimpleCaseExpr {
+            expr: Expression::Literal(LiteralValue::Integer(2)).into(),
+            when_branch: vec![
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(3)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(4)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
+                    is_nullable: false,
+                }
+            ],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    simple_case_keep_branches,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SimpleCase(SimpleCaseExpr {
+            expr: Expression::Reference(("a", 0u16).into()).into(),
+            when_branch: vec![
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(4)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(4)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
+                    is_nullable: false,
+                },
+            ],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    searched_case_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String(
+            "then true".into()
+        ))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SearchedCase(SearchedCaseExpr {
+            when_branch: vec![
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Boolean(false)).into(),
+                    then: Expression::Literal(LiteralValue::String("then false".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Boolean(true)).into(),
+                    then: Expression::Literal(LiteralValue::String("then true".into())).into(),
+                    is_nullable: false,
+                }
+            ],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    searched_case_ref_ahead,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SearchedCase(SearchedCaseExpr {
+            when_branch: vec![
+                WhenBranch {
+                    when: Expression::Reference(("a", 0u16).into()).into(),
+                    then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Boolean(true)).into(),
+                    then: Expression::Literal(LiteralValue::String("then true".into())).into(),
+                    is_nullable: true,
+                }
+            ],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    searched_case_prune_false,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SearchedCase(SearchedCaseExpr {
+            when_branch: vec![WhenBranch {
+                when: Expression::Reference(("a", 0u16).into()).into(),
+                then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
                 is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        merge_objects_empty,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Document(
-                unchecked_unique_linked_hash_map! {}.into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::MergeObjects,
-                vec![],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        merge_objects_combine_early_docs,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::MergeObjects,
-                args: vec![
-                    Expression::Document(
-                        unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
-                        "b".into() => Expression::Literal(LiteralValue::Integer(0)),
-                        "c".into() => Expression::Literal(LiteralValue::Integer(2))}
-                    .into()),
-                    Expression::Reference(("a", 0u16).into())
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::MergeObjects,
-                args: vec![
-                    Expression::Document(
-                        unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0)),
-                        "b".into() => Expression::Literal(LiteralValue::Integer(1))}
-                    .into()),
-                    Expression::Document(
-                        unchecked_unique_linked_hash_map! {"b".into() => Expression::Literal(LiteralValue::Integer(0)),
-                        "c".into() => Expression::Literal(LiteralValue::Integer(2))}
-                    .into()),
-                    Expression::Reference(("a", 0u16).into())
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        null_if_args_equal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::NullIf,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(1))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        null_if_args_unequal,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(1))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication::new(
-                ScalarFunction::NullIf,
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(2))
-                ],
-            ))],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        computed_field_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(2))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::ComputedFieldAccess,
-                args: vec![
-                    Expression::Document(
-                        unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(2))}
-                    .into()),
-                    Expression::Literal(LiteralValue::String("a".into()))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        computed_field_missing,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::ComputedFieldAccess,
-                args: vec![
-                    Expression::Document(
-                        unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(2))}
-                    .into()),
-                    Expression::Literal(LiteralValue::String("b".into()))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        slice_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![Expression::Literal(LiteralValue::Integer(2))].into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(1))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        slice_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Null),
-                    Expression::Literal(LiteralValue::Integer(1))
-                ],
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        slice_negative_length_no_start,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::Literal(LiteralValue::Integer(2)),
-                    Expression::Literal(LiteralValue::Integer(3))
-                ]
+            },],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SearchedCase(SearchedCaseExpr {
+            when_branch: vec![
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Boolean(false)).into(),
+                    then: Expression::Literal(LiteralValue::String("then false".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Reference(("a", 0u16).into()).into(),
+                    then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::String("false".into())).into(),
+                    then: Expression::Literal(LiteralValue::String("then false string".into()))
+                        .into(),
+                    is_nullable: false,
+                },
+            ],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    searched_case_else,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::String("else".into()))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::SearchedCase(SearchedCaseExpr {
+            when_branch: vec![
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Boolean(false)).into(),
+                    then: Expression::Literal(LiteralValue::String("then false".into())).into(),
+                    is_nullable: false,
+                },
+                WhenBranch {
+                    when: Expression::Literal(LiteralValue::Integer(4)).into(),
+                    then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
+                    is_nullable: false,
+                }
+            ],
+            else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    field_access_simple,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Literal(LiteralValue::Integer(0))],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::FieldAccess(FieldAccess {
+            expr: Expression::Document(
+                unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0))}
+            .into())
+            .into(),
+            field: "a".into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    field_access_reference,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Reference(("b", 0u16).into())],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::FieldAccess(FieldAccess {
+            expr: Expression::Document(
+                unchecked_unique_linked_hash_map! {"a".into() => Expression::Reference(("b", 0u16).into())}
+            .into())
+            .into(),
+            field: "a".into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    field_access_nested,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::Reference(("c", 0u16).into())],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::FieldAccess(FieldAccess {
+            expr: Expression::Document(
+                unchecked_unique_linked_hash_map! {"a".into() => Expression::FieldAccess(FieldAccess {
+                    expr: Expression::Document(
+                        unchecked_unique_linked_hash_map! {"b".into() => Expression::Reference(("c", 0u16).into())}.into()
+                    ).into(),
+                    field: "b".into(),
+                    is_nullable: false,
+                })}
+            .into())
+            .into(),
+            field: "a".into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold!(
+    field_access_mqlintrinstic_field_exists,
+    expected = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::MqlIntrinsicFieldExistence(FieldAccess {
+            expr: Expression::Reference(("ITBL", 1u16).into()).into(),
+            field: "baz".into(),
+            is_nullable: true,
+        }),],
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::MqlIntrinsicFieldExistence(FieldAccess {
+            expr: Expression::Document(
+                unchecked_unique_linked_hash_map! {
+                    "ofoo".into() => Expression::FieldAccess(FieldAccess {
+                        expr: Expression::Reference(("OTBL", 1u16).into()).into(),
+                        field: "foo".into(),
+                        is_nullable: false,
+                    }),
+                    "ifoo".into() => Expression::FieldAccess(FieldAccess {
+                        expr: Expression::Reference(("ITBL", 1u16).into()).into(),
+                        field: "foo".into(),
+                        is_nullable: true,
+                    }),
+                    "baz".into() => Expression::FieldAccess(FieldAccess {
+                        expr: Expression::Reference(("ITBL", 1u16).into()).into(),
+                        field: "baz".into(),
+                        is_nullable: true,
+                    }),
+                }
                 .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(-2))
-                ],
-                is_nullable: false,
+            )
+            .into(),
+            field: "baz".into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    field_access_missing_field,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::FieldAccess(FieldAccess {
+            expr: Expression::Document(
+                unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0))}
+            .into())
+            .into(),
+            field: "b".into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold_no_op!(
+    field_access_ref,
+    Stage::Array(ArraySource {
+        alias: "".into(),
+        array: vec![Expression::FieldAccess(FieldAccess {
+            expr: Expression::Reference(("a", 0u16).into()).into(),
+            field: "a".into(),
+            is_nullable: false,
+        })],
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    offset_simple,
+    expected = test_source(),
+    expected_changed = true,
+    input = Stage::Offset(Offset {
+        source: Box::new(test_source()),
+        offset: 0,
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    offset_nonzero,
+    Stage::Offset(Offset {
+        source: Box::new(test_source()),
+        offset: 1,
+        cache: SchemaCache::new(),
+    })
+);
+test_constant_fold!(
+    filter_simple,
+    expected = test_source(),
+    expected_changed = true,
+    input = Stage::Filter(Filter {
+        source: Box::new(test_source()),
+        condition: Expression::Literal(LiteralValue::Boolean(true)),
+        cache: SchemaCache::new(),
+    }),
+);
+test_constant_fold_no_op!(
+    filter_non_literal,
+    Stage::Filter(Filter {
+        source: Box::new(test_source()),
+        condition: Expression::Reference(("a", 0u16).into()),
+        cache: SchemaCache::new(),
+    })
+);
+
+test_constant_fold!(
+    multi_level_field_access_from_literal_document_is_constant_folded,
+    expected = Stage::Project(Project {
+        is_add_fields: false,
+        source: Box::new(Stage::Array(ArraySource {
+            array: vec![Expression::Document(DocumentExpr {
+                document: unchecked_unique_linked_hash_map! {},
             })],
+            alias: "_dual".to_string(),
             cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        slice_positive_length_no_start,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(2))
-                ]
-                .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(2))
-                ],
-                is_nullable: false,
+        })),
+        expression: map! {
+            (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
+                document: unchecked_unique_linked_hash_map! {
+                    "c".to_string() =>
+                    Expression::Literal(LiteralValue::Integer(1),),
+                },
+            }),
+        },
+        cache: SchemaCache::new(),
+    }),
+    expected_changed = true,
+    input = Stage::Project(Project {
+        is_add_fields: false,
+        source: Box::new(Stage::Array(ArraySource {
+            array: vec![Expression::Document(DocumentExpr {
+                document: unchecked_unique_linked_hash_map! {},
             })],
+            alias: "_dual".to_string(),
             cache: SchemaCache::new(),
-        }),
-    );
+        })),
+        expression: map! {
+            (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
+                document: unchecked_unique_linked_hash_map! {
+                    "c".to_string() => Expression::FieldAccess(FieldAccess {
+                        expr: Box::new(Expression::FieldAccess(FieldAccess {
+                            expr: Box::new(Expression::FieldAccess(FieldAccess {
+                                expr: Box::new(Expression::Document(DocumentExpr {
+                                    document: unchecked_unique_linked_hash_map! {
+                                        "a".to_string() => Expression::Document(DocumentExpr {
+                                            document: unchecked_unique_linked_hash_map! {
+                                                "b".to_string() => Expression::Document(DocumentExpr {
+                                                    document: unchecked_unique_linked_hash_map! {
+                                                        "c".to_string() => Expression::Literal(
+                                                            LiteralValue::Integer(1),
+                                                        ),
+                                                    },
+                                                }),
+                                            },
+                                        }),
+                                    },
+                                })),
+                                field: "a".to_string(),
+                                is_nullable: false,
+                            })),
+                            field: "b".to_string(),
+                            is_nullable: false,
+                        })),
+                        field: "c".to_string(),
+                        is_nullable: false,
+                    }),
+                },
+            }),
+        },
+        cache: SchemaCache::new(),
+    }),
+);
+
+mod cast {
+    use super::*;
+
     test_constant_fold!(
-        slice_negative_start_within_array,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![Expression::Literal(LiteralValue::Integer(2))].into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(-2)),
-                    Expression::Literal(LiteralValue::Integer(1))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        slice_negative_start_outside_array,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(2))
-                ]
-                .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(-5)),
-                    Expression::Literal(LiteralValue::Integer(2))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        slice_negative_len_longer_than_array,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(2)),
-                    Expression::Literal(LiteralValue::Integer(3))
-                ]
-                .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(-5))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        slice_positive_len_longer_than_array,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::Literal(LiteralValue::Integer(2)),
-                    Expression::Literal(LiteralValue::Integer(3))
-                ]
-                .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(5))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        slice_positive_len_longer_than_array_no_start,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![
-                    Expression::Literal(LiteralValue::Integer(1)),
-                    Expression::Literal(LiteralValue::Integer(2)),
-                    Expression::Literal(LiteralValue::Integer(3))
-                ]
-                .into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(5))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        slice_start_larger_than_array,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(vec![].into())],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(5)),
-                    Expression::Literal(LiteralValue::Integer(1))
-                ],
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        slice_with_pos_neg_length_is_null,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::ScalarFunction(ScalarFunctionApplication {
-                function: ScalarFunction::Slice,
-                args: vec![
-                    Expression::Array(
-                        vec![
-                            Expression::Literal(LiteralValue::Integer(1)),
-                            Expression::Literal(LiteralValue::Integer(2)),
-                            Expression::Literal(LiteralValue::Integer(3))
-                        ]
-                        .into()
-                    ),
-                    Expression::Literal(LiteralValue::Integer(5)),
-                    Expression::Literal(LiteralValue::Integer(-1))
-                ],
-                is_nullable: false,
-            }),],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        cast_simple,
+        simple,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::Boolean(true))],
@@ -2508,8 +3118,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold_no_op!(
-        cast_mismatched_types,
+        mismatched_types,
         Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Cast(CastExpr {
@@ -2522,8 +3133,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         })
     );
+
     test_constant_fold!(
-        cast_array_as_array,
+        array_as_array,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Array(
@@ -2547,8 +3159,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
-        cast_non_array_as_array,
+        non_array_as_array,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::String("error".into()))],
@@ -2567,8 +3180,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
-        cast_document_as_document,
+        document_as_document,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Document(
@@ -2592,8 +3206,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
-        cast_non_document_as_document,
+        non_document_as_document,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::String("error".into()))],
@@ -2612,8 +3227,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
-        cast_null,
+        null,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::String("null".into()))],
@@ -2632,8 +3248,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
-        cast_valid_string_to_date_with_milliseconds,
+        valid_string_to_date_with_milliseconds,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![
@@ -2681,8 +3298,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
-        cast_valid_string_to_date_without_milliseconds,
+        valid_string_to_date_without_milliseconds,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![
@@ -2724,10 +3342,11 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     // An unparseable date string cannot be folded and is left as a Cast, to be
     // evaluated at runtime by MongoDB.
     test_constant_fold_no_op!(
-        cast_invalid_string_to_date,
+        invalid_string_to_date,
         Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Cast(CastExpr {
@@ -2741,8 +3360,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         })
     );
+
     test_constant_fold!(
-        cast_valid_string_to_oid,
+        valid_string_to_oid,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::ObjectId(*OID))],
@@ -2762,10 +3382,11 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     // A string that cannot be parsed as an ObjectId statically fails, so the cast
     // folds to its on_error branch (here, Null).
     test_constant_fold!(
-        cast_invalid_string_to_oid,
+        invalid_string_to_oid,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::Null)],
@@ -2785,8 +3406,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
-        cast_valid_string_to_decimal128,
+        valid_string_to_decimal128,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::Decimal128(*STRING_DEC))],
@@ -2805,8 +3427,9 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
-        cast_valid_nested_string_cast_to_decimal128,
+        valid_nested_string_cast_to_decimal128,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::Decimal128(*STRING_DEC))],
@@ -2832,6 +3455,7 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     // A string that cannot be parsed as a Decimal128 statically fails, so the cast
     // folds to its on_error branch (here, Null).
     test_constant_fold!(
@@ -2854,6 +3478,7 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
         cast_double_to_decimal128,
         expected = Stage::Array(ArraySource {
@@ -2874,6 +3499,7 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
         cast_int_to_decimal128,
         expected = Stage::Array(ArraySource {
@@ -2894,6 +3520,7 @@ mod constant_folding {
             cache: SchemaCache::new(),
         }),
     );
+
     test_constant_fold!(
         cast_long_to_decimal128,
         expected = Stage::Array(ArraySource {
@@ -2911,612 +3538,6 @@ mod constant_folding {
                 on_error: Expression::Literal(LiteralValue::Null).into(),
                 is_nullable: true,
             })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_expr_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Is(IsExpr {
-                expr: Expression::Literal(LiteralValue::Integer(1)).into(),
-                target_type: TypeOrMissing::Type(Type::Int32),
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_expr_false,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(false))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Is(IsExpr {
-                expr: Expression::Literal(LiteralValue::String("a".into())).into(),
-                target_type: TypeOrMissing::Type(Type::Double),
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        is_expr_number,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Is(IsExpr {
-                expr: Expression::Literal(LiteralValue::Double(1.0)).into(),
-                target_type: TypeOrMissing::Number,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        is_expr_null,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Is(IsExpr {
-                expr: Expression::Literal(LiteralValue::Double(1.0)).into(),
-                target_type: TypeOrMissing::Type(Type::Null),
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        is_expr_nested,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Is(IsExpr {
-                expr: Expression::ScalarFunction(ScalarFunctionApplication::new(
-                    ScalarFunction::Concat,
-                    vec![
-                        Expression::Literal(LiteralValue::String("hello ".to_string())),
-                        Expression::Literal(LiteralValue::String("world".to_string())),
-                    ],
-                ))
-                .into(),
-                target_type: TypeOrMissing::Type(Type::String),
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        simple_case_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("then 2".into()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SimpleCase(SimpleCaseExpr {
-                expr: Expression::Literal(LiteralValue::Integer(2)).into(),
-                when_branch: vec![
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(3)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(2)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 2".into())).into(),
-                        is_nullable: false,
-                    }
-                ],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        simple_case_ref_ahead,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SimpleCase(SimpleCaseExpr {
-                expr: Expression::Literal(LiteralValue::Integer(2)).into(),
-                when_branch: vec![
-                    WhenBranch {
-                        when: Expression::Reference(("a", 0u16).into()).into(),
-                        then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(2)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 2".into())).into(),
-                        is_nullable: false,
-                    }
-                ],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        simple_case_prune_false,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SimpleCase(SimpleCaseExpr {
-                expr: Expression::Literal(LiteralValue::Integer(2)).into(),
-                when_branch: vec![WhenBranch {
-                    when: Expression::Reference(("a", 0u16).into()).into(),
-                    then: Expression::Literal(LiteralValue::String("then a".into())).into(),
-                    is_nullable: false,
-                },],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SimpleCase(SimpleCaseExpr {
-                expr: Expression::Literal(LiteralValue::Integer(2)).into(),
-                when_branch: vec![
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(3)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Reference(("a", 0u16).into()).into(),
-                        then: Expression::Literal(LiteralValue::String("then a".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(4)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
-                        is_nullable: false,
-                    },
-                ],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        simple_case_else,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("else".into()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SimpleCase(SimpleCaseExpr {
-                expr: Expression::Literal(LiteralValue::Integer(2)).into(),
-                when_branch: vec![
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(3)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(4)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
-                        is_nullable: false,
-                    }
-                ],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        simple_case_keep_branches,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SimpleCase(SimpleCaseExpr {
-                expr: Expression::Reference(("a", 0u16).into()).into(),
-                when_branch: vec![
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(4)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(4)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
-                        is_nullable: false,
-                    },
-                ],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        searched_case_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String(
-                "then true".into()
-            ))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SearchedCase(SearchedCaseExpr {
-                when_branch: vec![
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Boolean(false)).into(),
-                        then: Expression::Literal(LiteralValue::String("then false".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                        then: Expression::Literal(LiteralValue::String("then true".into())).into(),
-                        is_nullable: false,
-                    }
-                ],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        searched_case_ref_ahead,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SearchedCase(SearchedCaseExpr {
-                when_branch: vec![
-                    WhenBranch {
-                        when: Expression::Reference(("a", 0u16).into()).into(),
-                        then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                        then: Expression::Literal(LiteralValue::String("then true".into())).into(),
-                        is_nullable: true,
-                    }
-                ],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        searched_case_prune_false,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SearchedCase(SearchedCaseExpr {
-                when_branch: vec![WhenBranch {
-                    when: Expression::Reference(("a", 0u16).into()).into(),
-                    then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
-                    is_nullable: false,
-                },],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SearchedCase(SearchedCaseExpr {
-                when_branch: vec![
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Boolean(false)).into(),
-                        then: Expression::Literal(LiteralValue::String("then false".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Reference(("a", 0u16).into()).into(),
-                        then: Expression::Literal(LiteralValue::String("then 3".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::String("false".into())).into(),
-                        then: Expression::Literal(LiteralValue::String("then false string".into()))
-                            .into(),
-                        is_nullable: false,
-                    },
-                ],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        searched_case_else,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("else".into()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::SearchedCase(SearchedCaseExpr {
-                when_branch: vec![
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Boolean(false)).into(),
-                        then: Expression::Literal(LiteralValue::String("then false".into())).into(),
-                        is_nullable: false,
-                    },
-                    WhenBranch {
-                        when: Expression::Literal(LiteralValue::Integer(4)).into(),
-                        then: Expression::Literal(LiteralValue::String("then 4".into())).into(),
-                        is_nullable: false,
-                    }
-                ],
-                else_branch: Expression::Literal(LiteralValue::String("else".into())).into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        field_access_simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Integer(0))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::FieldAccess(FieldAccess {
-                expr: Expression::Document(
-                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0))}
-                .into())
-                .into(),
-                field: "a".into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        field_access_reference,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Reference(("b", 0u16).into())],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::FieldAccess(FieldAccess {
-                expr: Expression::Document(
-                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Reference(("b", 0u16).into())}
-                .into())
-                .into(),
-                field: "a".into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        field_access_nested,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Reference(("c", 0u16).into())],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::FieldAccess(FieldAccess {
-                expr: Expression::Document(
-                    unchecked_unique_linked_hash_map! {"a".into() => Expression::FieldAccess(FieldAccess {
-                        expr: Expression::Document(
-                            unchecked_unique_linked_hash_map! {"b".into() => Expression::Reference(("c", 0u16).into())}.into()
-                        ).into(),
-                        field: "b".into(),
-                        is_nullable: false,
-                    })}
-                .into())
-                .into(),
-                field: "a".into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold!(
-        field_access_mqlintrinstic_field_exists,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::MqlIntrinsicFieldExistence(FieldAccess {
-                expr: Expression::Reference(("ITBL", 1u16).into()).into(),
-                field: "baz".into(),
-                is_nullable: true,
-            }),],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::MqlIntrinsicFieldExistence(FieldAccess {
-                expr: Expression::Document(
-                    unchecked_unique_linked_hash_map! {
-                        "ofoo".into() => Expression::FieldAccess(FieldAccess {
-                            expr: Expression::Reference(("OTBL", 1u16).into()).into(),
-                            field: "foo".into(),
-                            is_nullable: false,
-                        }),
-                        "ifoo".into() => Expression::FieldAccess(FieldAccess {
-                            expr: Expression::Reference(("ITBL", 1u16).into()).into(),
-                            field: "foo".into(),
-                            is_nullable: true,
-                        }),
-                        "baz".into() => Expression::FieldAccess(FieldAccess {
-                            expr: Expression::Reference(("ITBL", 1u16).into()).into(),
-                            field: "baz".into(),
-                            is_nullable: true,
-                        }),
-                    }
-                    .into()
-                )
-                .into(),
-                field: "baz".into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        field_access_missing_field,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::FieldAccess(FieldAccess {
-                expr: Expression::Document(
-                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(0))}
-                .into())
-                .into(),
-                field: "b".into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold_no_op!(
-        field_access_ref,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::FieldAccess(FieldAccess {
-                expr: Expression::Reference(("a", 0u16).into()).into(),
-                field: "a".into(),
-                is_nullable: false,
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        offset_simple,
-        expected = test_source(),
-        expected_changed = true,
-        input = Stage::Offset(Offset {
-            source: Box::new(test_source()),
-            offset: 0,
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        offset_nonzero,
-        Stage::Offset(Offset {
-            source: Box::new(test_source()),
-            offset: 1,
-            cache: SchemaCache::new(),
-        })
-    );
-    test_constant_fold!(
-        filter_simple,
-        expected = test_source(),
-        expected_changed = true,
-        input = Stage::Filter(Filter {
-            source: Box::new(test_source()),
-            condition: Expression::Literal(LiteralValue::Boolean(true)),
-            cache: SchemaCache::new(),
-        }),
-    );
-    test_constant_fold_no_op!(
-        filter_non_literal,
-        Stage::Filter(Filter {
-            source: Box::new(test_source()),
-            condition: Expression::Reference(("a", 0u16).into()),
-            cache: SchemaCache::new(),
-        })
-    );
-
-    test_constant_fold!(
-        multi_level_field_access_from_literal_document_is_constant_folded,
-        expected = Stage::Project(Project {
-            is_add_fields: false,
-            source: Box::new(Stage::Array(ArraySource {
-                array: vec![Expression::Document(DocumentExpr {
-                    document: unchecked_unique_linked_hash_map! {},
-                })],
-                alias: "_dual".to_string(),
-                cache: SchemaCache::new(),
-            })),
-            expression: map! {
-                (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
-                    document: unchecked_unique_linked_hash_map! {
-                        "c".to_string() =>
-                        Expression::Literal(LiteralValue::Integer(1),),
-                    },
-                }),
-            },
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Project(Project {
-            is_add_fields: false,
-            source: Box::new(Stage::Array(ArraySource {
-                array: vec![Expression::Document(DocumentExpr {
-                    document: unchecked_unique_linked_hash_map! {},
-                })],
-                alias: "_dual".to_string(),
-                cache: SchemaCache::new(),
-            })),
-            expression: map! {
-                (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
-                    document: unchecked_unique_linked_hash_map! {
-                        "c".to_string() => Expression::FieldAccess(FieldAccess {
-                            expr: Box::new(Expression::FieldAccess(FieldAccess {
-                                expr: Box::new(Expression::FieldAccess(FieldAccess {
-                                    expr: Box::new(Expression::Document(DocumentExpr {
-                                        document: unchecked_unique_linked_hash_map! {
-                                            "a".to_string() => Expression::Document(DocumentExpr {
-                                                document: unchecked_unique_linked_hash_map! {
-                                                    "b".to_string() => Expression::Document(DocumentExpr {
-                                                        document: unchecked_unique_linked_hash_map! {
-                                                            "c".to_string() => Expression::Literal(
-                                                                LiteralValue::Integer(1),
-                                                            ),
-                                                        },
-                                                    }),
-                                                },
-                                            }),
-                                        },
-                                    })),
-                                    field: "a".to_string(),
-                                    is_nullable: false,
-                                })),
-                                field: "b".to_string(),
-                                is_nullable: false,
-                            })),
-                            field: "c".to_string(),
-                            is_nullable: false,
-                        }),
-                    },
-                }),
-            },
             cache: SchemaCache::new(),
         }),
     );

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -3603,20 +3603,16 @@ mod cast {
         test_constant_fold_cast_literal!(
             from_string_greater_than_max_int_literal,
             expected_expr = Expression::Literal(LiteralValue::String("error".into())),
-            input_expr = Expression::Literal(LiteralValue::String(format!(
-                "{}",
-                i32::MAX as i64 + 1i64
-            ))),
+            input_expr =
+                Expression::Literal(LiteralValue::String(format!("{}", i32::MAX as i64 + 1i64))),
             input_to = Type::Int32,
         );
 
         test_constant_fold_cast_literal!(
             from_string_less_than_min_int_literal,
             expected_expr = Expression::Literal(LiteralValue::String("error".into())),
-            input_expr = Expression::Literal(LiteralValue::String(format!(
-                "{}",
-                i32::MIN as i64 - 1i64
-            ))),
+            input_expr =
+                Expression::Literal(LiteralValue::String(format!("{}", i32::MIN as i64 - 1i64))),
             input_to = Type::Int32,
         );
 
@@ -4078,20 +4074,16 @@ mod cast {
         test_constant_fold_cast_literal!(
             from_string_greater_than_max_long_literal,
             expected_expr = Expression::Literal(LiteralValue::String("error".into())),
-            input_expr = Expression::Literal(LiteralValue::String(format!(
-                "{}",
-                i64::MAX as f64 + 1.0
-            ))),
+            input_expr =
+                Expression::Literal(LiteralValue::String(format!("{}", i64::MAX as f64 + 1.0))),
             input_to = Type::Int64,
         );
 
         test_constant_fold_cast_literal!(
             from_string_less_than_min_long_literal,
             expected_expr = Expression::Literal(LiteralValue::String("error".into())),
-            input_expr = Expression::Literal(LiteralValue::String(format!(
-                "{}",
-                i64::MIN as f64 - 1.0
-            ))),
+            input_expr =
+                Expression::Literal(LiteralValue::String(format!("{}", i64::MIN as f64 - 1.0))),
             input_to = Type::Int64,
         );
 
@@ -4439,9 +4431,8 @@ mod cast {
 
         test_constant_fold_cast_literal!(
             from_objectid_literal,
-            expected_expr = Expression::Literal(LiteralValue::String(
-                "507f1f77bcf86cd799439011".to_string()
-            )),
+            expected_expr =
+                Expression::Literal(LiteralValue::String("507f1f77bcf86cd799439011".to_string())),
             input_expr = Expression::Literal(LiteralValue::ObjectId(*OID)),
             input_to = Type::String,
         );

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -5171,7 +5171,7 @@ mod cast {
                 cache: SchemaCache::new(),
             }),
             schema_env = map! {
-                ("bar", 0u16).into() => Schema::Atomic(Atomic::Integer),
+                ("bar", 0u16).into() => Schema::Atomic(Atomic::Long),
             },
         );
 
@@ -5421,7 +5421,7 @@ mod cast {
             input = Stage::Array(ArraySource {
                 alias: "".into(),
                 array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(i64::MAX as f64 + 1.0)).into(),
+                    expr: Expression::Literal(LiteralValue::Double(f64::MAX)).into(),
                     to: Type::Int64,
                     on_null: Expression::Literal(LiteralValue::Null).into(),
                     on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
@@ -5444,7 +5444,7 @@ mod cast {
             input = Stage::Array(ArraySource {
                 alias: "".into(),
                 array: vec![Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::Double(i64::MIN as f64 - 1.0)).into(),
+                    expr: Expression::Literal(LiteralValue::Double(f64::MIN)).into(),
                     to: Type::Int64,
                     on_null: Expression::Literal(LiteralValue::Null).into(),
                     on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
@@ -5654,7 +5654,7 @@ mod cast {
                         1522039108044
                     )))
                     .into(),
-                    to: Type::Double,
+                    to: Type::Int64,
                     on_null: Expression::Literal(LiteralValue::Null).into(),
                     on_error: Expression::Literal(LiteralValue::Null).into(),
                     is_nullable: true,

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 macro_rules! test_constant_fold {
-    ($func_name:ident, expected = $expected:expr, expected_changed = $expected_changed:expr, input = $input:expr,) => {
+    ($func_name:ident, expected = $expected:expr, expected_changed = $expected_changed:expr, input = $input:expr, $(schema_env = $schema_env:expr,)?) => {
         #[test]
         fn $func_name() {
             use crate::{
@@ -23,11 +23,15 @@ macro_rules! test_constant_fold {
             let input = $input;
             let expected = $expected;
 
+            #[allow(unused_mut, unused_assignments)]
+            let mut schema_env = SchemaEnvironment::default();
+            $(schema_env = $schema_env;)?
+
             let (actual, actual_changed) = ConstantFoldingOptimizer::fold_constants(
                 input,
                 &SchemaInferenceState::new(
                     0,
-                    SchemaEnvironment::default(),
+                    schema_env,
                     &Catalog::default(),
                     map! {},
                     SchemaCheckingMode::Relaxed,
@@ -40,8 +44,8 @@ macro_rules! test_constant_fold {
 }
 
 macro_rules! test_constant_fold_no_op {
-    ($func_name:ident, $input:expr) => {
-        test_constant_fold! { $func_name, expected = $input, expected_changed = false, input = $input, }
+    ($func_name:ident, $input:expr $(, schema_env = $schema_env:expr,)?) => {
+        test_constant_fold! { $func_name, expected = $input, expected_changed = false, input = $input, $(schema_env = $schema_env,)? }
     };
 }
 
@@ -54,6 +58,10 @@ lazy_static! {
     };
     static ref DATE_WITHOUT_MS: bson::DateTime = {
         let chrono_dt: chrono::DateTime<Utc> = "2014-01-01T08:15:39Z".parse().unwrap();
+        chrono_dt.into()
+    };
+    static ref DATE_WITHOUT_TIME: bson::DateTime = {
+        let chrono_dt: chrono::DateTime<Utc> = "2014-01-01T00:00:00Z".parse().unwrap();
         chrono_dt.into()
     };
     static ref INT_DEC: bson::Decimal128 = bson::Decimal128::from_str("3").unwrap();
@@ -3098,138 +3106,11 @@ test_constant_fold!(
 mod cast {
     use super::*;
 
-    test_constant_fold!(
-        simple,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Boolean(true))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                to: Type::Boolean,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
+    use crate::schema::{Atomic, Schema, NULLISH};
 
-    test_constant_fold_no_op!(
-        mismatched_types,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
-                to: Type::String,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-
+    // Regardless of target type, casting from null literal folds to the on_null branch
     test_constant_fold!(
-        array_as_array,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Array(
-                vec![Expression::Literal(LiteralValue::Boolean(true))].into()
-            )],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Array(
-                    vec![Expression::Literal(LiteralValue::Boolean(true))].into()
-                )
-                .into(),
-                to: Type::Array,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-
-    test_constant_fold!(
-        non_array_as_array,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("error".into()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::Integer(0)).into(),
-                to: Type::Array,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-
-    test_constant_fold!(
-        document_as_document,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Document(
-                unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(1))}
-            .into())],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Document(
-                    unchecked_unique_linked_hash_map! {"a".into() => Expression::Literal(LiteralValue::Integer(1))}
-                .into())
-                .into(),
-                to: Type::Document,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-
-    test_constant_fold!(
-        non_document_as_document,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::String("error".into()))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::Integer(0)).into(),
-                to: Type::Document,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-
-    test_constant_fold!(
-        null,
+        from_null_literal,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::String("null".into()))],
@@ -3240,7 +3121,7 @@ mod cast {
             alias: "".into(),
             array: vec![Expression::Cast(CastExpr {
                 expr: Expression::Literal(LiteralValue::Null).into(),
-                to: Type::Array,
+                to: Type::Int32,
                 on_null: Expression::Literal(LiteralValue::String("null".into())).into(),
                 on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
                 is_nullable: false,
@@ -3249,187 +3130,34 @@ mod cast {
         }),
     );
 
+    // Regardless of target type, casting from an exactly nullish literal folds to the on_null
+    // branch
     test_constant_fold!(
-        valid_string_to_date_with_milliseconds,
+        from_exactly_nullish_expr,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
-            array: vec![
-                Expression::Literal(LiteralValue::DateTime(*DATE_WITH_MS)),
-                Expression::Literal(LiteralValue::DateTime(*DATE_WITH_MS)),
-                Expression::Literal(LiteralValue::DateTime(*DATE_WITH_MS)),
-            ],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![
-                Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(
-                        "2014-01-01T08:15:39.736Z".into()
-                    ))
-                    .into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                }),
-                Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(
-                        "2014-01-01 08:15:39.736Z".into()
-                    ))
-                    .into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                }),
-                Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String(
-                        "2014-01-01 08:15:39.736".into()
-                    ))
-                    .into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                }),
-            ],
-            cache: SchemaCache::new(),
-        }),
-    );
-
-    test_constant_fold!(
-        valid_string_to_date_without_milliseconds,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![
-                Expression::Literal(LiteralValue::DateTime(*DATE_WITHOUT_MS)),
-                Expression::Literal(LiteralValue::DateTime(*DATE_WITHOUT_MS)),
-                Expression::Literal(LiteralValue::DateTime(*DATE_WITHOUT_MS)),
-            ],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![
-                Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("2014-01-01T08:15:39Z".into()))
-                        .into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                }),
-                Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("2014-01-01 08:15:39Z".into()))
-                        .into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                }),
-                Expression::Cast(CastExpr {
-                    expr: Expression::Literal(LiteralValue::String("2014-01-01 08:15:39".into()))
-                        .into(),
-                    to: Type::Datetime,
-                    on_null: Expression::Literal(LiteralValue::Null).into(),
-                    on_error: Expression::Literal(LiteralValue::Null).into(),
-                    is_nullable: true,
-                }),
-            ],
-            cache: SchemaCache::new(),
-        }),
-    );
-
-    // An unparseable date string cannot be folded and is left as a Cast, to be
-    // evaluated at runtime by MongoDB.
-    test_constant_fold_no_op!(
-        invalid_string_to_date,
-        Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::String("2014-01-56T08:15:39.736Z".into()))
-                    .into(),
-                to: Type::Datetime,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        })
-    );
-
-    test_constant_fold!(
-        valid_string_to_oid,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::ObjectId(*OID))],
+            array: vec![Expression::Literal(LiteralValue::String("null".into()))],
             cache: SchemaCache::new(),
         }),
         expected_changed = true,
         input = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::String("507f1f77bcf86cd799439011".into()))
-                    .into(),
-                to: Type::ObjectId,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
+                expr: Expression::Reference(("bar", 0u16).into()).into(),
+                to: Type::Int32,
+                on_null: Expression::Literal(LiteralValue::String("null".into())).into(),
+                on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
+                is_nullable: false,
             })],
             cache: SchemaCache::new(),
         }),
-    );
-
-    // A string that cannot be parsed as an ObjectId statically fails, so the cast
-    // folds to its on_error branch (here, Null).
-    test_constant_fold!(
-        invalid_string_to_oid,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::String("57f1f77bcf86cd799439011".into()))
-                    .into(),
-                to: Type::ObjectId,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
+        schema_env = map! {
+            ("bar", 0u16).into() => NULLISH.clone(),
+        },
     );
 
     test_constant_fold!(
-        valid_string_to_decimal128,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Decimal128(*STRING_DEC))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::String("3.14159265".into())).into(),
-                to: Type::Decimal128,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
-
-    test_constant_fold!(
-        valid_nested_string_cast_to_decimal128,
+        valid_nested_casts,
         expected = Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Literal(LiteralValue::Decimal128(*STRING_DEC))],
@@ -3456,89 +3184,2850 @@ mod cast {
         }),
     );
 
-    // A string that cannot be parsed as a Decimal128 statically fails, so the cast
-    // folds to its on_error branch (here, Null).
-    test_constant_fold!(
-        cast_invalid_string_to_decimal128,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Null)],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
+    test_constant_fold_no_op!(
+        mismatched_types,
+        Stage::Array(ArraySource {
             alias: "".into(),
             array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::String("hello".into())).into(),
-                to: Type::Decimal128,
+                expr: Expression::Reference(("bar", 0u16).into()).into(),
+                to: Type::String,
                 on_null: Expression::Literal(LiteralValue::Null).into(),
                 on_error: Expression::Literal(LiteralValue::Null).into(),
                 is_nullable: true,
             })],
             cache: SchemaCache::new(),
         }),
+        schema_env = map! {
+            ("bar", 0u16).into() => Schema::Atomic(Atomic::Boolean),
+        },
     );
 
-    test_constant_fold!(
-        cast_double_to_decimal128,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Decimal128(*DOUBLE_DEC))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::Double(std::f64::consts::PI)).into(),
-                to: Type::Decimal128,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
+    // Note that starting in server version 8.3, $convert to "array" is supported. However, the
+    // MongoSQL spec does not support that conversion, so the tests here and implementation of this
+    // optimization, as well as general translation of CAST "AS ARRAY", are limited.
+    mod to_array {
+        use super::*;
 
-    test_constant_fold!(
-        cast_int_to_decimal128,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Decimal128(*INT_DEC))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::Integer(3)).into(),
-                to: Type::Decimal128,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
+        test_constant_fold!(
+            from_array,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Array(
+                    vec![Expression::Literal(LiteralValue::Boolean(true))].into()
+                )],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Array(
+                        vec![Expression::Literal(LiteralValue::Boolean(true))].into()
+                    )
+                    .into(),
+                    to: Type::Array,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
 
-    test_constant_fold!(
-        cast_long_to_decimal128,
-        expected = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Literal(LiteralValue::Decimal128(*INT_DEC))],
-            cache: SchemaCache::new(),
-        }),
-        expected_changed = true,
-        input = Stage::Array(ArraySource {
-            alias: "".into(),
-            array: vec![Expression::Cast(CastExpr {
-                expr: Expression::Literal(LiteralValue::Long(3)).into(),
-                to: Type::Decimal128,
-                on_null: Expression::Literal(LiteralValue::Null).into(),
-                on_error: Expression::Literal(LiteralValue::Null).into(),
-                is_nullable: true,
-            })],
-            cache: SchemaCache::new(),
-        }),
-    );
+        test_constant_fold!(
+            from_non_array,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String("error".into()))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Integer(0)).into(),
+                    to: Type::Array,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
+
+    // Note that starting in server version 8.3, $convert to "object" is supported. However, the
+    // MongoSQL spec does not support that conversion, so the tests here and implementation of this
+    // optimization, as well as general translation of CAST "AS DOCUMENT", are limited.
+    mod to_document {
+        use super::*;
+
+        test_constant_fold!(
+            from_document,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Document(
+                    unchecked_unique_linked_hash_map! {
+                        "a".into() => Expression::Literal(LiteralValue::Integer(1))
+                    }
+                    .into()
+                )],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Document(
+                        unchecked_unique_linked_hash_map! {
+                            "a".into() => Expression::Literal(LiteralValue::Integer(1))
+                        }
+                        .into()
+                    )
+                    .into(),
+                    to: Type::Document,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_non_document,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String("error".into()))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Integer(0)).into(),
+                    to: Type::Document,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
+
+    // Tests adapted from:
+    // https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#convert-to-boolean
+    mod to_boolean {
+        use super::*;
+
+        test_constant_fold!(
+            from_boolean_non_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Reference(("bar", 0u16).into())],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Reference(("bar", 0u16).into()).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+            schema_env = map! {
+                ("bar", 0u16).into() => Schema::Atomic(Atomic::Boolean),
+            },
+        );
+
+        test_constant_fold!(
+            from_array_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Array(ArrayExpr { array: vec![] }).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_bindata_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Binary(bson::Binary {
+                        bytes: vec![],
+                        subtype: bson::spec::BinarySubtype::Generic,
+                    }))
+                    .into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_boolean_true_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_boolean_false_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_date_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::DateTime(bson::DateTime::now())).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_zero_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str("0.0").unwrap()
+                    ))
+                    .into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_non_zero_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str("1.0").unwrap()
+                    ))
+                    .into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_document_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Document(DocumentExpr {
+                        document: unchecked_unique_linked_hash_map! {},
+                    })
+                    .into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_zero_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(0.0)).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_non_zero_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(1.0)).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_int_zero_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Integer(0)).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_int_non_zero_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Integer(1)).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_javascript_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::JavaScriptCode("".to_string())).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_javascript_with_scope_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::JavaScriptCodeWithScope(
+                        bson::JavaScriptCodeWithScope {
+                            code: "".to_string(),
+                            scope: bson::Document::new(),
+                        }
+                    ))
+                    .into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_zero_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(false))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(0)).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_non_zero_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(1)).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_max_key_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::MaxKey).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_min_key_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::MinKey).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_object_id_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::ObjectId(bson::oid::ObjectId::new()))
+                        .into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_regex_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::RegularExpression(bson::Regex {
+                        pattern: "".to_string(),
+                        options: "".to_string(),
+                    }))
+                    .into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("".to_string())).into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_timestamp_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Boolean(true))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Timestamp(bson::Timestamp {
+                        time: 0,
+                        increment: 0,
+                    }))
+                    .into(),
+                    to: Type::Boolean,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
+
+    // Tests adapted from:
+    // https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#convert-to-integer
+    mod to_int {
+        use super::*;
+
+        test_constant_fold!(
+            from_integer_non_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Reference(("bar", 0u16).into())],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Reference(("bar", 0u16).into()).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+            schema_env = map! {
+                ("bar", 0u16).into() => Schema::Atomic(Atomic::Integer),
+            },
+        );
+
+        test_constant_fold!(
+            from_boolean_false_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(0))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_boolean_true_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(1))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        // In general, for Decimal and Double, $convert truncates. The truncated value must be
+        // within the range of a 32-bit signed integer, otherwise the onError value is returned.
+        test_constant_fold!(
+            from_decimal_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(1))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str("1.2").unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_max_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(i32::MAX))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}.9", i32::MAX).as_str()).unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_min_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(i32::MIN))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}.9", i32::MIN).as_str()).unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_greater_than_max_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}", i32::MAX as i64 + 1i64).as_str())
+                            .unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_less_than_min_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}", i32::MIN as i64 - 1i64).as_str())
+                            .unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(1))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(1.2)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_max_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(i32::MAX))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(i32::MAX as f64 + 0.9)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_min_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(i32::MIN))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(i32::MIN as f64 - 0.9)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_greater_than_max_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(i32::MAX as f64 + 1.0)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_less_than_min_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(i32::MIN as f64 - 1.0)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(5))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(5)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_max_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(i32::MAX))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(i32::MAX as i64)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_min_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(i32::MIN))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(i32::MIN as i64)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_greater_than_max_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(i32::MAX as i64 + 1)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_less_than_min_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(i32::MIN as i64 - 1)).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+        test_constant_fold!(
+            from_string_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(5))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("5".to_string())).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_max_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(i32::MAX))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(i32::MAX.to_string())).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_min_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Integer(i32::MIN))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(i32::MIN.to_string())).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_greater_than_max_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(format!(
+                        "{}",
+                        i32::MAX as i64 + 1i64
+                    )))
+                    .into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_less_than_min_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(format!(
+                        "{}",
+                        i32::MIN as i64 - 1i64
+                    )))
+                    .into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_not_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("5.5".to_string())).into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_not_a_number_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("not a number".to_string()))
+                        .into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
+
+    // Tests adapted from:
+    // https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#convert-to-decimal
+    mod to_decimal {
+        use super::*;
+
+        test_constant_fold!(
+            from_decimal_non_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Reference(("bar", 0u16).into())],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Reference(("bar", 0u16).into()).into(),
+                    to: Type::Decimal128,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+            schema_env = map! {
+                ("bar", 0u16).into() => Schema::Atomic(Atomic::Decimal),
+            },
+        );
+
+        test_constant_fold!(
+            from_boolean_false_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Decimal128(
+                    bson::Decimal128::from_str("0.0").unwrap()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
+                    to: Type::Decimal128,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_boolean_true_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Decimal128(
+                    bson::Decimal128::from_str("1.0").unwrap()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
+                    to: Type::Decimal128,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Decimal128(*DOUBLE_DEC))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(std::f64::consts::PI)).into(),
+                    to: Type::Decimal128,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Decimal128(*INT_DEC))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Integer(3)).into(),
+                    to: Type::Decimal128,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Decimal128(*INT_DEC))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(3)).into(),
+                    to: Type::Decimal128,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_valid_string_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Decimal128(*STRING_DEC))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("3.14159265".into())).into(),
+                    to: Type::Decimal128,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        // A string that cannot be parsed as a Decimal128 statically fails, so the cast
+        // folds to its on_error branch.
+        test_constant_fold!(
+            from_invalid_string_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String("error".into()))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("hello".into())).into(),
+                    to: Type::Decimal128,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".into())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_date_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Decimal128(
+                    bson::Decimal128::from_str("1522039108044").unwrap()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::DateTime(bson::DateTime::from_millis(
+                        1522039108044
+                    )))
+                    .into(),
+                    to: Type::Decimal128,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
+
+    // Tests adapted from:
+    // https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#convert-to-double
+    mod to_double {
+        use super::*;
+
+        test_constant_fold!(
+            from_double_non_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Reference(("bar", 0u16).into())],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Reference(("bar", 0u16).into()).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+            schema_env = map! {
+                ("bar", 0u16).into() => Schema::Atomic(Atomic::Double),
+            },
+        );
+
+        test_constant_fold!(
+            from_boolean_false_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(0.0))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_boolean_true_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(1.0))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(1.2))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str("1.2").unwrap()
+                    ))
+                    .into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_max_f64_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(f64::MAX))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}", f64::MAX).as_str()).unwrap()
+                    ))
+                    .into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_min_f64_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(f64::MIN))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}", f64::MIN).as_str()).unwrap()
+                    ))
+                    .into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_greater_than_max_f64_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}1", f64::MAX).as_str()).unwrap()
+                    ))
+                    .into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_less_than_min_f64_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}1", f64::MIN).as_str()).unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int32,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(5.0))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Integer(5)).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(10000.0))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(10000)).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(-5.5))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("-5.5".to_string())).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_scientific_notation_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(50000000000.0))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("5e10".to_string())).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_invalid_string_not_a_number_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("not a number".to_string()))
+                        .into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_date_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(1522039108044.0))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::DateTime(bson::DateTime::from_millis(
+                        1522039108044
+                    )))
+                    .into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
+
+    // Tests adapted from:
+    // https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#convert-to-long
+    mod to_long {
+        use super::*;
+
+        test_constant_fold!(
+            from_long_non_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Reference(("bar", 0u16).into())],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Reference(("bar", 0u16).into()).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+            schema_env = map! {
+                ("bar", 0u16).into() => Schema::Atomic(Atomic::Integer),
+            },
+        );
+
+        test_constant_fold!(
+            from_boolean_false_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(0))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_boolean_true_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(1))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        // In general, for Decimal and Double, $convert truncates. The truncated value must be
+        // within the range of a 64-bit signed integer, otherwise the onError value is returned.
+        test_constant_fold!(
+            from_decimal_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(1))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str("1.2").unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_max_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(i64::MAX))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}.9", i64::MAX).as_str()).unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_min_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(i64::MIN))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}.9", i64::MIN).as_str()).unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_greater_than_max_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}", i64::MAX as f64 + 1.0).as_str())
+                            .unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_less_than_min_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str(format!("{}", i64::MIN as f64 - 1.0).as_str())
+                            .unwrap()
+                    ))
+                    .into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(1))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(1.2)).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_max_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(i64::MAX))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(i64::MAX as f64 + 0.9)).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_min_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(i64::MIN))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(i64::MIN as f64 - 0.9)).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_greater_than_max_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(i64::MAX as f64 + 1.0)).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_less_than_min_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(i64::MIN as f64 - 1.0)).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(5))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Integer(5)).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(5))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("5".to_string())).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_max_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(i64::MAX))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(i64::MAX.to_string())).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_min_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(i64::MIN))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(i64::MIN.to_string())).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_greater_than_max_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(format!(
+                        "{}",
+                        i64::MAX as f64 + 1.0
+                    )))
+                    .into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_less_than_min_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(format!(
+                        "{}",
+                        i64::MIN as f64 - 1.0
+                    )))
+                    .into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_not_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("5.5".to_string())).into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_not_a_number_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("not a number".to_string()))
+                        .into(),
+                    to: Type::Int64,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_date_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Long(1522039108044))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::DateTime(bson::DateTime::from_millis(
+                        1522039108044
+                    )))
+                    .into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
+
+    // Tests adapted from:
+    // https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#convert-to-date
+    mod to_datetime {
+        use super::*;
+
+        test_constant_fold!(
+            from_datetime_non_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Reference(("bar", 0u16).into())],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Reference(("bar", 0u16).into()).into(),
+                    to: Type::Datetime,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+            schema_env = map! {
+                ("bar", 0u16).into() => Schema::Atomic(Atomic::Date),
+            },
+        );
+
+        test_constant_fold!(
+            from_double_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::DateTime(
+                    bson::DateTime::from_millis(120000000000)
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(120000000000.5)).into(),
+                    to: Type::Datetime,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::DateTime(
+                    bson::DateTime::from_millis(1253372036000)
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str("1253372036000.50").unwrap()
+                    ))
+                    .into(),
+                    to: Type::Datetime,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::DateTime(
+                    bson::DateTime::from_millis(1100000000000)
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(1100000000000)).into(),
+                    to: Type::Datetime,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_with_date_and_time_with_milliseconds,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![
+                    Expression::Literal(LiteralValue::DateTime(*DATE_WITH_MS)),
+                    Expression::Literal(LiteralValue::DateTime(*DATE_WITH_MS)),
+                    Expression::Literal(LiteralValue::DateTime(*DATE_WITH_MS)),
+                ],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![
+                    Expression::Cast(CastExpr {
+                        expr: Expression::Literal(LiteralValue::String(
+                            "2014-01-01T08:15:39.736Z".into()
+                        ))
+                        .into(),
+                        to: Type::Datetime,
+                        on_null: Expression::Literal(LiteralValue::Null).into(),
+                        on_error: Expression::Literal(LiteralValue::Null).into(),
+                        is_nullable: true,
+                    }),
+                    Expression::Cast(CastExpr {
+                        expr: Expression::Literal(LiteralValue::String(
+                            "2014-01-01 08:15:39.736Z".into()
+                        ))
+                        .into(),
+                        to: Type::Datetime,
+                        on_null: Expression::Literal(LiteralValue::Null).into(),
+                        on_error: Expression::Literal(LiteralValue::Null).into(),
+                        is_nullable: true,
+                    }),
+                    Expression::Cast(CastExpr {
+                        expr: Expression::Literal(LiteralValue::String(
+                            "2014-01-01 08:15:39.736".into()
+                        ))
+                        .into(),
+                        to: Type::Datetime,
+                        on_null: Expression::Literal(LiteralValue::Null).into(),
+                        on_error: Expression::Literal(LiteralValue::Null).into(),
+                        is_nullable: true,
+                    }),
+                ],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_with_date_and_time_without_milliseconds,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![
+                    Expression::Literal(LiteralValue::DateTime(*DATE_WITHOUT_MS)),
+                    Expression::Literal(LiteralValue::DateTime(*DATE_WITHOUT_MS)),
+                    Expression::Literal(LiteralValue::DateTime(*DATE_WITHOUT_MS)),
+                ],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![
+                    Expression::Cast(CastExpr {
+                        expr: Expression::Literal(LiteralValue::String(
+                            "2014-01-01T08:15:39Z".into()
+                        ))
+                        .into(),
+                        to: Type::Datetime,
+                        on_null: Expression::Literal(LiteralValue::Null).into(),
+                        on_error: Expression::Literal(LiteralValue::Null).into(),
+                        is_nullable: true,
+                    }),
+                    Expression::Cast(CastExpr {
+                        expr: Expression::Literal(LiteralValue::String(
+                            "2014-01-01 08:15:39Z".into()
+                        ))
+                        .into(),
+                        to: Type::Datetime,
+                        on_null: Expression::Literal(LiteralValue::Null).into(),
+                        on_error: Expression::Literal(LiteralValue::Null).into(),
+                        is_nullable: true,
+                    }),
+                    Expression::Cast(CastExpr {
+                        expr: Expression::Literal(LiteralValue::String(
+                            "2014-01-01 08:15:39".into()
+                        ))
+                        .into(),
+                        to: Type::Datetime,
+                        on_null: Expression::Literal(LiteralValue::Null).into(),
+                        on_error: Expression::Literal(LiteralValue::Null).into(),
+                        is_nullable: true,
+                    }),
+                ],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_with_date_without_time,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::DateTime(
+                    *DATE_WITHOUT_MS
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("2014-01-01".into())).into(),
+                    to: Type::Datetime,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                }),],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        // An unparseable date string cannot be folded and is left as a Cast, to be
+        // evaluated at runtime by MongoDB.
+        test_constant_fold_no_op!(
+            invalid_string_to_date,
+            Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(
+                        "2014-01-56T08:15:39.736Z".into()
+                    ))
+                    .into(),
+                    to: Type::Datetime,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            })
+        );
+
+        test_constant_fold!(
+            from_object_id_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::DateTime(OID.timestamp()))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::ObjectId(*OID)).into(),
+                    to: Type::Datetime,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
+
+    // Tests adapted from:
+    // https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#convert-to-objectid
+    mod to_object_id {
+        use super::*;
+
+        test_constant_fold!(
+            from_object_id_non_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Reference(("bar", 0u16).into())],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Reference(("bar", 0u16).into()).into(),
+                    to: Type::ObjectId,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+            schema_env = map! {
+                ("bar", 0u16).into() => Schema::Atomic(Atomic::ObjectId),
+            },
+        );
+
+        test_constant_fold!(
+            from_valid_string,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::ObjectId(*OID))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(
+                        "507f1f77bcf86cd799439011".into()
+                    ))
+                    .into(),
+                    to: Type::ObjectId,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        // A string that cannot be parsed as an ObjectId statically fails, so the cast
+        // folds to its on_error branch.
+        test_constant_fold!(
+            from_invalid_string,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(
+                        "57f1f77bcf86cd799439011".into()
+                    ))
+                    .into(),
+                    to: Type::ObjectId,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
+
+    // Tests adapted from:
+    // https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#convert-to-string
+    mod to_string {
+        use super::*;
+
+        test_constant_fold!(
+            from_string_non_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Reference(("bar", 0u16).into())],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Reference(("bar", 0u16).into()).into(),
+                    to: Type::String,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+            schema_env = map! {
+                ("bar", 0u16).into() => Schema::Atomic(Atomic::String),
+            },
+        );
+
+        test_constant_fold!(
+            from_boolean_false_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "false".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(false)).into(),
+                    to: Type::String,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_boolean_true_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "true".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Boolean(true)).into(),
+                    to: Type::String,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_date_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    DATE_WITH_MS.to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::DateTime(*DATE_WITH_MS)).into(),
+                    to: Type::String,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_decimal_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String("1.2".to_string()))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Decimal128(
+                        bson::Decimal128::from_str("1.2").unwrap()
+                    ))
+                    .into(),
+                    to: Type::String,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_double_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String("2.5".to_string()))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Double(2.5)).into(),
+                    to: Type::String,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_int_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String("2".to_string()))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Integer(2)).into(),
+                    to: Type::String,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_long_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "1000".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(1000)).into(),
+                    to: Type::String,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_objectid_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "507f1f77bcf86cd799439011".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::ObjectId(*OID)).into(),
+                    to: Type::String,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+    }
 }

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -4451,7 +4451,7 @@ mod cast {
             expected = Stage::Array(ArraySource {
                 alias: "".into(),
                 array: vec![Expression::Literal(LiteralValue::Decimal128(
-                    bson::Decimal128::from_str("0.0").unwrap()
+                    bson::Decimal128::from_str("0").unwrap()
                 ))],
                 cache: SchemaCache::new(),
             }),
@@ -4474,7 +4474,7 @@ mod cast {
             expected = Stage::Array(ArraySource {
                 alias: "".into(),
                 array: vec![Expression::Literal(LiteralValue::Decimal128(
-                    bson::Decimal128::from_str("1.0").unwrap()
+                    bson::Decimal128::from_str("1").unwrap()
                 ))],
                 cache: SchemaCache::new(),
             }),

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -4783,7 +4783,7 @@ mod cast {
                 alias: "".into(),
                 array: vec![Expression::Cast(CastExpr {
                     expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}1", f64::MAX).as_str()).unwrap()
+                        bson::Decimal128::from_str(format!("1{}", f64::MAX).as_str()).unwrap()
                     ))
                     .into(),
                     to: Type::Double,
@@ -4809,10 +4809,13 @@ mod cast {
                 alias: "".into(),
                 array: vec![Expression::Cast(CastExpr {
                     expr: Expression::Literal(LiteralValue::Decimal128(
-                        bson::Decimal128::from_str(format!("{}1", f64::MIN).as_str()).unwrap()
+                        bson::Decimal128::from_str(
+                            format!("{}", f64::MIN).replacen('1', "2", 1).as_str()
+                        )
+                        .unwrap()
                     ))
                     .into(),
-                    to: Type::Int32,
+                    to: Type::Double,
                     on_null: Expression::Literal(LiteralValue::Null).into(),
                     on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
                     is_nullable: true,
@@ -4863,6 +4866,50 @@ mod cast {
             }),
         );
 
+        // MongoDB loses precision when converting from sufficiently large long values to double.
+        test_constant_fold!(
+            from_long_max_i64_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(i64::MAX as f64))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(i64::MAX)).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        // MongoDB loses precision when converting from sufficiently large long values to double.
+        test_constant_fold!(
+            from_long_min_i64_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(i64::MIN as f64))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::Long(i64::MIN)).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
         test_constant_fold!(
             from_string_literal,
             expected = Stage::Array(ArraySource {
@@ -4875,6 +4922,151 @@ mod cast {
                 alias: "".into(),
                 array: vec![Expression::Cast(CastExpr {
                     expr: Expression::Literal(LiteralValue::String("-5.5".to_string())).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_greater_than_max_f64_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(format!("1{}", f64::MAX)))
+                        .into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_less_than_min_f64_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::String(
+                    "error".to_string()
+                ))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String(
+                        format!("{}", f64::MIN).replacen('1', "2", 1)
+                    ))
+                    .into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::String("error".to_string())).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        // f64::NAN does not equal f64::NAN, so we can't use test_constant_fold! conveniently.
+        // Instead, we manually implement this test and assert that the value is folded to a
+        // LiteralValue::Double(f64::NAN).
+        #[test]
+        fn from_string_nan_literal() {
+            use crate::{
+                catalog::Catalog,
+                map,
+                mir::{
+                    optimizer::constant_folding::ConstantFoldingOptimizer,
+                    schema::{SchemaCheckingMode, SchemaInferenceState},
+                },
+                schema::SchemaEnvironment,
+            };
+            let input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("NaN".to_string())).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            });
+
+            let (actual, actual_changed) = ConstantFoldingOptimizer::fold_constants(
+                input,
+                &SchemaInferenceState::new(
+                    0,
+                    SchemaEnvironment::default(),
+                    &Catalog::default(),
+                    map! {},
+                    SchemaCheckingMode::Relaxed,
+                ),
+            );
+            // We should have constant-folded
+            assert!(actual_changed);
+
+            let Stage::Array(ArraySource {
+                alias: _,
+                array,
+                cache: _,
+            }) = actual
+            else {
+                panic!("Expected ArraySource, got {:?}", actual);
+            };
+            let [Expression::Literal(LiteralValue::Double(folded_val))] = array.as_slice() else {
+                panic!("Expected single Literal in array, got {:?}", array);
+            };
+            assert!(folded_val.is_nan());
+        }
+
+        test_constant_fold!(
+            from_string_inf_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(f64::INFINITY))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("inf".to_string())).into(),
+                    to: Type::Double,
+                    on_null: Expression::Literal(LiteralValue::Null).into(),
+                    on_error: Expression::Literal(LiteralValue::Null).into(),
+                    is_nullable: true,
+                })],
+                cache: SchemaCache::new(),
+            }),
+        );
+
+        test_constant_fold!(
+            from_string_neg_inf_literal,
+            expected = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Literal(LiteralValue::Double(f64::NEG_INFINITY))],
+                cache: SchemaCache::new(),
+            }),
+            expected_changed = true,
+            input = Stage::Array(ArraySource {
+                alias: "".into(),
+                array: vec![Expression::Cast(CastExpr {
+                    expr: Expression::Literal(LiteralValue::String("-inf".to_string())).into(),
                     to: Type::Double,
                     on_null: Expression::Literal(LiteralValue::Null).into(),
                     on_error: Expression::Literal(LiteralValue::Null).into(),

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -3826,18 +3826,32 @@ mod cast {
         );
 
         test_constant_fold_cast_literal!(
-            from_string_greater_than_max_f64_literal,
+            from_string_greater_than_max_f64_literal_that_parses_to_inf,
             expected_expr = Expression::Literal(LiteralValue::String("error".into())),
             input_expr = Expression::Literal(LiteralValue::String(format!("1{}", f64::MAX))),
             input_to = Type::Double,
         );
 
         test_constant_fold_cast_literal!(
-            from_string_less_than_min_f64_literal,
+            from_string_greater_than_max_f64_literal_that_parses_to_max_f64,
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String("179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000100000".to_string())),
+            input_to = Type::Double,
+        );
+
+        test_constant_fold_cast_literal!(
+            from_string_less_than_min_f64_literal_that_parses_to_neg_inf,
             expected_expr = Expression::Literal(LiteralValue::String("error".into())),
             input_expr = Expression::Literal(LiteralValue::String(
                 format!("{}", f64::MIN).replacen('1', "2", 1)
             )),
+            input_to = Type::Double,
+        );
+
+        test_constant_fold_cast_literal!(
+            from_string_less_than_min_f64_literal_that_parses_to_min_f64,
+            expected_expr = Expression::Literal(LiteralValue::String("error".into())),
+            input_expr = Expression::Literal(LiteralValue::String("-179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000001000000".to_string())),
             input_to = Type::Double,
         );
 

--- a/testdata/index_usage/filter.yml
+++ b/testdata/index_usage/filter.yml
@@ -129,3 +129,24 @@ dataset:
           bsonType: "array"
           items:
             bsonType: "int"
+
+  - db: "index_usage_filter"
+    collection:
+      name: "dates"
+      docs:
+        - { "_id": 1, "d": { "$date": "2026-06-28T03:05:30Z" } }
+        - { "_id": 2, "d": { "$date": "2025-08-16T05:35:30Z" } }
+        - { "_id": 3, "d": { "$date": "2027-07-01T12:00:00Z" } }
+        - { "_id": 4, "d": { "$date": "2026-07-01T00:00:01Z" } }
+        - { "_id": 5, "d": { "$date": "2026-10-15T12:12:12Z" } }
+      indexes:
+        - { "key": { "d": 1 } }
+    schema:
+      bsonType: "object"
+      required: [ "_id", "d" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        d:
+          bsonType: "date"

--- a/tests/index_usage_tests/filter.yml
+++ b/tests/index_usage_tests/filter.yml
@@ -259,3 +259,8 @@ tests:
     current_db: index_usage_filter
     query: "SELECT * FROM nullable_fields WHERE b IN (SELECT b FROM non_nullable_fields WHERE a < 300)"
     expected_utilization: COLL_SCAN
+
+  - description: CAST literal date using Tableau Date format to datetime uses index
+    current_db: index_usage_filter
+    query: "SELECT * FROM dates WHERE d >= CAST('2026-07-01' AS BSON_DATE)"
+    expected_utilization: IX_SCAN


### PR DESCRIPTION
This PR updates the `constant_folding` optimization to support more constant folding of `CAST` expressions with literal input arguments.

Apologies that the PR turned out so big -- it is primarily testing that led to so many line changes. The tests are (loosely) adapted from MongoDB docs ([link](https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/)) so you have a more easily readable source of truth available when reviewing.

The main motivation for this ticket came from the linked [HELP ticket](https://jira.mongodb.org/browse/HELP-95941) which revealed users of the Tableau driver who attempt to use `Date` literals ended up with expressions like `CAST('2026-07-22' AS TIMESTAMP)` in their queries. Until SQL-3311 was implemented (#174), most `CAST` expressions with literal inputs were not constant folded until desugaring time which definitively prevented index utilization when such expressions appeared in filters. To enable this type of expression to utilize an index when used in a filter, we need to constant fold it to a literal value _before_ translating from `mir` to `air` since that is when we determine semantics (SQL vs MQL). (By default, a `CAST` expression without `ON NULL` and `ON ERROR` specified is considered nullable since those two branches return `null` for their respective cases. Positive nullability of what is effectively a non-null literal prevents the happy path for translation to MQL-semantic comparison operations, which are typically index-eligible.)

As a follow-up to SQL-3311 (#174), this PR expands constant folding to support converting date-formatted strings that use our Tableau connector's prescribed format ([link](https://github.com/mongodb/mongo-tableau-connector/blob/91baa895c6355bff5a6220925b9c1755245226e3/connector/dialect.tdd#L1271)) into datetime literals. Additionally, this PR expands constant folding for most other valid target types as well. The full list of new supported constant folding `CAST` conversions is:
- `array`, `bindata`, `boolean`, `date`, `decimal`, `document`, `double`, `int`, `javascript`, `javascript_with_scope`, `long`, `max_key`, `min_key`, `object_id`, `regex`, `string`, and `timestamp` literals to boolean
- `boolean`, `decimal`, `double`, `int`, `long`, and `string` literals to int
- `boolean`, `decimal`, `double`, `int`, `long`, `string`, and `date` literals to decimal128
- `boolean`, `decimal`, `double`, `int`, `long`, `string`, and `date` literals to double
- `boolean`, `decimal`, `double`, `int`, `long`, `string`, and `date` literals to long
- `string` and `object_id` literals to object_id
- `decimal`, `double`, `long`, `string`, `date`, and `object_id` literals to date
- `boolean`, `date`, `decimal`, `double`, `int`, `long`, and `object_id` literals to string