### PR TITLE
SQL-3295: Implement HigherOrderFunctionRewritePass stub

### DIFF
--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -1,0 +1,29 @@
+use crate::ast::{
+    self,
+    rewrites::{Pass, Result},
+    visitor::Visitor,
+};
+
+pub struct HigherOrderFunctionsRewritePass;
+
+impl Pass for HigherOrderFunctionsRewritePass {
+    fn apply(&self, query: ast::Query) -> Result<ast::Query> {
+        let mut func_alias_visitor = HigherOrderFunctionsAliasVisitor;
+        let query = query.walk(&mut func_alias_visitor);
+
+        let mut func_arg_visitor = FunctionArgumentVisitor;
+        let query = query.walk(&mut func_arg_visitor);
+
+        Ok(query)
+    }
+}
+
+struct HigherOrderFunctionsAliasVisitor;
+
+// SQL-3297: Implement HigherOrderFunctionsAliasVisitor
+impl Visitor for HigherOrderFunctionsAliasVisitor {}
+
+struct FunctionArgumentVisitor;
+
+// SQL-3296: Implement FunctionArgumentVisitor
+impl Visitor for FunctionArgumentVisitor {}

--- a/mongosql/src/ast/rewrites/mod.rs
+++ b/mongosql/src/ast/rewrites/mod.rs
@@ -27,9 +27,12 @@ mod scalar_functions;
 use scalar_functions::ScalarFunctionsRewritePass;
 mod with_query;
 pub use with_query::WithQueryRewritePass;
+mod higher_order_functions;
+pub use higher_order_functions::HigherOrderFunctionsRewritePass;
 
 #[cfg(test)]
 mod test;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors that can occur during rewrite passes
@@ -84,6 +87,7 @@ pub fn rewrite_query(query: ast::Query) -> Result<ast::Query> {
         &TableSubqueryRewritePass,
         &OptionalParameterRewritePass,
         &NotComparisonRewritePass,
+        &HigherOrderFunctionsRewritePass,
         &ScalarFunctionsRewritePass,
         // WithQueryRewritePass can introduce duplicated queries, so it should be the last pass so
         // any rewrites that apply in the WithQuery queries are applied only once.


### PR DESCRIPTION
This PR introduces the `HigherOrderFunctionRewritePass` with a stub implementation. The stub creates and invokes the two visitors that will be implemented in follow-up tickets ([SQL-3296](https://jira.mongodb.org/browse/SQL-3296) and SQL-[3297](https://jira.mongodb.org/browse/SQL-3297)). This new rewrite pass is already included in the rewrites list in the correct location, as described by the [design doc](https://docs.google.com/document/d/15bcFJ1wH6BcQYem7slPP8eG142BSvmjY3UuTNve8r7I/edit?tab=t.0#heading=h.he6cyip700kh). Since the visitors do nothing right now, the pass is effectively a no-op.