### PR TITLE
DEVPROD-34208: pull Silkbomb and Garasign images from ECR

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -705,6 +705,21 @@ functions:
           echo "---------------------------------------------"
           echo "<<<< Done scanning SBOM"
 
+  "authenticate with devprod platforms ecr":
+    - command: ec2.assume_role
+      display_name: Assume DevProd Platforms ECR readonly IAM role
+      params:
+        role_arn: ${devprod_platforms_ecr_readonly_role_arn}
+    - command: shell.exec
+      display_name: Log in to DevProd Platforms ECR
+      params:
+        silent: true
+        shell: bash
+        include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
+        script: |
+          set -o errexit
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
+
   "augment SBOM":
     - command: ec2.assume_role
       display_name: Assume IAM role with permissions to pull Kondukto API token
@@ -739,7 +754,7 @@ functions:
           echo "-- Augmenting SBOM Lite --"
           docker run -i --platform="linux/amd64" --rm -v "$PWD":/pwd \
           --env-file ${workdir}/kondukto_credentials.env \
-          artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:2.0 \
+          901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
           augment --repo mongodb/mongosql --branch ${branch_name} --sbom-in /pwd/$SBOM_FINAL --sbom-out /pwd/${project_folder}.augmented.sbom.json --force
           echo "-------------------------------"
     - *assume_role_cmd

--- a/evergreen/mongosqltranslate.yml
+++ b/evergreen/mongosqltranslate.yml
@@ -178,13 +178,6 @@ functions:
         local_file: mongosql-rs/mongosqltranslate.dll
     - command: shell.exec
       type: system
-      retry_on_failure: true
-      params:
-        silent: true
-        script: |
-          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
-    - command: shell.exec
-      type: system
       params:
         silent: true
         env:
@@ -219,13 +212,6 @@ functions:
         <<: *evg_bucket_config
         remote_file: mongosql-rs/artifacts/${version_id}/${build_variant}/libmongosqltranslate.so
         local_file: mongosql-rs/libmongosqltranslate.so
-    - command: shell.exec
-      type: system
-      retry_on_failure: true
-      params:
-        silent: true
-        script: |
-          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
     - command: shell.exec
       type: system
       params:
@@ -408,6 +394,7 @@ tasks:
       - func: "scan SBOM"
         vars:
           project_folder: "mongosqltranslate"
+      - func: "authenticate with devprod platforms ecr"
       - func: "augment SBOM"
         vars:
           project_folder: "mongosqltranslate"
@@ -421,6 +408,13 @@ tasks:
     depends_on:
       - name: compile-mongosqltranslate
     commands:
+      - func: "authenticate with devprod platforms ecr"
+        variants:
+          [
+            mongosqltranslate-windows-64,
+            mongosqltranslate-linux-x86_64,
+            mongosqltranslate-linux-arm64,
+          ]
       - func: "sign mongosqltranslate windows"
         retry_on_failure: true
         variants: [mongosqltranslate-windows-64]

--- a/evergreen/schema-builder-library.yml
+++ b/evergreen/schema-builder-library.yml
@@ -54,13 +54,6 @@ functions:
         local_file: mongosql-rs/schema-builder-library.tgz
     - command: shell.exec
       type: system
-      retry_on_failure: true
-      params:
-        silent: true
-        script: |
-          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
-    - command: shell.exec
-      type: system
       params:
         silent: true
         env:
@@ -145,6 +138,7 @@ tasks:
     depends_on:
       - name: compile-schema-builder-library
     commands:
+      - func: "authenticate with devprod platforms ecr"
       - func: "sign schema-builder-library"
         retry_on_failure: true
 
@@ -168,6 +162,7 @@ tasks:
       - func: "scan SBOM"
         vars:
           project_folder: "schema-builder-library"
+      - func: "authenticate with devprod platforms ecr"
       - func: "augment SBOM"
         vars:
           project_folder: "schema-builder-library"


### PR DESCRIPTION
MongoDB Artifactory will be deprecated soon, so I am updating the source of the DevProd container images to ECR.

Test Patch: https://spruce.corp.mongodb.com/version/6a638bd875751600076be159/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

```
evergreen patch -p mongosql \
  -y -f --browse -u \
  -v schema-builder-library-code-quality-security,schema-builder-library,mongosqltranslate-code-quality-security,mongosqltranslate-windows-64,mongosqltranslate-linux-x86_64 \
  -t schema-builder-library-sbom,sign-schema-builder-library,mongosqltranslate-sbom,sign-mongosqltranslate \
  -d "Test DevProd Platforms ECR migration (silkbomb + garasign)" \
  --param garasign_gpg_image=901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-gpg \
  --param garasign_jsign_image=901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-jsign
```

> [!IMPORTANT]  
> The `garasign_gpg_image ` and `garasign_jsign_image` project variables must be updated to the values above before merging this pull request.