### PR TITLE
SQL-3293: Refactor algebrizer to pass expression context via self instead of algebrize_* method api

### DIFF
--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -17,7 +17,7 @@ use crate::{
     util::unique_linked_hash_map::UniqueLinkedHashMap,
     SchemaCheckingMode,
 };
-use std::{cell::RefCell, collections::BTreeSet};
+use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -231,17 +231,21 @@ impl std::fmt::Display for ClauseType {
 #[derive(Debug, Clone)]
 pub struct Algebrizer<'a> {
     current_db: &'a str,
-    pub schema_env: SchemaEnvironment,
+    pub schema_env: Rc<SchemaEnvironment>,
     catalog: &'a Catalog,
     scope_level: u16,
     schema_checking_mode: SchemaCheckingMode,
     allow_order_by_missing_columns: bool,
     clause_type: RefCell<ClauseType>,
+    expression_context: ExpressionContext,
 }
 
+/// ExpressionContext contains information about the context in which an expression is being
+/// algebrized. In certain contexts, certain ast::Expressions are resolved differently. See fields
+/// for more information.
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct ExpressionContext {
-    // Indicates if the expression is being algebrized is in an implicit type conversion context.
+    // Indicates if the expression is being algebrized in an implicit type conversion context.
     // An expression is "in an implicit type conversion context" whenever it appears in a place
     // where a string is unexpected. For example, the operands of a numeric operator like + are
     // unexpected to be strings. MongoSQL supports implicit type conversion from extended-JSON
@@ -250,9 +254,9 @@ pub(crate) struct ExpressionContext {
 }
 
 impl ExpressionContext {
-    pub(crate) fn with_implicit_type_conversion_ctx(self) -> Self {
+    pub(crate) fn with_implicit_type_conversion_ctx(self, value: bool) -> Self {
         Self {
-            in_implicit_type_conversion_ctx: true,
+            in_implicit_type_conversion_ctx: value,
             ..self
         }
     }
@@ -275,6 +279,7 @@ impl<'a> Algebrizer<'a> {
             schema_checking_mode,
             allow_order_by_missing_columns,
             clause_type,
+            ExpressionContext::default(),
         )
     }
 
@@ -286,21 +291,23 @@ impl<'a> Algebrizer<'a> {
         schema_checking_mode: SchemaCheckingMode,
         allow_order_by_missing_columns: bool,
         clause_type: ClauseType,
+        expression_context: ExpressionContext,
     ) -> Self {
         Self {
             current_db,
-            schema_env,
+            schema_env: Rc::new(schema_env),
             catalog,
             scope_level,
             schema_checking_mode,
             allow_order_by_missing_columns,
             clause_type: RefCell::new(clause_type),
+            expression_context,
         }
     }
 
     pub fn schema_inference_state(&self) -> SchemaInferenceState<'_> {
         SchemaInferenceState {
-            env: self.schema_env.clone(),
+            env: (*self.schema_env).clone(),
             catalog: self.catalog,
             scope_level: self.scope_level,
             schema_checking_mode: self.schema_checking_mode,
@@ -315,12 +322,33 @@ impl<'a> Algebrizer<'a> {
             catalog: self.catalog,
             scope_level: self.scope_level + 1,
             schema_checking_mode: self.schema_checking_mode,
+            allow_order_by_missing_columns: self.allow_order_by_missing_columns,
             // subquery should use a copy of the current ClauseType, not share a RefCell with the
             // parent. It probably does not matter, but we do not want subqueries to modify parent
             // state.
+            clause_type: RefCell::new(*self.clause_type.borrow()),
+            expression_context: self.expression_context,
+        }
+    }
+
+    pub(crate) fn with_expression_context(&self, context: ExpressionContext) -> Self {
+        Self {
+            current_db: self.current_db,
+            schema_env: self.schema_env.clone(),
+            catalog: self.catalog,
+            scope_level: self.scope_level,
+            schema_checking_mode: self.schema_checking_mode,
             allow_order_by_missing_columns: self.allow_order_by_missing_columns,
             clause_type: RefCell::new(*self.clause_type.borrow()),
+            expression_context: context,
         }
+    }
+
+    fn with_implicit_type_conversion_ctx(&self, value: bool) -> Self {
+        self.with_expression_context(
+            self.expression_context
+                .with_implicit_type_conversion_ctx(value),
+        )
     }
 
     fn args_are_nullable(args: &[mir::Expression]) -> bool {
@@ -334,8 +362,8 @@ impl<'a> Algebrizer<'a> {
         if matches!(func, mir::ScalarFunction::In | mir::ScalarFunction::NotIn) {
             Self::determine_in_expression_nullability(args)
         } else {
-            // some functions can always be nullable regardless of argument nullablity,
-            // we check those first. If this function is not one of those, we set nullablity
+            // some functions can always be nullable regardless of argument nullability,
+            // we check those first. If this function is not one of those, we set nullability
             // based off the arguments.
             func.is_always_nullable() || Self::args_are_nullable(args)
         }
@@ -365,11 +393,16 @@ impl<'a> Algebrizer<'a> {
         }
     }
 
-    fn with_merged_mappings(mut self, mappings: SchemaEnvironment) -> Result<Self> {
-        self.schema_env
+    fn with_merged_mappings(&self, mappings: SchemaEnvironment) -> Result<Self> {
+        let mut merged_env = (*self.schema_env).clone();
+        merged_env
             .merge(mappings)
             .map_err(|e| Error::DuplicateKey(e.key))?;
-        Ok(self)
+        Ok(Self {
+            schema_env: Rc::new(merged_env),
+            clause_type: RefCell::new(*self.clause_type.borrow()),
+            ..*self
+        })
     }
 
     pub fn construct_field_access_expr(
@@ -490,14 +523,15 @@ impl<'a> Algebrizer<'a> {
         is_add_fields: bool,
         is_distinct: bool,
     ) -> Result<mir::Stage> {
-        let expression_algebrizer = self.clone();
         // Algebrization for every node that has a source should get the schema for the source.
         // The SchemaEnvironment from the source is merged into the SchemaEnvironment from the
         // current Algebrizer, correctly giving us the correlated bindings with the bindings
         // available from the current query level.
-        #[allow(unused_variables)]
-        let expression_algebrizer = expression_algebrizer
-            .with_merged_mappings(source.schema(&self.schema_inference_state())?.schema_env)?;
+        let expression_algebrizer = self
+            .with_merged_mappings(source.schema(&self.schema_inference_state())?.schema_env)?
+            // We should not algebrize the select values body exprs in an implicit type conversion
+            // context since there is no sepcific type expected for these values.
+            .with_implicit_type_conversion_ctx(false);
 
         // We must check for duplicate Datasource Keys, which is an error. The datasources
         // Set keeps track of which Keys have been seen.
@@ -524,8 +558,7 @@ impl<'a> Algebrizer<'a> {
                     // for now, and depending on the rest of the select query, a DuplicateKey or SchemaChecking
                     // error will occur downstream.
                     _ => {
-                        let e = expression_algebrizer
-                            .algebrize_expression(e, ExpressionContext::default())?;
+                        let e = expression_algebrizer.algebrize_expression(e)?;
                         let bot = Key::bot(expression_algebrizer.scope_level);
                         datasources
                             .insert(bot.clone())
@@ -570,10 +603,8 @@ impl<'a> Algebrizer<'a> {
         // if we found Expressions's, algebrize them as a single document, and add it to the expression
         // under the Bottom namespace.
         if let Some(bottom) = bottom {
-            let e = expression_algebrizer.algebrize_expression(
-                ast::Expression::Document(bottom),
-                ExpressionContext::default(),
-            )?;
+            let e =
+                expression_algebrizer.algebrize_expression(ast::Expression::Document(bottom))?;
             let bot = Key::bot(expression_algebrizer.scope_level);
             datasources
                 .insert(bot.clone())
@@ -681,10 +712,13 @@ impl<'a> Algebrizer<'a> {
         if !array_is_literal {
             return Err(Error::ArrayDatasourceMustBeLiteral);
         }
+        // We should not algebrize the array element exprs in an implicit type conversion context
+        // since there is no sepcific type expected for these values.
+        let element_algebrizer = self.with_implicit_type_conversion_ctx(false);
         let src = mir::Stage::Array(mir::ArraySource {
             array: ve
                 .into_iter()
-                .map(|e| self.algebrize_expression(e, ExpressionContext::default()))
+                .map(|e| element_algebrizer.algebrize_expression(e))
                 .collect::<Result<_>>()?,
             alias,
             cache: SchemaCache::new(),
@@ -734,18 +768,28 @@ impl<'a> Algebrizer<'a> {
         let right_src = self.algebrize_datasource(*j.right)?;
         let left_src_result_set = left_src.schema(&self.schema_inference_state())?;
         let right_src_result_set = right_src.schema(&self.schema_inference_state())?;
-        let join_algebrizer = self
+        let condition_algebrizer = self
             .clone()
             .with_merged_mappings(left_src_result_set.schema_env)?
-            .with_merged_mappings(right_src_result_set.schema_env)?;
+            .with_merged_mappings(right_src_result_set.schema_env)?
+            // Although the condition expression is expected to Boolean (or nullish), we choose not
+            // to algebrize it in an implicit type conversion context. We do this because we do not
+            // want to confuse users with seemingly inconsistent behavior. For example, if the user
+            // wrote `... FROM foo JOIN bar ON 'false'` and we implicitly converted the `'false'` to
+            // `fasle`, the join condition would fail for all rows. But if they wrote `... FROM foo
+            // JOIN bar ON 'false'::BOOL`, the `CAST` would convert the `'false'` to `true`! And the
+            // join condition would succeed for all rows! This is because in MongoDB, any String
+            // unconditionally converts to true when casting to a Boolean. Given that potential for
+            // "inconsistency", we choose not to implicitly convert the condition expression.
+            .with_implicit_type_conversion_ctx(false);
         let condition = j
             .condition
-            .map(|e| join_algebrizer.algebrize_expression(e, ExpressionContext::default()))
+            .map(|e| condition_algebrizer.algebrize_expression(e))
             .transpose()?
             .map(Self::convert_literal_to_bool);
         condition
             .clone()
-            .map(|e| e.schema(&join_algebrizer.schema_inference_state()));
+            .map(|e| e.schema(&condition_algebrizer.schema_inference_state()));
         let stage = match j.join_type {
             ast::JoinType::Left => {
                 if condition.is_none() {
@@ -975,6 +1019,7 @@ impl<'a> Algebrizer<'a> {
             self.schema_checking_mode,
             self.allow_order_by_missing_columns,
             *self.clause_type.borrow(),
+            self.expression_context,
         );
 
         let path = match path {
@@ -1006,7 +1051,7 @@ impl<'a> Algebrizer<'a> {
     /// expression which consists of only other FieldAccess expressions up the
     /// chain of exprs until it hits a Reference expression.
     fn algebrize_unwind_path(&self, path: ast::Expression) -> Result<mir::FieldPath> {
-        let path = self.algebrize_expression(path, ExpressionContext::default())?;
+        let path = self.algebrize_expression(path)?;
         (&path).try_into().map_err(|_| Error::InvalidUnwindPath)
     }
 
@@ -1062,13 +1107,26 @@ impl<'a> Algebrizer<'a> {
         let filtered = match ast_node {
             None => source,
             Some(expr) => {
-                let expression_algebrizer = self.clone().with_merged_mappings(
-                    source.schema(&self.schema_inference_state())?.schema_env,
-                )?;
+                let expression_algebrizer = self
+                    .clone()
+                    .with_merged_mappings(
+                        source.schema(&self.schema_inference_state())?.schema_env,
+                    )?
+                    // Although the condition expression is expected to Boolean (or nullish), we
+                    // choose not to algebrize it in an implicit type conversion context. We do this
+                    // because we do not want to confuse users with seemingly inconsistent behavior.
+                    // For example, if the user wrote `... FROM foo WHERE 'false'` and we implicitly
+                    // converted the `'false'` to `fasle`, the filter would fail for all rows. But
+                    // if they wrote `... FROM foo WHERE 'false'::BOOL`, the `CAST` would convert
+                    // the `'false'` to `true`, and the filter would succeed for all rows! This is
+                    // because in MongoDB, any String unconditionally converts to true when casting
+                    // to a Boolean. Given that potential for "inconsistency", we choose not to
+                    // implicitly convert the condition expression.
+                    .with_implicit_type_conversion_ctx(false);
                 mir::Stage::Filter(mir::Filter {
                     source: Box::new(source),
                     condition: expression_algebrizer
-                        .algebrize_expression(expr, ExpressionContext::default())
+                        .algebrize_expression(expr)
                         .map(Self::convert_literal_to_bool)?,
                     cache: SchemaCache::new(),
                 })
@@ -1230,7 +1288,10 @@ impl<'a> Algebrizer<'a> {
         *self.clause_type.borrow_mut() = ClauseType::OrderBy;
         let expression_algebrizer = self
             .clone()
-            .with_merged_mappings(source.schema(&self.schema_inference_state())?.schema_env)?;
+            .with_merged_mappings(source.schema(&self.schema_inference_state())?.schema_env)?
+            // We should not algebrize the sort key exprs in an implicit type conversion
+            // context since there is no sepcific type expected for these values.
+            .with_implicit_type_conversion_ctx(false);
         let ordered = match ast_node {
             None => source,
             Some(o) => {
@@ -1239,8 +1300,9 @@ impl<'a> Algebrizer<'a> {
                     .into_iter()
                     .map(|s| {
                         let sort_key = match s.key {
-                            ast::SortKey::Simple(expr) => expression_algebrizer
-                                .algebrize_expression(expr, ExpressionContext::default()),
+                            ast::SortKey::Simple(expr) => {
+                                expression_algebrizer.algebrize_expression(expr)
+                            }
                             ast::SortKey::Positional(_) => panic!(
                                 "positional sort keys should have been rewritten to references"
                             ),
@@ -1281,9 +1343,14 @@ impl<'a> Algebrizer<'a> {
         let grouped = match ast_node {
             None => source,
             Some(ast_expr) => {
-                let expression_algebrizer = self.clone().with_merged_mappings(
-                    source.schema(&self.schema_inference_state())?.schema_env,
-                )?;
+                let expression_algebrizer = self
+                    .clone()
+                    .with_merged_mappings(
+                        source.schema(&self.schema_inference_state())?.schema_env,
+                    )?
+                    // We should not algebrize the group key exprs in an implicit type conversion
+                    // context since there is no sepcific type expected for these values.
+                    .with_implicit_type_conversion_ctx(false);
 
                 let mut group_clause_aliases = UniqueLinkedHashMap::new();
                 let keys = ast_expr
@@ -1296,14 +1363,11 @@ impl<'a> Algebrizer<'a> {
                                 .map_err(|e| Error::DuplicateDocumentKey(e.get_key_name()))?;
                             Ok(mir::OptionallyAliasedExpr::Aliased(mir::AliasedExpr {
                                 alias: ast_key.alias,
-                                expr: expression_algebrizer.algebrize_expression(
-                                    ast_key.expr,
-                                    ExpressionContext::default(),
-                                )?,
+                                expr: expression_algebrizer.algebrize_expression(ast_key.expr)?,
                             }))
                         }
                         ast::OptionallyAliasedExpr::Unaliased(expr) => expression_algebrizer
-                            .algebrize_expression(expr, ExpressionContext::default())
+                            .algebrize_expression(expr)
                             .map(mir::OptionallyAliasedExpr::Unaliased),
                     })
                     .collect::<Result<_>>()?;
@@ -1362,7 +1426,7 @@ impl<'a> Algebrizer<'a> {
                 let arg = if ve.len() != 1 {
                     return Err(Error::AggregationFunctionMustHaveOneArgument);
                 } else {
-                    self.algebrize_expression(ve[0].clone(), ExpressionContext::default())?
+                    self.algebrize_expression(ve[0].clone())?
                 };
                 mir::AggregationExpr::Function(mir::AggregationFunctionApplication {
                     function: mir::AggregationFunction::try_from(function)?,
@@ -1378,31 +1442,23 @@ impl<'a> Algebrizer<'a> {
         Ok(mir_node)
     }
 
-    pub fn algebrize_expression(
-        &self,
-        ast_node: ast::Expression,
-        context: ExpressionContext,
-    ) -> Result<mir::Expression> {
+    /// Algebrizes an `ast::Expression` node into a `mir::Expression` node. Callers must ensure
+    /// that the `Algeberizer`'s `expression_context` is set correctly for the given context of the
+    /// `ast_node` being algebrized.
+    pub fn algebrize_expression(&self, ast_node: ast::Expression) -> Result<mir::Expression> {
         match ast_node {
             ast::Expression::Literal(l) => Ok(mir::Expression::Literal(self.algebrize_literal(l))),
-            ast::Expression::StringConstructor(s) => {
-                Ok(self.algebrize_string_constructor(s, context.in_implicit_type_conversion_ctx))
-            }
+            ast::Expression::StringConstructor(s) => Ok(self.algebrize_string_constructor(s)),
             ast::Expression::Array(a) => Ok(mir::Expression::Array(
                 a.into_iter()
-                    .map(|e| self.algebrize_expression(e, ExpressionContext::default()))
+                    .map(|e| self.algebrize_expression(e))
                     .collect::<Result<Vec<mir::Expression>>>()?
                     .into(),
             )),
             ast::Expression::Document(d) => Ok(mir::Expression::Document({
                 let algebrized = d
                     .into_iter()
-                    .map(|kv| {
-                        Ok((
-                            kv.key,
-                            self.algebrize_expression(kv.value, ExpressionContext::default())?,
-                        ))
-                    })
+                    .map(|kv| Ok((kv.key, self.algebrize_expression(kv.value)?)))
                     .collect::<Result<Vec<_>>>()?;
                 let mut out = UniqueLinkedHashMap::new();
                 out.insert_many(algebrized.into_iter())
@@ -1411,7 +1467,7 @@ impl<'a> Algebrizer<'a> {
             })),
             // If we ever see Identifier in algebrize_expression it must be an unqualified
             // reference, because we do not recurse on the expr field of Subpath if it is an
-            // Identifier
+            // Identifier. It may also be a Variable, which is determined by the ExpressionContext.
             ast::Expression::Identifier(i) => self.algebrize_unqualified_identifier(i),
             ast::Expression::Subpath(s) => self.algebrize_subpath(s),
             ast::Expression::Unary(u) => self.algebrize_unary_expr(u),
@@ -1429,11 +1485,7 @@ impl<'a> Algebrizer<'a> {
             ast::Expression::Like(l) => self.algebrize_like(l),
             ast::Expression::Tuple(a) => Ok(mir::Expression::Array(
                 a.into_iter()
-                    // Passes the context to each element so that algebrize_in_operands can
-                    // drive implicit type conversion (ITC) for all-StringConstructor Tuples
-                    // via its (false, true) arm. Reverting this to hardcode `false` would
-                    // silently break ITC for `field IN ('{"$date":"..."}', ...)`.
-                    .map(|e| self.algebrize_expression(e, context))
+                    .map(|e| self.algebrize_expression(e))
                     .collect::<Result<Vec<mir::Expression>>>()?
                     .into(),
             )),
@@ -1454,13 +1506,9 @@ impl<'a> Algebrizer<'a> {
         }
     }
 
-    pub fn algebrize_string_constructor(
-        &self,
-        s: String,
-        in_implicit_type_conversion_context: bool,
-    ) -> mir::Expression {
+    pub fn algebrize_string_constructor(&self, s: String) -> mir::Expression {
         // treat the string as a literal if we are not in a context where we want to implicitly cast
-        if !in_implicit_type_conversion_context {
+        if !self.expression_context.in_implicit_type_conversion_ctx {
             return mir::Expression::Literal(mir::LiteralValue::String(s));
         }
 
@@ -1522,7 +1570,8 @@ impl<'a> Algebrizer<'a> {
         &self,
         non_literal: ast::Expression,
     ) -> Result<(mir::Expression, bool)> {
-        let non_literal = self.algebrize_expression(non_literal, ExpressionContext::default())?;
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(false);
+        let non_literal = expr_algebrizer.algebrize_expression(non_literal)?;
         let non_literal_schema = non_literal.schema(&self.schema_inference_state())?;
         let is_nullable_string =
             non_literal_schema.satisfies(&STRING_OR_NULLISH) == Satisfaction::Must;
@@ -1548,10 +1597,8 @@ impl<'a> Algebrizer<'a> {
 
         // Again, if is_nullable_string is true, that means we _do_ expect the StringConstructor
         // to be a String value, so we set in_implicit_type_conversion_ctx to false.
-        let context = ExpressionContext {
-            in_implicit_type_conversion_ctx: !is_nullable_string,
-        };
-        let literal = self.algebrize_expression(literal, context)?;
+        let literal_algebrizer = self.with_implicit_type_conversion_ctx(!is_nullable_string);
+        let literal = literal_algebrizer.algebrize_expression(literal)?;
 
         Ok((literal, non_literal))
     }
@@ -1570,13 +1617,14 @@ impl<'a> Algebrizer<'a> {
         left: ast::Expression,
         right: ast::Expression,
     ) -> Result<(mir::Expression, mir::Expression)> {
+        let non_itc_algebrizer = self.with_implicit_type_conversion_ctx(false);
         match (left, right) {
             (
                 l @ ast::Expression::StringConstructor(_),
                 r @ ast::Expression::StringConstructor(_),
             ) => Ok((
-                self.algebrize_expression(l, ExpressionContext::default())?,
-                self.algebrize_expression(r, ExpressionContext::default())?,
+                non_itc_algebrizer.algebrize_expression(l)?,
+                non_itc_algebrizer.algebrize_expression(r)?,
             )),
             (literal @ ast::Expression::StringConstructor(_), non_literal) => {
                 let (literal, non_literal) =
@@ -1589,8 +1637,8 @@ impl<'a> Algebrizer<'a> {
                 Ok((non_literal, literal))
             }
             (l, r) => Ok((
-                self.algebrize_expression(l, ExpressionContext::default())?,
-                self.algebrize_expression(r, ExpressionContext::default())?,
+                non_itc_algebrizer.algebrize_expression(l)?,
+                non_itc_algebrizer.algebrize_expression(r)?,
             )),
         }
     }
@@ -1613,6 +1661,9 @@ impl<'a> Algebrizer<'a> {
         left: ast::Expression,
         right: ast::Expression,
     ) -> Result<(mir::Expression, mir::Expression)> {
+        let itc_algebrizer = self.with_implicit_type_conversion_ctx(true);
+        let non_itc_algebrizer = self.with_implicit_type_conversion_ctx(false);
+
         // 1. Check if all the elements of the right expression are StringConstructors.
         let are_any_array_elements_string_constructors = match &right {
             ast::Expression::Tuple(arr) => arr
@@ -1629,8 +1680,8 @@ impl<'a> Algebrizer<'a> {
         ) {
             // Both sides are string constructors, or neither is — no conversion needed.
             (true, true) | (false, false) => Ok((
-                self.algebrize_expression(left, ExpressionContext::default())?,
-                self.algebrize_expression(right, ExpressionContext::default())?,
+                non_itc_algebrizer.algebrize_expression(left)?,
+                non_itc_algebrizer.algebrize_expression(right)?,
             )),
             // LHS is a StringConstructor; RHS Tuple does not have any string constructors among its
             // elements
@@ -1638,33 +1689,22 @@ impl<'a> Algebrizer<'a> {
                 Ok((
                     // Because the left is a StringConstructor, we algebrize with ITC to convert it
                     // to the right value
-                    self.algebrize_expression(
-                        left,
-                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                    )?,
+                    itc_algebrizer.algebrize_expression(left)?,
                     // Because none of the elements in the RHS are StringConstructors, we can safely
                     // algebrize the entire RHS with in_implicit_type_conversion_ctx set to false.
-                    self.algebrize_expression(right, ExpressionContext::default())?,
+                    non_itc_algebrizer.algebrize_expression(right)?,
                 ))
             }
             // LHS is not a string constructor, RHS has some elements that StringConstructors
             // We algebrize the LHS with in_implicit_context false, and then algebrize each element
-            // in the RHS.
+            // in the RHS in an ITC context.
             (false, true) => {
                 let rhs_algebrized_per_element = match right {
                     ast::Expression::Tuple(elements) => {
                         let mut algebrized_elements = Vec::new();
                         for element in elements {
-                            let algebrized_element = match element {
-                                ast::Expression::StringConstructor(_) => self
-                                    .algebrize_expression(
-                                        element,
-                                        ExpressionContext::default()
-                                            .with_implicit_type_conversion_ctx(),
-                                    )?,
-                                _ => self
-                                    .algebrize_expression(element, ExpressionContext::default())?,
-                            };
+                            let algebrized_element =
+                                itc_algebrizer.algebrize_expression(element)?;
 
                             algebrized_elements.push(algebrized_element);
                         }
@@ -1674,7 +1714,7 @@ impl<'a> Algebrizer<'a> {
                 };
 
                 Ok((
-                    self.algebrize_expression(left, ExpressionContext::default())?,
+                    non_itc_algebrizer.algebrize_expression(left)?,
                     mir::Expression::Array(ArrayExpr {
                         array: rhs_algebrized_per_element,
                     }),
@@ -1687,6 +1727,12 @@ impl<'a> Algebrizer<'a> {
         if f.set_quantifier == Some(ast::SetQuantifier::Distinct) {
             return Err(Error::DistinctScalarFunction);
         }
+
+        // Create an algebrizer that will algebrize expressions in an implicit type conversion
+        // context when necessary (i.e. when the operator expects non-String operands), and one
+        // that will not.
+        let itc_algebrizer = self.with_implicit_type_conversion_ctx(true);
+        let non_itc_algebrizer = self.with_implicit_type_conversion_ctx(false);
 
         // get the arguments as a vec of ast::Expressions. If the arguments are
         // Star this must be a COUNT function, otherwise it is an error.
@@ -1725,24 +1771,22 @@ impl<'a> Algebrizer<'a> {
             | (ast::FunctionName::Round, _)
             | (ast::FunctionName::DayOfWeek, _) => args
                 .into_iter()
-                .map(|e| {
-                    self.algebrize_expression(
-                        e,
-                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                    )
-                })
+                // These functions do not expect String arguments, so we use the ITC algebrizer
+                // which will convert StringConstructors to their corresponding BSON values.
+                .map(|e| itc_algebrizer.algebrize_expression(e))
                 .collect::<Result<Vec<_>>>()?,
             (ast::FunctionName::Split, 3) => {
                 let [string, delimiter, token_number]: [ast::Expression; 3] = args
                     .try_into()
                     .expect("Could not unpack args for ast Split function");
                 vec![
-                    self.algebrize_expression(string, ExpressionContext::default())?,
-                    self.algebrize_expression(delimiter, ExpressionContext::default())?,
-                    self.algebrize_expression(
-                        token_number,
-                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                    )?,
+                    // `string` and `delimiter` are expected to be String values so we do not
+                    // algebrize in an ITC context.
+                    non_itc_algebrizer.algebrize_expression(string)?,
+                    non_itc_algebrizer.algebrize_expression(delimiter)?,
+                    // `token_number` is not expected to be a String so we algebrize in an ITC
+                    // context.
+                    itc_algebrizer.algebrize_expression(token_number)?,
                 ]
             }
             (ast::FunctionName::Substring, 3) => {
@@ -1750,15 +1794,13 @@ impl<'a> Algebrizer<'a> {
                     .try_into()
                     .expect("Could not unpack args for ast Substring function");
                 vec![
-                    self.algebrize_expression(string, ExpressionContext::default())?,
-                    self.algebrize_expression(
-                        start,
-                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                    )?,
-                    self.algebrize_expression(
-                        length,
-                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                    )?,
+                    // `string` is expected to be a String value so we do not algebrize in an ITC
+                    // context.
+                    non_itc_algebrizer.algebrize_expression(string)?,
+                    // `start` and `length` are not expected to be String values so we algebrize in
+                    // an ITC context.
+                    itc_algebrizer.algebrize_expression(start)?,
+                    itc_algebrizer.algebrize_expression(length)?,
                 ]
             }
             (ast::FunctionName::NullIf, 2) => {
@@ -1779,7 +1821,9 @@ impl<'a> Algebrizer<'a> {
             | (ast::FunctionName::Replace, _)
             | (ast::FunctionName::Upper, _) => args
                 .into_iter()
-                .map(|e| self.algebrize_expression(e, ExpressionContext::default()))
+                // These functions expect String arguments, so we use the non-ITC algebrizer which
+                // will not convert StringConstructors.
+                .map(|e| non_itc_algebrizer.algebrize_expression(e))
                 .collect::<Result<Vec<_>>>()?,
             // the following patterns should not be hit due to rewrites; throw an error for aggregation functions
             // to indicate programmer error, otherwise panic
@@ -1831,10 +1875,10 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_unary_expr(&self, u: ast::UnaryExpr) -> Result<mir::Expression> {
-        let arg = self.algebrize_expression(
-            *u.expr,
-            ExpressionContext::default().with_implicit_type_conversion_ctx(),
-        )?;
+        // None of the UnaryOp operators expect String operands, so we algebrize their operands in
+        // an implicit type conversion context.
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(true);
+        let arg = expr_algebrizer.algebrize_expression(*u.expr)?;
         let args = vec![arg];
         Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
@@ -1859,36 +1903,39 @@ impl<'a> Algebrizer<'a> {
     fn algebrize_binary_expr(&self, b: ast::BinaryExpr) -> Result<mir::Expression> {
         use crate::ast::BinaryOp::*;
 
+        // Create an algebrizer that will algebrize expressions in an implicit type conversion
+        // context when necessary (i.e. when the operator expects non-String operands), and one
+        // that will not.
+        let itc_algebrizer = self.with_implicit_type_conversion_ctx(true);
+        let non_itc_algebrizer = self.with_implicit_type_conversion_ctx(false);
+
         // First, we must determine if the left and right operands each need to
         // be algebrized in an implicit type conversion context (this is done
         // by toggling the bool argument to aglebrize_expression). The different
         // cases are detailed below.
         let (mut left, mut right) = match b.op {
-            // Add, And, Div, Mul, Or, and Sub do not expect String operands,
-            // therefore we algebrize their left and right operands with true.
-            // This means we _should_ attempt to implicitly convert any
-            // StringConstructors into different literal types.
+            // Add, And, Div, Mul, Or, and Sub do not expect String operands, therefore we algebrize
+            // their left and right operands with the ITC algebrizer. This means we _should_ attempt
+            // to implicitly convert any StringConstructors into different literal types.
             Add | And | Div | Mul | Or | Sub => (
-                self.algebrize_expression(
-                    *b.left,
-                    ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                )?,
-                self.algebrize_expression(
-                    *b.right,
-                    ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                )?,
+                itc_algebrizer.algebrize_expression(*b.left)?,
+                itc_algebrizer.algebrize_expression(*b.right)?,
             ),
 
-            // Concat expects String operands, therefore we algebrize its left
-            // and right operands with false. This means we should not attempt
-            // to convert any StringConstructors into different literal types.
+            // Concat expects String operands, therefore we algebrize its left and right operands
+            // with the non-ITC algebrizer. This means we should not attempt to convert any
+            // StringConstructors into different literal types.
             Concat => (
-                self.algebrize_expression(*b.left, ExpressionContext::default())?,
-                self.algebrize_expression(*b.right, ExpressionContext::default())?,
+                non_itc_algebrizer.algebrize_expression(*b.left)?,
+                non_itc_algebrizer.algebrize_expression(*b.right)?,
             ),
 
+            // algebrize_binary_comparison_operands handles implicit type conversion context
+            // sensitivity based on the operand types.
             Comparison(_) => self.algebrize_binary_comparison_operands(*b.left, *b.right)?,
 
+            // algebrize_in_operands handles implicit type conversion context sensitivity based on
+            // the operand types.
             In | NotIn => self.algebrize_in_operands(*b.left, *b.right)?,
         };
 
@@ -1970,23 +2017,27 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_is(&self, ast_node: ast::IsExpr) -> Result<mir::Expression> {
+        // `IS` is an interesting case: the operand is not expected to be any particular type, so
+        // typically we should prefer not to implicitly convert it. However, if the target type is
+        // NOT String, then we know that the expr is not expected to be a String, so we algebrize it
+        // in an implicit type conversion context. This could be useful for experimental queries
+        // such as `'{"$numberIn": "1"}' IS INT`.
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(
+            ast_node.target_type != ast::TypeOrMissing::Type(ast::Type::String),
+        );
         Ok(mir::Expression::Is(mir::IsExpr {
-            expr: Box::new(self.algebrize_expression(
-                *ast_node.expr,
-                ExpressionContext::default().with_implicit_type_conversion_ctx(),
-            )?),
+            expr: Box::new(expr_algebrizer.algebrize_expression(*ast_node.expr)?),
             target_type: mir::TypeOrMissing::try_from(ast_node.target_type)?,
         }))
     }
 
     fn algebrize_like(&self, ast_node: ast::LikeExpr) -> Result<mir::Expression> {
+        // LIKE expects String operands, therefore we algebrize its left and right operands in a
+        // non-ITC context.
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(false);
         Ok(mir::Expression::Like(mir::LikeExpr {
-            expr: Box::new(
-                self.algebrize_expression(*ast_node.expr, ExpressionContext::default())?,
-            ),
-            pattern: Box::new(
-                self.algebrize_expression(*ast_node.pattern, ExpressionContext::default())?,
-            ),
+            expr: Box::new(expr_algebrizer.algebrize_expression(*ast_node.expr)?),
+            pattern: Box::new(expr_algebrizer.algebrize_expression(*ast_node.pattern)?),
             escape: ast_node.escape,
         }))
     }
@@ -2047,17 +2098,12 @@ impl<'a> Algebrizer<'a> {
         // Again, if non_literals_are_nullable_strings is true, that means we
         // _do_ expect any StringConstructors to be String values, so we set
         // in_implicit_type_conversion_context to false.
-        let in_implicit_type_conversion_context = !non_literals_are_nullable_strings;
+        let expr_algebrizer =
+            self.with_implicit_type_conversion_ctx(!non_literals_are_nullable_strings);
         let args = vec![
-            arg.unwrap_or(
-                self.algebrize_string_constructor(arg_lit, in_implicit_type_conversion_context),
-            ),
-            min.unwrap_or(
-                self.algebrize_string_constructor(min_lit, in_implicit_type_conversion_context),
-            ),
-            max.unwrap_or(
-                self.algebrize_string_constructor(max_lit, in_implicit_type_conversion_context),
-            ),
+            arg.unwrap_or(expr_algebrizer.algebrize_string_constructor(arg_lit)),
+            min.unwrap_or(expr_algebrizer.algebrize_string_constructor(min_lit)),
+            max.unwrap_or(expr_algebrizer.algebrize_string_constructor(max_lit)),
         ];
 
         let function = mir::ScalarFunction::Between;
@@ -2072,14 +2118,16 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_trim(&self, t: ast::TrimExpr) -> Result<mir::Expression> {
+        // TRIM expects String operands, therefore we algebrize its operands in a non-ITC context.
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(false);
         let function = match t.trim_spec {
             ast::TrimSpec::Leading => mir::ScalarFunction::LTrim,
             ast::TrimSpec::Trailing => mir::ScalarFunction::RTrim,
             ast::TrimSpec::Both => mir::ScalarFunction::BTrim,
         };
         let args = vec![
-            self.algebrize_expression(*t.trim_chars, ExpressionContext::default())?,
-            self.algebrize_expression(*t.arg, ExpressionContext::default())?,
+            expr_algebrizer.algebrize_expression(*t.trim_chars)?,
+            expr_algebrizer.algebrize_expression(*t.arg)?,
         ];
         Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
@@ -2107,10 +2155,10 @@ impl<'a> Algebrizer<'a> {
             IsoWeekday => mir::ScalarFunction::IsoWeekday,
             Quarter => panic!("'Quarter' is not a supported date part for EXTRACT"),
         };
-        let args = vec![self.algebrize_expression(
-            *e.arg,
-            ExpressionContext::default().with_implicit_type_conversion_ctx(),
-        )?];
+
+        // EXTRACT expects a datetime operand, therefore we algebrize its operand in an ITC context.
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(true);
+        let args = vec![expr_algebrizer.algebrize_expression(*e.arg)?];
         let is_nullable = Self::args_are_nullable(&args);
         Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
@@ -2146,15 +2194,12 @@ impl<'a> Algebrizer<'a> {
             }
         };
 
+        // Date functions expect non-String operands, therefore we algebrize them in an ITC context.
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(true);
         let args = d
             .args
             .into_iter()
-            .map(|e| {
-                self.algebrize_expression(
-                    e,
-                    ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                )
-            })
+            .map(|e| expr_algebrizer.algebrize_expression(e))
             .collect::<Result<Vec<_>>>()?;
 
         // All date functions are nullable
@@ -2171,42 +2216,46 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_access(&self, a: ast::AccessExpr) -> Result<mir::Expression> {
-        let expr = self.algebrize_expression(
-            *a.expr,
-            ExpressionContext::default().with_implicit_type_conversion_ctx(),
-        )?;
+        // The `expr` of an AccessExpr is algebrized in an implicit type conversion context since a
+        // String is unexpected in this position.
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(true);
+        let expr = expr_algebrizer.algebrize_expression(*a.expr)?;
         Ok(match *a.subfield {
             ast::Expression::StringConstructor(s) => self.construct_field_access_expr(expr, s)?,
             sf => mir::Expression::ScalarFunction(mir::ScalarFunctionApplication::new(
                 mir::ScalarFunction::ComputedFieldAccess,
                 vec![
                     expr,
-                    self.algebrize_expression(sf, ExpressionContext::default())?,
+                    // Since this expression is certainly not a StringConstructor, we can just use
+                    // `self` to algebrize it since the implicit type conversion context does not
+                    // matter.
+                    self.algebrize_expression(sf)?,
                 ],
             )),
         })
     }
 
     fn algebrize_type_assertion(&self, t: ast::TypeAssertionExpr) -> Result<mir::Expression> {
-        // If the target_type is String, we do not implicitly convert the
-        // expr since it is being asserted as a String. Otherwise, we do
-        // attempt to convert.
-        let context = ExpressionContext {
-            in_implicit_type_conversion_ctx: t.target_type != ast::Type::String,
-        };
+        // If the target_type is String, we do not implicitly convert the expr since it is being
+        // asserted as a String. Otherwise, we do attempt to convert.
+        let expr_algebrizer =
+            self.with_implicit_type_conversion_ctx(t.target_type != ast::Type::String);
         Ok(mir::Expression::TypeAssertion(mir::TypeAssertionExpr {
-            expr: Box::new(self.algebrize_expression(*t.expr, context)?),
+            expr: Box::new(expr_algebrizer.algebrize_expression(*t.expr)?),
             target_type: mir::Type::try_from(t.target_type)?,
         }))
     }
 
     fn algebrize_case(&self, c: ast::CaseExpr) -> Result<mir::Expression> {
+        let itc_algebrizer = self.with_implicit_type_conversion_ctx(true);
+        let non_itc_algebrizer = self.with_implicit_type_conversion_ctx(false);
+
         // if we don't have an else branch, the resulting case expression _is_ nullable; otherwise, we will
         // check the then and else expressions to determine nullability
         let mut is_nullable = c.else_branch.is_none();
         let else_branch = c
             .else_branch
-            .map(|e| self.algebrize_expression(*e, ExpressionContext::default()))
+            .map(|e| non_itc_algebrizer.algebrize_expression(*e))
             .transpose()?
             .inspect(|expr| {
                 is_nullable = is_nullable
@@ -2224,8 +2273,8 @@ impl<'a> Algebrizer<'a> {
             .clone()
             .into_iter()
             .map(|wb| {
-                let when = self.algebrize_expression(*wb.when, ExpressionContext::default())?;
-                let then = self.algebrize_expression(*wb.then, ExpressionContext::default())?;
+                let when = non_itc_algebrizer.algebrize_expression(*wb.when)?;
+                let then = non_itc_algebrizer.algebrize_expression(*wb.then)?;
                 let then_is_nullable = NULLISH
                     .satisfies(&then.schema(&self.schema_inference_state()).unwrap())
                     != Satisfaction::Not;
@@ -2246,16 +2295,16 @@ impl<'a> Algebrizer<'a> {
         // if all the `when` branches have string schemas, we should not implicitly convert our
         // expr if we have one, so that they may be compared directly. Otherwise, we algebrize the
         // expr in an implicit type conversion context.
-        let context = ExpressionContext {
-            in_implicit_type_conversion_ctx: !when_branches_all_strings,
-        };
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(!when_branches_all_strings);
         let expr = c
             .expr
-            .map(|e| self.algebrize_expression(*e, context))
+            .map(|e| expr_algebrizer.algebrize_expression(*e))
             .transpose()?;
 
-        // if the expr exists and MUST satisfy string, we can use the previously algebrized when_branch without implicit type conversion;
-        // otherwise, we should re-algebrize with implicit type conversion for comparison with non-string expressions (SimpleCase), or for SearchedCase
+        // if the expr exists and MUST satisfy string, we can use the previously algebrized
+        // when_branch without implicit type conversion; otherwise, we should re-algebrize with
+        // implicit type conversion for comparison with non-string expressions (SimpleCase), or for
+        // SearchedCase
         let expr_schema = expr.as_ref().map(|e| {
             e.schema(&self.schema_inference_state())
                 .unwrap_or(schema::Schema::Unsat)
@@ -2268,11 +2317,8 @@ impl<'a> Algebrizer<'a> {
                 .when_branch
                 .into_iter()
                 .map(|wb| {
-                    let when = self.algebrize_expression(
-                        *wb.when,
-                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                    )?;
-                    let then = self.algebrize_expression(*wb.then, ExpressionContext::default())?;
+                    let when = itc_algebrizer.algebrize_expression(*wb.when)?;
+                    let then = non_itc_algebrizer.algebrize_expression(*wb.then)?;
                     Ok(mir::WhenBranch {
                         is_nullable: NULLISH
                             .satisfies(&then.schema(&self.schema_inference_state())?)
@@ -2310,6 +2356,9 @@ impl<'a> Algebrizer<'a> {
             }};
         }
 
+        let itc_algebrizer = self.with_implicit_type_conversion_ctx(true);
+        let non_itc_algebrizer = self.with_implicit_type_conversion_ctx(false);
+
         match c.to {
             BinData | DbPointer | Javascript | JavascriptWithScope | MaxKey | MinKey
             | RegularExpression | Symbol | Timestamp | Undefined | Date | Time => {
@@ -2317,18 +2366,17 @@ impl<'a> Algebrizer<'a> {
             }
             Array | Boolean | Datetime | Decimal128 | Document | Double | Int32 | Int64 | Null
             | ObjectId | String => {
-                let expr = self.algebrize_expression(
-                    *c.expr,
-                    ExpressionContext::default().with_implicit_type_conversion_ctx(),
-                )?;
-                let on_null = self.algebrize_expression(
-                    *(c.on_null.unwrap_or_else(|| null_expr!())),
-                    ExpressionContext::default(),
-                )?;
-                let on_error = self.algebrize_expression(
-                    *(c.on_error.unwrap_or_else(|| null_expr!())),
-                    ExpressionContext::default(),
-                )?;
+                // MongoDB does not natively support casting extended-JSON encoded strings to their
+                // underlying type via `$convert` (which is the translation of `CAST`). Therefore,
+                // we algebrize the expr in an ITC context in case it is a StringConstructor that
+                // is formatted in extended-JSON.
+                let expr = itc_algebrizer.algebrize_expression(*c.expr)?;
+                // on_null and on_error do not have expected types, so we do not algebrize them in
+                // an ITC context.
+                let on_null = non_itc_algebrizer
+                    .algebrize_expression(*(c.on_null.unwrap_or_else(|| null_expr!())))?;
+                let on_error = non_itc_algebrizer
+                    .algebrize_expression(*(c.on_error.unwrap_or_else(|| null_expr!())))?;
                 let is_nullable =
                     expr.is_nullable() || on_error.is_nullable() || on_null.is_nullable();
                 Ok(mir::Expression::Cast(mir::CastExpr {
@@ -2401,10 +2449,8 @@ impl<'a> Algebrizer<'a> {
         // that value set to true.
         let is_nullable_string =
             subquery_schema.satisfies(&STRING_OR_NULLISH) == Satisfaction::Must;
-        let context = ExpressionContext {
-            in_implicit_type_conversion_ctx: !is_nullable_string,
-        };
-        let argument = self.algebrize_expression(*s.expr, context)?;
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(!is_nullable_string);
+        let argument = expr_algebrizer.algebrize_expression(*s.expr)?;
 
         // Determine the overall nullability of the subquery comparison expr.
         let arg_schema = argument.schema(&self.schema_inference_state())?;
@@ -2430,10 +2476,10 @@ impl<'a> Algebrizer<'a> {
         if let ast::Expression::Identifier(s) = *p.expr {
             return self.algebrize_possibly_qualified_field_access(s, p.subpath);
         }
-        let expr = self.algebrize_expression(
-            *p.expr,
-            ExpressionContext::default().with_implicit_type_conversion_ctx(),
-        )?;
+        // The `expr` of a SubpathExpr is algebrized in an implicit type conversion context since a
+        // String is unexpected in this position.
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(true);
+        let expr = expr_algebrizer.algebrize_expression(*p.expr)?;
         let expr_schema = expr.schema(&self.schema_inference_state())?;
         let is_nullable = NULLISH.satisfies(&expr_schema) != Satisfaction::Not
             || expr_schema.contains_field(&p.subpath) != Satisfaction::Must;
@@ -2499,8 +2545,7 @@ impl<'a> Algebrizer<'a> {
             .collect::<Vec<_>>();
         // If there is no datasource containing the field, the field is not found.
         if i_containing_datasources.is_empty() {
-            let all_keys = self
-                .schema_env
+            let all_keys = (*self.schema_env)
                 .clone()
                 .into_iter()
                 .flat_map(|(_, s)| s.keys())

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -775,7 +775,7 @@ impl<'a> Algebrizer<'a> {
             // to algebrize it in an implicit type conversion context. We do this because we do not
             // want to confuse users with seemingly inconsistent behavior. For example, if the user
             // wrote `... FROM foo JOIN bar ON 'false'` and we implicitly converted the `'false'` to
-            // `fasle`, the join condition would fail for all rows. But if they wrote `... FROM foo
+            // `false`, the join condition would fail for all rows. But if they wrote `... FROM foo
             // JOIN bar ON 'false'::BOOL`, the `CAST` would convert the `'false'` to `true`! And the
             // join condition would succeed for all rows! This is because in MongoDB, any String
             // unconditionally converts to true when casting to a Boolean. Given that potential for
@@ -1114,7 +1114,7 @@ impl<'a> Algebrizer<'a> {
                     // choose not to algebrize it in an implicit type conversion context. We do this
                     // because we do not want to confuse users with seemingly inconsistent behavior.
                     // For example, if the user wrote `... FROM foo WHERE 'false'` and we implicitly
-                    // converted the `'false'` to `fasle`, the filter would fail for all rows. But
+                    // converted the `'false'` to `false`, the filter would fail for all rows. But
                     // if they wrote `... FROM foo WHERE 'false'::BOOL`, the `CAST` would convert
                     // the `'false'` to `true`, and the filter would succeed for all rows! This is
                     // because in MongoDB, any String unconditionally converts to true when casting

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -257,7 +257,6 @@ impl ExpressionContext {
     pub(crate) fn with_implicit_type_conversion_ctx(self, value: bool) -> Self {
         Self {
             in_implicit_type_conversion_ctx: value,
-            ..self
         }
     }
 }
@@ -283,6 +282,7 @@ impl<'a> Algebrizer<'a> {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn with_schema_env(
         current_db: &'a str,
         schema_env: SchemaEnvironment,

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -769,7 +769,6 @@ impl<'a> Algebrizer<'a> {
         let left_src_result_set = left_src.schema(&self.schema_inference_state())?;
         let right_src_result_set = right_src.schema(&self.schema_inference_state())?;
         let condition_algebrizer = self
-            .clone()
             .with_merged_mappings(left_src_result_set.schema_env)?
             .with_merged_mappings(right_src_result_set.schema_env)?
             // Although the condition expression is expected to Boolean (or nullish), we choose not
@@ -1108,7 +1107,6 @@ impl<'a> Algebrizer<'a> {
             None => source,
             Some(expr) => {
                 let expression_algebrizer = self
-                    .clone()
                     .with_merged_mappings(
                         source.schema(&self.schema_inference_state())?.schema_env,
                     )?
@@ -1287,7 +1285,6 @@ impl<'a> Algebrizer<'a> {
     ) -> Result<mir::Stage> {
         *self.clause_type.borrow_mut() = ClauseType::OrderBy;
         let expression_algebrizer = self
-            .clone()
             .with_merged_mappings(source.schema(&self.schema_inference_state())?.schema_env)?
             // We should not algebrize the sort key exprs in an implicit type conversion
             // context since there is no specific type expected for these values.
@@ -1344,7 +1341,6 @@ impl<'a> Algebrizer<'a> {
             None => source,
             Some(ast_expr) => {
                 let expression_algebrizer = self
-                    .clone()
                     .with_merged_mappings(
                         source.schema(&self.schema_inference_state())?.schema_env,
                     )?
@@ -2250,8 +2246,8 @@ impl<'a> Algebrizer<'a> {
         let itc_algebrizer = self.with_implicit_type_conversion_ctx(true);
         let non_itc_algebrizer = self.with_implicit_type_conversion_ctx(false);
 
-        // if we don't have an else branch, the resulting case expression _is_ nullable; otherwise, we will
-        // check the then and else expressions to determine nullability
+        // if we don't have an else branch, the resulting case expression _is_ nullable; otherwise,
+        // we will check the then and else expressions to determine nullability
         let mut is_nullable = c.else_branch.is_none();
         let else_branch = c
             .else_branch
@@ -2265,8 +2261,8 @@ impl<'a> Algebrizer<'a> {
             .map(Box::new)
             .unwrap_or_else(|| Box::new(mir::Expression::Literal(mir::LiteralValue::Null)));
 
-        // algebrize the when branches without implicit casting, keeping track of the schema of all of the when expressions
-        // to inform how we algebrize the expr
+        // algebrize the `when` branches without implicit casting, keeping track of the schema of
+        // all the `when` expressions to inform how we algebrize the expr
         let mut when_branches_all_strings = true;
         let mut when_branch: Vec<mir::WhenBranch> = c
             .when_branch

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -239,6 +239,25 @@ pub struct Algebrizer<'a> {
     clause_type: RefCell<ClauseType>,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ExpressionContext {
+    // Indicates if the expression is being algebrized is in an implicit type conversion context.
+    // An expression is "in an implicit type conversion context" whenever it appears in a place
+    // where a string is unexpected. For example, the operands of a numeric operator like + are
+    // unexpected to be strings. MongoSQL supports implicit type conversion from extended-JSON
+    // encoded string literals to the corresponding BSON type in these contexts.
+    in_implicit_type_conversion_ctx: bool,
+}
+
+impl ExpressionContext {
+    pub(crate) fn with_implicit_type_conversion_ctx(self) -> Self {
+        Self {
+            in_implicit_type_conversion_ctx: true,
+            ..self
+        }
+    }
+}
+
 impl<'a> Algebrizer<'a> {
     pub fn new(
         current_db: &'a str,
@@ -505,7 +524,8 @@ impl<'a> Algebrizer<'a> {
                     // for now, and depending on the rest of the select query, a DuplicateKey or SchemaChecking
                     // error will occur downstream.
                     _ => {
-                        let e = expression_algebrizer.algebrize_expression(e, false)?;
+                        let e = expression_algebrizer
+                            .algebrize_expression(e, ExpressionContext::default())?;
                         let bot = Key::bot(expression_algebrizer.scope_level);
                         datasources
                             .insert(bot.clone())
@@ -550,8 +570,10 @@ impl<'a> Algebrizer<'a> {
         // if we found Expressions's, algebrize them as a single document, and add it to the expression
         // under the Bottom namespace.
         if let Some(bottom) = bottom {
-            let e = expression_algebrizer
-                .algebrize_expression(ast::Expression::Document(bottom), false)?;
+            let e = expression_algebrizer.algebrize_expression(
+                ast::Expression::Document(bottom),
+                ExpressionContext::default(),
+            )?;
             let bot = Key::bot(expression_algebrizer.scope_level);
             datasources
                 .insert(bot.clone())
@@ -662,7 +684,7 @@ impl<'a> Algebrizer<'a> {
         let src = mir::Stage::Array(mir::ArraySource {
             array: ve
                 .into_iter()
-                .map(|e| self.algebrize_expression(e, false))
+                .map(|e| self.algebrize_expression(e, ExpressionContext::default()))
                 .collect::<Result<_>>()?,
             alias,
             cache: SchemaCache::new(),
@@ -718,7 +740,7 @@ impl<'a> Algebrizer<'a> {
             .with_merged_mappings(right_src_result_set.schema_env)?;
         let condition = j
             .condition
-            .map(|e| join_algebrizer.algebrize_expression(e, false))
+            .map(|e| join_algebrizer.algebrize_expression(e, ExpressionContext::default()))
             .transpose()?
             .map(Self::convert_literal_to_bool);
         condition
@@ -984,7 +1006,7 @@ impl<'a> Algebrizer<'a> {
     /// expression which consists of only other FieldAccess expressions up the
     /// chain of exprs until it hits a Reference expression.
     fn algebrize_unwind_path(&self, path: ast::Expression) -> Result<mir::FieldPath> {
-        let path = self.algebrize_expression(path, false)?;
+        let path = self.algebrize_expression(path, ExpressionContext::default())?;
         (&path).try_into().map_err(|_| Error::InvalidUnwindPath)
     }
 
@@ -1046,7 +1068,7 @@ impl<'a> Algebrizer<'a> {
                 mir::Stage::Filter(mir::Filter {
                     source: Box::new(source),
                     condition: expression_algebrizer
-                        .algebrize_expression(expr, false)
+                        .algebrize_expression(expr, ExpressionContext::default())
                         .map(Self::convert_literal_to_bool)?,
                     cache: SchemaCache::new(),
                 })
@@ -1217,9 +1239,8 @@ impl<'a> Algebrizer<'a> {
                     .into_iter()
                     .map(|s| {
                         let sort_key = match s.key {
-                            ast::SortKey::Simple(expr) => {
-                                expression_algebrizer.algebrize_expression(expr, false)
-                            }
+                            ast::SortKey::Simple(expr) => expression_algebrizer
+                                .algebrize_expression(expr, ExpressionContext::default()),
                             ast::SortKey::Positional(_) => panic!(
                                 "positional sort keys should have been rewritten to references"
                             ),
@@ -1275,12 +1296,14 @@ impl<'a> Algebrizer<'a> {
                                 .map_err(|e| Error::DuplicateDocumentKey(e.get_key_name()))?;
                             Ok(mir::OptionallyAliasedExpr::Aliased(mir::AliasedExpr {
                                 alias: ast_key.alias,
-                                expr: expression_algebrizer
-                                    .algebrize_expression(ast_key.expr, false)?,
+                                expr: expression_algebrizer.algebrize_expression(
+                                    ast_key.expr,
+                                    ExpressionContext::default(),
+                                )?,
                             }))
                         }
                         ast::OptionallyAliasedExpr::Unaliased(expr) => expression_algebrizer
-                            .algebrize_expression(expr, false)
+                            .algebrize_expression(expr, ExpressionContext::default())
                             .map(mir::OptionallyAliasedExpr::Unaliased),
                     })
                     .collect::<Result<_>>()?;
@@ -1339,7 +1362,7 @@ impl<'a> Algebrizer<'a> {
                 let arg = if ve.len() != 1 {
                     return Err(Error::AggregationFunctionMustHaveOneArgument);
                 } else {
-                    self.algebrize_expression(ve[0].clone(), false)?
+                    self.algebrize_expression(ve[0].clone(), ExpressionContext::default())?
                 };
                 mir::AggregationExpr::Function(mir::AggregationFunctionApplication {
                     function: mir::AggregationFunction::try_from(function)?,
@@ -1358,23 +1381,28 @@ impl<'a> Algebrizer<'a> {
     pub fn algebrize_expression(
         &self,
         ast_node: ast::Expression,
-        in_implicit_type_conversion_context: bool,
+        context: ExpressionContext,
     ) -> Result<mir::Expression> {
         match ast_node {
             ast::Expression::Literal(l) => Ok(mir::Expression::Literal(self.algebrize_literal(l))),
             ast::Expression::StringConstructor(s) => {
-                Ok(self.algebrize_string_constructor(s, in_implicit_type_conversion_context))
+                Ok(self.algebrize_string_constructor(s, context.in_implicit_type_conversion_ctx))
             }
             ast::Expression::Array(a) => Ok(mir::Expression::Array(
                 a.into_iter()
-                    .map(|e| self.algebrize_expression(e, false))
+                    .map(|e| self.algebrize_expression(e, ExpressionContext::default()))
                     .collect::<Result<Vec<mir::Expression>>>()?
                     .into(),
             )),
             ast::Expression::Document(d) => Ok(mir::Expression::Document({
                 let algebrized = d
                     .into_iter()
-                    .map(|kv| Ok((kv.key, self.algebrize_expression(kv.value, false)?)))
+                    .map(|kv| {
+                        Ok((
+                            kv.key,
+                            self.algebrize_expression(kv.value, ExpressionContext::default())?,
+                        ))
+                    })
                     .collect::<Result<Vec<_>>>()?;
                 let mut out = UniqueLinkedHashMap::new();
                 out.insert_many(algebrized.into_iter())
@@ -1401,11 +1429,11 @@ impl<'a> Algebrizer<'a> {
             ast::Expression::Like(l) => self.algebrize_like(l),
             ast::Expression::Tuple(a) => Ok(mir::Expression::Array(
                 a.into_iter()
-                    // Passes in_implicit_type_conversion_context to each element so that
-                    // algebrize_in_operands can drive ITC for all-StringConstructor Tuples
+                    // Passes the context to each element so that algebrize_in_operands can
+                    // drive implicit type conversion (ITC) for all-StringConstructor Tuples
                     // via its (false, true) arm. Reverting this to hardcode `false` would
                     // silently break ITC for `field IN ('{"$date":"..."}', ...)`.
-                    .map(|e| self.algebrize_expression(e, in_implicit_type_conversion_context))
+                    .map(|e| self.algebrize_expression(e, context))
                     .collect::<Result<Vec<mir::Expression>>>()?
                     .into(),
             )),
@@ -1494,7 +1522,7 @@ impl<'a> Algebrizer<'a> {
         &self,
         non_literal: ast::Expression,
     ) -> Result<(mir::Expression, bool)> {
-        let non_literal = self.algebrize_expression(non_literal, false)?;
+        let non_literal = self.algebrize_expression(non_literal, ExpressionContext::default())?;
         let non_literal_schema = non_literal.schema(&self.schema_inference_state())?;
         let is_nullable_string =
             non_literal_schema.satisfies(&STRING_OR_NULLISH) == Satisfaction::Must;
@@ -1505,7 +1533,7 @@ impl<'a> Algebrizer<'a> {
     /// This is a helper function for algebrizing binary comparison operands when one is a
     /// StringConstructor (literal) and one is not (non_literal). The non_literal is algebrized
     /// first. If its schema MUST satisfy STRING_OR_NULLISH, then the literal is algebrized with
-    /// in_implicit_type_conversion_context set to false because that means a String is expected;
+    /// in_implicit_type_conversion_ctx set to false because that means a String is expected;
     /// otherwise, it is algebrized with that value set to true.
     ///
     /// - "itc" stands for "implicit type conversion".
@@ -1519,8 +1547,11 @@ impl<'a> Algebrizer<'a> {
             self.algebrize_non_literal_itc_operand(non_literal)?;
 
         // Again, if is_nullable_string is true, that means we _do_ expect the StringConstructor
-        // to be a String value, so we set in_implicit_type_conversion_context to false.
-        let literal = self.algebrize_expression(literal, !is_nullable_string)?;
+        // to be a String value, so we set in_implicit_type_conversion_ctx to false.
+        let context = ExpressionContext {
+            in_implicit_type_conversion_ctx: !is_nullable_string,
+        };
+        let literal = self.algebrize_expression(literal, context)?;
 
         Ok((literal, non_literal))
     }
@@ -1531,7 +1562,7 @@ impl<'a> Algebrizer<'a> {
     /// determines if exactly one of the operands is a StringConstructor and
     /// dispatches to algebrize_itc_eligible_binary_comparison_operands if
     /// that is the case. Otherwise, this function algebrizes both operands
-    /// with in_implicit_type_conversion_context set to false. This is because
+    /// with in_implicit_type_conversion_ctx set to false. This is because
     /// if both are StringConstructors, we can leave them both as String values,
     /// and if neither are StringConstructors, there is nothing to convert.
     fn algebrize_binary_comparison_operands(
@@ -1544,8 +1575,8 @@ impl<'a> Algebrizer<'a> {
                 l @ ast::Expression::StringConstructor(_),
                 r @ ast::Expression::StringConstructor(_),
             ) => Ok((
-                self.algebrize_expression(l, false)?,
-                self.algebrize_expression(r, false)?,
+                self.algebrize_expression(l, ExpressionContext::default())?,
+                self.algebrize_expression(r, ExpressionContext::default())?,
             )),
             (literal @ ast::Expression::StringConstructor(_), non_literal) => {
                 let (literal, non_literal) =
@@ -1558,8 +1589,8 @@ impl<'a> Algebrizer<'a> {
                 Ok((non_literal, literal))
             }
             (l, r) => Ok((
-                self.algebrize_expression(l, false)?,
-                self.algebrize_expression(r, false)?,
+                self.algebrize_expression(l, ExpressionContext::default())?,
+                self.algebrize_expression(r, ExpressionContext::default())?,
             )),
         }
     }
@@ -1569,7 +1600,7 @@ impl<'a> Algebrizer<'a> {
     /// Mirrors [`Self::algebrize_binary_comparison_operands`] but handles the fact that the RHS
     /// is an [`ast::Expression::Tuple`] containing multiple elements rather than a single
     /// expression. If exactly any side contains a [`ast::Expression::StringConstructor`]
-    /// node, those strings are algebrized with `in_implicit_type_conversion_context = true`
+    /// node, those strings are algebrized with `in_implicit_type_conversion_ctx = true`
     /// so that extended-JSON strings (e.g. `'{"$date":"2020-01-01"}'`) are converted to the
     /// corresponding BSON values. If both or neither side consists of string constructors,
     /// both operands are algebrized with the flag set to `false`.
@@ -1598,30 +1629,41 @@ impl<'a> Algebrizer<'a> {
         ) {
             // Both sides are string constructors, or neither is — no conversion needed.
             (true, true) | (false, false) => Ok((
-                self.algebrize_expression(left, false)?,
-                self.algebrize_expression(right, false)?,
+                self.algebrize_expression(left, ExpressionContext::default())?,
+                self.algebrize_expression(right, ExpressionContext::default())?,
             )),
-            // LHS is a StringConstructor; RHS Tuple does not have any string constructors among its elements
+            // LHS is a StringConstructor; RHS Tuple does not have any string constructors among its
+            // elements
             (true, false) => {
                 Ok((
-                    // Because the left is a StringConstructor, we algebrize with ITC to convert it to the right value
-                    self.algebrize_expression(left, true)?,
-                    // Because none of the elements in the RHS are StringConstructors, we can safely algebrize the entire RHS with in_implicit_type_conversion_context set to false.
-                    self.algebrize_expression(right, false)?,
+                    // Because the left is a StringConstructor, we algebrize with ITC to convert it
+                    // to the right value
+                    self.algebrize_expression(
+                        left,
+                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                    )?,
+                    // Because none of the elements in the RHS are StringConstructors, we can safely
+                    // algebrize the entire RHS with in_implicit_type_conversion_ctx set to false.
+                    self.algebrize_expression(right, ExpressionContext::default())?,
                 ))
             }
             // LHS is not a string constructor, RHS has some elements that StringConstructors
-            // We algebrize the LHS with in_implicit_context false, and then algebrize each element in the RHS.
+            // We algebrize the LHS with in_implicit_context false, and then algebrize each element
+            // in the RHS.
             (false, true) => {
                 let rhs_algebrized_per_element = match right {
                     ast::Expression::Tuple(elements) => {
                         let mut algebrized_elements = Vec::new();
                         for element in elements {
                             let algebrized_element = match element {
-                                ast::Expression::StringConstructor(_) => {
-                                    self.algebrize_expression(element, true)?
-                                }
-                                _ => self.algebrize_expression(element, false)?,
+                                ast::Expression::StringConstructor(_) => self
+                                    .algebrize_expression(
+                                        element,
+                                        ExpressionContext::default()
+                                            .with_implicit_type_conversion_ctx(),
+                                    )?,
+                                _ => self
+                                    .algebrize_expression(element, ExpressionContext::default())?,
                             };
 
                             algebrized_elements.push(algebrized_element);
@@ -1632,7 +1674,7 @@ impl<'a> Algebrizer<'a> {
                 };
 
                 Ok((
-                    self.algebrize_expression(left, false)?,
+                    self.algebrize_expression(left, ExpressionContext::default())?,
                     mir::Expression::Array(ArrayExpr {
                         array: rhs_algebrized_per_element,
                     }),
@@ -1653,8 +1695,9 @@ impl<'a> Algebrizer<'a> {
             ast::FunctionArguments::Args(ve) => ve,
         };
 
-        // When algebrizing function arguments below, we set in_implicit_type_conversion_context to true whenever a String argument is unexpected,
-        // and false wherever a String argument is expected.
+        // When algebrizing function arguments below, we set in_implicit_type_conversion_ctx
+        // to true whenever a String argument is unexpected, and false wherever a String argument
+        // is expected.
         let args = match (f.function, args.len()) {
             // if the function is CURRENT_TIMESTAMP with exactly one arg,
             // throw away the argument. we break the spec intentionally
@@ -1682,16 +1725,24 @@ impl<'a> Algebrizer<'a> {
             | (ast::FunctionName::Round, _)
             | (ast::FunctionName::DayOfWeek, _) => args
                 .into_iter()
-                .map(|e| self.algebrize_expression(e, true))
+                .map(|e| {
+                    self.algebrize_expression(
+                        e,
+                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                    )
+                })
                 .collect::<Result<Vec<_>>>()?,
             (ast::FunctionName::Split, 3) => {
                 let [string, delimiter, token_number]: [ast::Expression; 3] = args
                     .try_into()
                     .expect("Could not unpack args for ast Split function");
                 vec![
-                    self.algebrize_expression(string, false)?,
-                    self.algebrize_expression(delimiter, false)?,
-                    self.algebrize_expression(token_number, true)?,
+                    self.algebrize_expression(string, ExpressionContext::default())?,
+                    self.algebrize_expression(delimiter, ExpressionContext::default())?,
+                    self.algebrize_expression(
+                        token_number,
+                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                    )?,
                 ]
             }
             (ast::FunctionName::Substring, 3) => {
@@ -1699,9 +1750,15 @@ impl<'a> Algebrizer<'a> {
                     .try_into()
                     .expect("Could not unpack args for ast Substring function");
                 vec![
-                    self.algebrize_expression(string, false)?,
-                    self.algebrize_expression(start, true)?,
-                    self.algebrize_expression(length, true)?,
+                    self.algebrize_expression(string, ExpressionContext::default())?,
+                    self.algebrize_expression(
+                        start,
+                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                    )?,
+                    self.algebrize_expression(
+                        length,
+                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                    )?,
                 ]
             }
             (ast::FunctionName::NullIf, 2) => {
@@ -1722,7 +1779,7 @@ impl<'a> Algebrizer<'a> {
             | (ast::FunctionName::Replace, _)
             | (ast::FunctionName::Upper, _) => args
                 .into_iter()
-                .map(|e| self.algebrize_expression(e, false))
+                .map(|e| self.algebrize_expression(e, ExpressionContext::default()))
                 .collect::<Result<Vec<_>>>()?,
             // the following patterns should not be hit due to rewrites; throw an error for aggregation functions
             // to indicate programmer error, otherwise panic
@@ -1774,7 +1831,10 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_unary_expr(&self, u: ast::UnaryExpr) -> Result<mir::Expression> {
-        let arg = self.algebrize_expression(*u.expr, true)?;
+        let arg = self.algebrize_expression(
+            *u.expr,
+            ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        )?;
         let args = vec![arg];
         Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
@@ -1809,16 +1869,22 @@ impl<'a> Algebrizer<'a> {
             // This means we _should_ attempt to implicitly convert any
             // StringConstructors into different literal types.
             Add | And | Div | Mul | Or | Sub => (
-                self.algebrize_expression(*b.left, true)?,
-                self.algebrize_expression(*b.right, true)?,
+                self.algebrize_expression(
+                    *b.left,
+                    ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                )?,
+                self.algebrize_expression(
+                    *b.right,
+                    ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                )?,
             ),
 
             // Concat expects String operands, therefore we algebrize its left
             // and right operands with false. This means we should not attempt
             // to convert any StringConstructors into different literal types.
             Concat => (
-                self.algebrize_expression(*b.left, false)?,
-                self.algebrize_expression(*b.right, false)?,
+                self.algebrize_expression(*b.left, ExpressionContext::default())?,
+                self.algebrize_expression(*b.right, ExpressionContext::default())?,
             ),
 
             Comparison(_) => self.algebrize_binary_comparison_operands(*b.left, *b.right)?,
@@ -1905,27 +1971,33 @@ impl<'a> Algebrizer<'a> {
 
     fn algebrize_is(&self, ast_node: ast::IsExpr) -> Result<mir::Expression> {
         Ok(mir::Expression::Is(mir::IsExpr {
-            expr: Box::new(self.algebrize_expression(*ast_node.expr, true)?),
+            expr: Box::new(self.algebrize_expression(
+                *ast_node.expr,
+                ExpressionContext::default().with_implicit_type_conversion_ctx(),
+            )?),
             target_type: mir::TypeOrMissing::try_from(ast_node.target_type)?,
         }))
     }
 
     fn algebrize_like(&self, ast_node: ast::LikeExpr) -> Result<mir::Expression> {
         Ok(mir::Expression::Like(mir::LikeExpr {
-            expr: Box::new(self.algebrize_expression(*ast_node.expr, false)?),
-            pattern: Box::new(self.algebrize_expression(*ast_node.pattern, false)?),
+            expr: Box::new(
+                self.algebrize_expression(*ast_node.expr, ExpressionContext::default())?,
+            ),
+            pattern: Box::new(
+                self.algebrize_expression(*ast_node.pattern, ExpressionContext::default())?,
+            ),
             escape: ast_node.escape,
         }))
     }
 
     fn algebrize_between(&self, b: ast::BetweenExpr) -> Result<mir::Expression> {
         // First, we must determine if the arguments need to be algebrized in an
-        // implicit type conversion context (this is done by toggling the bool
-        // argument to algebrize_expression). We do this in two steps. First, we
+        // implicit type conversion context. We do this in two steps. First, we
         // algebrize the non-StringConstructor arguments and determine if all of
         // their schema MUST satisfy STRING_OR_NULLISH. Then, we algebrize any
         // StringConstructor operands using that information. If all non-literal
-        // operand schema MUST be nullable Strings, we are not in an implicit
+        // operand schema MUST satisfy nullable String, we are not in an implicit
         // type conversion context (because Strings are expected); otherwise, we
         // are.
         let mut non_literals_are_nullable_strings = true;
@@ -2006,8 +2078,8 @@ impl<'a> Algebrizer<'a> {
             ast::TrimSpec::Both => mir::ScalarFunction::BTrim,
         };
         let args = vec![
-            self.algebrize_expression(*t.trim_chars, false)?,
-            self.algebrize_expression(*t.arg, false)?,
+            self.algebrize_expression(*t.trim_chars, ExpressionContext::default())?,
+            self.algebrize_expression(*t.arg, ExpressionContext::default())?,
         ];
         Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
@@ -2035,7 +2107,10 @@ impl<'a> Algebrizer<'a> {
             IsoWeekday => mir::ScalarFunction::IsoWeekday,
             Quarter => panic!("'Quarter' is not a supported date part for EXTRACT"),
         };
-        let args = vec![self.algebrize_expression(*e.arg, true)?];
+        let args = vec![self.algebrize_expression(
+            *e.arg,
+            ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        )?];
         let is_nullable = Self::args_are_nullable(&args);
         Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
@@ -2074,7 +2149,12 @@ impl<'a> Algebrizer<'a> {
         let args = d
             .args
             .into_iter()
-            .map(|e| self.algebrize_expression(e, true))
+            .map(|e| {
+                self.algebrize_expression(
+                    e,
+                    ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                )
+            })
             .collect::<Result<Vec<_>>>()?;
 
         // All date functions are nullable
@@ -2091,12 +2171,18 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_access(&self, a: ast::AccessExpr) -> Result<mir::Expression> {
-        let expr = self.algebrize_expression(*a.expr, true)?;
+        let expr = self.algebrize_expression(
+            *a.expr,
+            ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        )?;
         Ok(match *a.subfield {
             ast::Expression::StringConstructor(s) => self.construct_field_access_expr(expr, s)?,
             sf => mir::Expression::ScalarFunction(mir::ScalarFunctionApplication::new(
                 mir::ScalarFunction::ComputedFieldAccess,
-                vec![expr, self.algebrize_expression(sf, false)?],
+                vec![
+                    expr,
+                    self.algebrize_expression(sf, ExpressionContext::default())?,
+                ],
             )),
         })
     }
@@ -2105,8 +2191,11 @@ impl<'a> Algebrizer<'a> {
         // If the target_type is String, we do not implicitly convert the
         // expr since it is being asserted as a String. Otherwise, we do
         // attempt to convert.
+        let context = ExpressionContext {
+            in_implicit_type_conversion_ctx: t.target_type != ast::Type::String,
+        };
         Ok(mir::Expression::TypeAssertion(mir::TypeAssertionExpr {
-            expr: Box::new(self.algebrize_expression(*t.expr, t.target_type != ast::Type::String)?),
+            expr: Box::new(self.algebrize_expression(*t.expr, context)?),
             target_type: mir::Type::try_from(t.target_type)?,
         }))
     }
@@ -2117,7 +2206,7 @@ impl<'a> Algebrizer<'a> {
         let mut is_nullable = c.else_branch.is_none();
         let else_branch = c
             .else_branch
-            .map(|e| self.algebrize_expression(*e, false))
+            .map(|e| self.algebrize_expression(*e, ExpressionContext::default()))
             .transpose()?
             .inspect(|expr| {
                 is_nullable = is_nullable
@@ -2135,8 +2224,8 @@ impl<'a> Algebrizer<'a> {
             .clone()
             .into_iter()
             .map(|wb| {
-                let when = self.algebrize_expression(*wb.when, false)?;
-                let then = self.algebrize_expression(*wb.then, false)?;
+                let when = self.algebrize_expression(*wb.when, ExpressionContext::default())?;
+                let then = self.algebrize_expression(*wb.then, ExpressionContext::default())?;
                 let then_is_nullable = NULLISH
                     .satisfies(&then.schema(&self.schema_inference_state()).unwrap())
                     != Satisfaction::Not;
@@ -2154,11 +2243,15 @@ impl<'a> Algebrizer<'a> {
             })
             .collect::<Result<_>>()?;
 
-        // if all of the when branches have string schemas, we should not implicitly convert our expr if we have one, so that they may
-        // be compared directly. Otherwise, we algebrize the expr with implicit type conversion
+        // if all the `when` branches have string schemas, we should not implicitly convert our
+        // expr if we have one, so that they may be compared directly. Otherwise, we algebrize the
+        // expr in an implicit type conversion context.
+        let context = ExpressionContext {
+            in_implicit_type_conversion_ctx: !when_branches_all_strings,
+        };
         let expr = c
             .expr
-            .map(|e| self.algebrize_expression(*e, !when_branches_all_strings))
+            .map(|e| self.algebrize_expression(*e, context))
             .transpose()?;
 
         // if the expr exists and MUST satisfy string, we can use the previously algebrized when_branch without implicit type conversion;
@@ -2175,8 +2268,11 @@ impl<'a> Algebrizer<'a> {
                 .when_branch
                 .into_iter()
                 .map(|wb| {
-                    let when = self.algebrize_expression(*wb.when, true)?;
-                    let then = self.algebrize_expression(*wb.then, false)?;
+                    let when = self.algebrize_expression(
+                        *wb.when,
+                        ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                    )?;
+                    let then = self.algebrize_expression(*wb.then, ExpressionContext::default())?;
                     Ok(mir::WhenBranch {
                         is_nullable: NULLISH
                             .satisfies(&then.schema(&self.schema_inference_state())?)
@@ -2221,11 +2317,18 @@ impl<'a> Algebrizer<'a> {
             }
             Array | Boolean | Datetime | Decimal128 | Document | Double | Int32 | Int64 | Null
             | ObjectId | String => {
-                let expr = self.algebrize_expression(*c.expr, true)?;
-                let on_null =
-                    self.algebrize_expression(*(c.on_null.unwrap_or_else(|| null_expr!())), false)?;
-                let on_error = self
-                    .algebrize_expression(*(c.on_error.unwrap_or_else(|| null_expr!())), false)?;
+                let expr = self.algebrize_expression(
+                    *c.expr,
+                    ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                )?;
+                let on_null = self.algebrize_expression(
+                    *(c.on_null.unwrap_or_else(|| null_expr!())),
+                    ExpressionContext::default(),
+                )?;
+                let on_error = self.algebrize_expression(
+                    *(c.on_error.unwrap_or_else(|| null_expr!())),
+                    ExpressionContext::default(),
+                )?;
                 let is_nullable =
                     expr.is_nullable() || on_error.is_nullable() || on_null.is_nullable();
                 Ok(mir::Expression::Cast(mir::CastExpr {
@@ -2293,12 +2396,15 @@ impl<'a> Algebrizer<'a> {
         let (subquery_expr, subquery_schema) = self.algebrize_subquery_expr(*s.subquery)?;
 
         // If the schema of the subquery output field MUST satisfy STRING_OR_NULLISH,
-        // then we algebrize s.expr with in_implicit_type_conversion_context set to
-        // false because that means a String is expected. Otherwise, it is algebrized
-        // with that value set to true.
+        // then we algebrize s.expr with in_implicit_type_conversion_ctx set to false
+        // because that means a String is expected. Otherwise, it is algebrized with
+        // that value set to true.
         let is_nullable_string =
             subquery_schema.satisfies(&STRING_OR_NULLISH) == Satisfaction::Must;
-        let argument = self.algebrize_expression(*s.expr, !is_nullable_string)?;
+        let context = ExpressionContext {
+            in_implicit_type_conversion_ctx: !is_nullable_string,
+        };
+        let argument = self.algebrize_expression(*s.expr, context)?;
 
         // Determine the overall nullability of the subquery comparison expr.
         let arg_schema = argument.schema(&self.schema_inference_state())?;
@@ -2324,7 +2430,10 @@ impl<'a> Algebrizer<'a> {
         if let ast::Expression::Identifier(s) = *p.expr {
             return self.algebrize_possibly_qualified_field_access(s, p.subpath);
         }
-        let expr = self.algebrize_expression(*p.expr, true)?;
+        let expr = self.algebrize_expression(
+            *p.expr,
+            ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        )?;
         let expr_schema = expr.schema(&self.schema_inference_state())?;
         let is_nullable = NULLISH.satisfies(&expr_schema) != Satisfaction::Not
             || expr_schema.contains_field(&p.subpath) != Satisfaction::Must;

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -530,7 +530,7 @@ impl<'a> Algebrizer<'a> {
         let expression_algebrizer = self
             .with_merged_mappings(source.schema(&self.schema_inference_state())?.schema_env)?
             // We should not algebrize the select values body exprs in an implicit type conversion
-            // context since there is no sepcific type expected for these values.
+            // context since there is no specific type expected for these values.
             .with_implicit_type_conversion_ctx(false);
 
         // We must check for duplicate Datasource Keys, which is an error. The datasources
@@ -713,7 +713,7 @@ impl<'a> Algebrizer<'a> {
             return Err(Error::ArrayDatasourceMustBeLiteral);
         }
         // We should not algebrize the array element exprs in an implicit type conversion context
-        // since there is no sepcific type expected for these values.
+        // since there is no specific type expected for these values.
         let element_algebrizer = self.with_implicit_type_conversion_ctx(false);
         let src = mir::Stage::Array(mir::ArraySource {
             array: ve
@@ -1290,7 +1290,7 @@ impl<'a> Algebrizer<'a> {
             .clone()
             .with_merged_mappings(source.schema(&self.schema_inference_state())?.schema_env)?
             // We should not algebrize the sort key exprs in an implicit type conversion
-            // context since there is no sepcific type expected for these values.
+            // context since there is no specific type expected for these values.
             .with_implicit_type_conversion_ctx(false);
         let ordered = match ast_node {
             None => source,
@@ -1349,7 +1349,7 @@ impl<'a> Algebrizer<'a> {
                         source.schema(&self.schema_inference_state())?.schema_env,
                     )?
                     // We should not algebrize the group key exprs in an implicit type conversion
-                    // context since there is no sepcific type expected for these values.
+                    // context since there is no specific type expected for these values.
                     .with_implicit_type_conversion_ctx(false);
 
                 let mut group_clause_aliases = UniqueLinkedHashMap::new();
@@ -1443,7 +1443,7 @@ impl<'a> Algebrizer<'a> {
     }
 
     /// Algebrizes an `ast::Expression` node into a `mir::Expression` node. Callers must ensure
-    /// that the `Algeberizer`'s `expression_context` is set correctly for the given context of the
+    /// that the `Algebrizer`'s `expression_context` is set correctly for the given context of the
     /// `ast_node` being algebrized.
     pub fn algebrize_expression(&self, ast_node: ast::Expression) -> Result<mir::Expression> {
         match ast_node {
@@ -1911,7 +1911,7 @@ impl<'a> Algebrizer<'a> {
 
         // First, we must determine if the left and right operands each need to
         // be algebrized in an implicit type conversion context (this is done
-        // by toggling the bool argument to aglebrize_expression). The different
+        // by toggling the bool argument to algebrize_expression). The different
         // cases are detailed below.
         let (mut left, mut right) = match b.op {
             // Add, And, Div, Mul, Or, and Sub do not expect String operands, therefore we algebrize

--- a/mongosql/src/algebrizer/test/expressions/between.rs
+++ b/mongosql/src/algebrizer/test/expressions/between.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     simple,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -25,7 +25,7 @@ test_algebrize!(
 test_algebrize!(
     does_not_convert_ext_json_if_all_are_strings,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -59,7 +59,7 @@ test_algebrize!(
 test_algebrize!(
     convert_arg_and_min_ext_json_if_max_is_non_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -99,7 +99,7 @@ test_algebrize!(
 test_algebrize!(
     do_not_convert_arg_or_min_ext_json_if_max_is_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -143,7 +143,7 @@ test_algebrize!(
 test_algebrize!(
     convert_arg_and_max_ext_json_if_min_is_non_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -183,7 +183,7 @@ test_algebrize!(
 test_algebrize!(
     do_not_convert_arg_or_max_ext_json_if_min_is_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -227,7 +227,7 @@ test_algebrize!(
 test_algebrize!(
     convert_min_and_max_ext_json_if_arg_is_non_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -267,7 +267,7 @@ test_algebrize!(
 test_algebrize!(
     do_not_convert_min_or_max_ext_json_if_arg_is_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -311,7 +311,7 @@ test_algebrize!(
 test_algebrize!(
     convert_arg_ext_json_if_neither_min_nor_max_is_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -354,7 +354,7 @@ test_algebrize!(
 test_algebrize!(
     convert_arg_ext_json_if_one_of_min_or_max_is_non_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -397,7 +397,7 @@ test_algebrize!(
 test_algebrize!(
     do_not_convert_arg_ext_json_if_both_min_and_max_are_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -442,7 +442,7 @@ test_algebrize!(
 test_algebrize!(
     convert_min_ext_json_if_neither_arg_nor_max_is_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -485,7 +485,7 @@ test_algebrize!(
 test_algebrize!(
     convert_min_ext_json_if_one_of_arg_or_max_is_non_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -528,7 +528,7 @@ test_algebrize!(
 test_algebrize!(
     do_not_convert_min_ext_json_if_both_arg_and_max_are_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -573,7 +573,7 @@ test_algebrize!(
 test_algebrize!(
     convert_max_ext_json_if_neither_arg_nor_min_is_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -616,7 +616,7 @@ test_algebrize!(
 test_algebrize!(
     convert_max_ext_json_if_one_of_arg_or_min_is_non_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,
@@ -659,7 +659,7 @@ test_algebrize!(
 test_algebrize!(
     do_not_convert_max_ext_json_if_both_arg_and_min_are_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Between,

--- a/mongosql/src/algebrizer/test/expressions/binary.rs
+++ b/mongosql/src/algebrizer/test/expressions/binary.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     add_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Add,
@@ -24,7 +24,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     add_wrong_types,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Add",
         required: NUMERIC_OR_NULLISH.clone().into(),
@@ -42,7 +42,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     sub_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Sub,
@@ -63,7 +63,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     sub_wrong_types,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Sub",
         required: NUMERIC_OR_NULLISH.clone().into(),
@@ -81,7 +81,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     div_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Div,
@@ -102,7 +102,7 @@ test_algebrize!(
 test_algebrize!(
     cast_div_result_of_two_integers_to_integer,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Cast(mir::CastExpr {
         expr: Box::new(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
@@ -129,7 +129,7 @@ test_algebrize!(
 test_algebrize!(
     cast_div_result_of_long_and_integer_to_long,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Cast(mir::CastExpr {
         expr: Box::new(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
@@ -155,7 +155,7 @@ test_algebrize!(
 test_algebrize!(
     cast_implicit_converts_expr_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Cast(mir::CastExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(42))),
         to: mir::Type::String,
@@ -184,7 +184,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     div_wrong_types,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Div",
         required: NUMERIC_OR_NULLISH.clone().into(),
@@ -202,7 +202,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     mul_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Mul,
@@ -223,7 +223,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     mul_wrong_types,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Mul",
         required: NUMERIC_OR_NULLISH.clone().into(),
@@ -241,7 +241,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     concat_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Concat,
@@ -262,7 +262,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     concat_wrong_types,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Concat",
         required: STRING_OR_NULLISH.clone().into(),
@@ -280,7 +280,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     eq_bool_and_int,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Eq,
@@ -301,7 +301,7 @@ test_algebrize!(
 test_algebrize!(
     gt_bool_and_int,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Gt,
@@ -322,7 +322,7 @@ test_algebrize!(
 test_algebrize!(
     and_bool_and_int,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::And,
@@ -343,7 +343,7 @@ test_algebrize!(
 test_algebrize!(
     or_int_and_int,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Or,
@@ -364,7 +364,7 @@ test_algebrize!(
 test_algebrize!(
     add_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Add,
@@ -389,7 +389,7 @@ test_algebrize!(
 test_algebrize!(
     and_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::And,
@@ -414,7 +414,7 @@ test_algebrize!(
 test_algebrize!(
     div_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Div,
@@ -439,7 +439,7 @@ test_algebrize!(
 test_algebrize!(
     mul_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Mul,
@@ -464,7 +464,7 @@ test_algebrize!(
 test_algebrize!(
     or_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Or,
@@ -489,7 +489,7 @@ test_algebrize!(
 test_algebrize!(
     sub_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Sub,
@@ -514,7 +514,7 @@ test_algebrize!(
 test_algebrize!(
     concat_does_not_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Concat,
@@ -543,7 +543,7 @@ test_algebrize!(
 test_algebrize!(
     comp_with_two_strings_does_not_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Eq,
@@ -572,7 +572,7 @@ test_algebrize!(
 test_algebrize!(
     comp_with_left_that_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Gt,
@@ -609,7 +609,7 @@ test_algebrize!(
 test_algebrize!(
     comp_with_left_that_does_not_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Lt,
@@ -648,7 +648,7 @@ test_algebrize!(
 test_algebrize!(
     comp_with_right_that_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Gte,
@@ -685,7 +685,7 @@ test_algebrize!(
 test_algebrize!(
     comp_with_right_that_does_not_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Lte,
@@ -726,7 +726,7 @@ mod in_operator {
     test_algebrize!(
         in_operator_is_transformed_to_in_scalar_function,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
                 function: mir::ScalarFunction::In,
@@ -771,7 +771,7 @@ mod in_operator {
     test_algebrize!(
         not_in_operator_is_transformed_to_in_scalar_function,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
                 function: mir::ScalarFunction::NotIn,
@@ -816,7 +816,7 @@ mod in_operator {
     test_algebrize!(
         in_operator_translates_array_with_one_element,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
                 function: mir::ScalarFunction::In,
@@ -855,7 +855,7 @@ mod in_operator {
     test_algebrize!(
         in_operator_converts_type_when_left_is_extended_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
                 function: mir::ScalarFunction::In,
@@ -900,7 +900,7 @@ mod in_operator {
     test_algebrize!(
         in_operator_converts_rhs_strings_when_lhs_is_date_field,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
                 function: mir::ScalarFunction::In,
@@ -959,7 +959,7 @@ mod in_operator {
     test_algebrize!(
         in_operator_no_conversion_when_lhs_is_string_field_and_rhs_is_string_constructors,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
                 function: mir::ScalarFunction::In,
@@ -1004,7 +1004,7 @@ mod in_operator {
     test_algebrize!(
         in_operator_no_conversion_when_both_sides_are_string_constructors,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
                 function: mir::ScalarFunction::In,
@@ -1035,7 +1035,7 @@ mod in_operator {
     test_algebrize!(
         in_operator_no_conversion_when_neither_side_has_string_constructors,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
                 function: mir::ScalarFunction::In,
@@ -1082,7 +1082,7 @@ mod in_operator {
     test_algebrize!(
         in_operator_translates_rhs_on_per_element_basis,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::ScalarFunction(
             mir::ScalarFunctionApplication {
                 function: mir::ScalarFunction::In,

--- a/mongosql/src/algebrizer/test/expressions/case.rs
+++ b/mongosql/src/algebrizer/test/expressions/case.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     searched_case,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SearchedCase(mir::SearchedCaseExpr {
         when_branch: vec![mir::WhenBranch {
             when: Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
@@ -30,7 +30,7 @@ test_algebrize!(
 test_algebrize!(
     searched_case_no_else,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SearchedCase(mir::SearchedCaseExpr {
         when_branch: vec![mir::WhenBranch {
             when: Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
@@ -55,7 +55,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     searched_case_when_condition_is_not_bool,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "SearchedCase",
         required: BOOLEAN_OR_NULLISH.clone().into(),
@@ -76,7 +76,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     searched_case_nullable_then_expression_is_nullable,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SearchedCase(mir::SearchedCaseExpr {
         when_branch: vec![mir::WhenBranch {
             when: Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
@@ -101,7 +101,7 @@ test_algebrize!(
 test_algebrize!(
     searched_case_nullable_else_expression_is_nullable,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SearchedCase(mir::SearchedCaseExpr {
         when_branch: vec![mir::WhenBranch {
             when: Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
@@ -124,7 +124,7 @@ test_algebrize!(
 test_algebrize!(
     simple_case,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SimpleCase(mir::SimpleCaseExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
         when_branch: vec![mir::WhenBranch {
@@ -152,7 +152,7 @@ test_algebrize!(
 test_algebrize!(
     simple_case_no_else,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SimpleCase(mir::SimpleCaseExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
         when_branch: vec![mir::WhenBranch {
@@ -178,7 +178,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     simple_case_operand_and_when_operand_not_comparable,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(
         mir::schema::Error::InvalidComparison {
             name: "SimpleCase",
@@ -201,7 +201,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     simple_case_nullable_then_expression_is_nullable,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SimpleCase(mir::SimpleCaseExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
         when_branch: vec![mir::WhenBranch {
@@ -227,7 +227,7 @@ test_algebrize!(
 test_algebrize!(
     simple_case_nullable_else_expression_is_nullable,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SimpleCase(mir::SimpleCaseExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
         when_branch: vec![mir::WhenBranch {
@@ -253,7 +253,7 @@ test_algebrize!(
 test_algebrize!(
     simple_case_expr_not_string_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SimpleCase(mir::SimpleCaseExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
         when_branch: vec![mir::WhenBranch {
@@ -287,7 +287,7 @@ test_algebrize!(
 test_algebrize!(
     simple_case_string_expr_does_not_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SimpleCase(mir::SimpleCaseExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::String(
             "hello".to_string()
@@ -319,7 +319,7 @@ test_algebrize!(
 test_algebrize!(
     simple_case_where_all_strings_does_not_implicit_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SimpleCase(mir::SimpleCaseExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::String(
             "{\"$numberInt\": \"1\"}".to_string()
@@ -351,7 +351,7 @@ test_algebrize!(
 test_algebrize!(
     searched_case_implicit_converts_when_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::SearchedCase(mir::SearchedCaseExpr {
         when_branch: vec![mir::WhenBranch {
             when: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),

--- a/mongosql/src/algebrizer/test/expressions/date_function.rs
+++ b/mongosql/src/algebrizer/test/expressions/date_function.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     dateadd,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::DateFunction(
         mir::DateFunctionApplication {
             function: mir::DateFunction::Add,
@@ -36,7 +36,7 @@ test_algebrize!(
 test_algebrize!(
     datediff,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::DateFunction(
         mir::DateFunctionApplication {
             function: mir::DateFunction::Diff,
@@ -79,7 +79,7 @@ test_algebrize!(
 test_algebrize!(
     datetrunc,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::DateFunction(
         mir::DateFunctionApplication {
             function: mir::DateFunction::Trunc,
@@ -112,7 +112,7 @@ test_algebrize!(
 test_algebrize!(
     date_function_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::DateFunction(
         mir::DateFunctionApplication {
             function: mir::DateFunction::Add,

--- a/mongosql/src/algebrizer/test/expressions/extract.rs
+++ b/mongosql/src/algebrizer/test/expressions/extract.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     extract_year,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Year,
@@ -30,7 +30,7 @@ test_algebrize!(
 test_algebrize!(
     extract_month,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Month,
@@ -57,7 +57,7 @@ test_algebrize!(
 test_algebrize!(
     extract_day,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Day,
@@ -84,7 +84,7 @@ test_algebrize!(
 test_algebrize!(
     extract_hour,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Hour,
@@ -111,7 +111,7 @@ test_algebrize!(
 test_algebrize!(
     extract_minute,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Minute,
@@ -138,7 +138,7 @@ test_algebrize!(
 test_algebrize!(
     extract_second,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Second,
@@ -165,7 +165,7 @@ test_algebrize!(
 test_algebrize!(
     extract_millsecond,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Millisecond,
@@ -192,7 +192,7 @@ test_algebrize!(
 test_algebrize!(
     extract_day_of_year,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::DayOfYear,
@@ -219,7 +219,7 @@ test_algebrize!(
 test_algebrize!(
     extract_iso_week,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::IsoWeek,
@@ -246,7 +246,7 @@ test_algebrize!(
 test_algebrize!(
     extract_day_of_week,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::DayOfWeek,
@@ -273,7 +273,7 @@ test_algebrize!(
 test_algebrize!(
     extract_iso_weekday,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::IsoWeekday,
@@ -300,7 +300,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     extract_must_be_date,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Second",
         required: DATE_OR_NULLISH.clone().into(),
@@ -317,7 +317,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     extract_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Year,

--- a/mongosql/src/algebrizer/test/expressions/identifier_and_subpath.rs
+++ b/mongosql/src/algebrizer/test/expressions/identifier_and_subpath.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     qualified_ref_in_current_scope,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(("foo", 1u16).into())),
         field: "a".into(),
@@ -36,7 +36,7 @@ test_algebrize!(
 test_algebrize!(
     qualified_ref_in_super_scope,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(("foo", 0u16).into())),
         field: "a".into(),
@@ -69,7 +69,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_ref_may_exist_in_current_scope,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(("foo", 1u16).into())),
         field: "a".into(),
@@ -91,7 +91,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_ref_must_exist_in_current_scope,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(("foo", 1u16).into())),
         field: "a".into(),
@@ -113,7 +113,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_ref_may_exist_only_in_super_scope,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(("foo", 0u16).into())),
         field: "a".into(),
@@ -136,7 +136,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_ref_must_exist_in_super_scope,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(("foo", 0u16).into())),
         field: "a".into(),
@@ -159,7 +159,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_ref_must_exist_in_super_scope_bot_source,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(Key::bot(0u16).into())),
         field: "a".into(),
@@ -182,7 +182,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_ref_may_and_must_exist_in_two_sources_one_of_which_is_bot,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(Key::bot(1u16).into())),
         field: "a".into(),
@@ -212,7 +212,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_ref_must_exist_in_two_non_bot_sources,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::AmbiguousField(
         "a".into(),
         ClauseType::Unintialized,
@@ -243,7 +243,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_subpath_in_current_and_super_must_exist_in_current,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
             expr: Box::new(mir::Expression::Reference(("test", 1u16).into())),
@@ -290,7 +290,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_subpath_in_current_and_super_may_exist_is_ambiguous,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::AmbiguousField(
         "a".into(),
         ClauseType::Unintialized,
@@ -333,7 +333,7 @@ test_algebrize!(
 test_algebrize!(
     subpath_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Document(
             unchecked_unique_linked_hash_map! {
@@ -363,7 +363,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_subpath_in_super_scope,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
             expr: Box::new(mir::Expression::Reference(("super_test", 0u16).into())),
@@ -410,7 +410,7 @@ test_algebrize!(
 test_algebrize!(
     qualified_ref_prefers_super_datasource_to_local_field,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(("foo", 0u16).into())),
         field: "a".into(),
@@ -449,7 +449,7 @@ test_algebrize!(
 test_algebrize!(
     qualified_ref_to_local_field,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
             expr: Box::new(mir::Expression::Reference(("bar", 1u16).into())),
@@ -495,7 +495,7 @@ test_algebrize!(
 test_algebrize!(
     unqualified_reference_and_may_contain_sub_and_must_contain_outer_is_ambiguous,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::AmbiguousField(
         "a".into(),
         ClauseType::Unintialized,
@@ -539,7 +539,7 @@ test_algebrize!(
 test_algebrize!(
     ref_does_not_exist,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::FieldNotFound(
         "bar".into(),
         None,

--- a/mongosql/src/algebrizer/test/expressions/literal.rs
+++ b/mongosql/src/algebrizer/test/expressions/literal.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     null,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Literal(mir::LiteralValue::Null)),
     input = ast::Expression::Literal(ast::Literal::Null),
 );
@@ -11,7 +11,7 @@ test_algebrize!(
 test_algebrize!(
     expr_true,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
     input = ast::Expression::Literal(ast::Literal::Boolean(true)),
 );
@@ -19,7 +19,7 @@ test_algebrize!(
 test_algebrize!(
     expr_false,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Literal(mir::LiteralValue::Boolean(false))),
     input = ast::Expression::Literal(ast::Literal::Boolean(false)),
 );
@@ -27,7 +27,7 @@ test_algebrize!(
 test_algebrize!(
     string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Literal(mir::LiteralValue::String(
         "hello!".into(),
     ))),
@@ -37,7 +37,7 @@ test_algebrize!(
 test_algebrize!(
     int,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Literal(mir::LiteralValue::Integer(42))),
     input = ast::Expression::Literal(ast::Literal::Integer(42)),
 );
@@ -45,7 +45,7 @@ test_algebrize!(
 test_algebrize!(
     long,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Literal(mir::LiteralValue::Long(42))),
     input = ast::Expression::Literal(ast::Literal::Long(42)),
 );
@@ -53,7 +53,7 @@ test_algebrize!(
 test_algebrize!(
     double,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Literal(mir::LiteralValue::Double(42f64))),
     input = ast::Expression::Literal(ast::Literal::Double(42f64)),
 );
@@ -61,7 +61,7 @@ test_algebrize!(
 test_algebrize!(
     empty_array,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Array(vec![].into())),
     input = ast::Expression::Array(vec![]),
 );
@@ -69,7 +69,7 @@ test_algebrize!(
 test_algebrize!(
     nested_array,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Array(
         vec![mir::Expression::Array(
             vec![
@@ -89,7 +89,7 @@ test_algebrize!(
 test_algebrize!(
     empty_document,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Document(
         unchecked_unique_linked_hash_map! {}.into(),
     )),
@@ -99,7 +99,7 @@ test_algebrize!(
 test_algebrize!(
             nested_document,
             method = algebrize_expression,
-            in_implicit_type_conversion_context = false,
+            expression_context = ExpressionContext::default(),
             expected = Ok(mir::Expression::Document(
                 unchecked_unique_linked_hash_map! {
                     "foo2".into() => mir::Expression::Document(
@@ -119,7 +119,7 @@ test_algebrize!(
 test_algebrize!(
     document_with_keys_containing_dots_and_dollars,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Document(
         unchecked_unique_linked_hash_map! {
             "a.b".into() => mir::Expression::Literal(mir::LiteralValue::Integer(1)),
@@ -139,7 +139,7 @@ mod ext_json {
     test_algebrize!(
         array_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Array(
             vec![
                 mir::Expression::Literal(mir::LiteralValue::Integer(1)),
@@ -153,7 +153,7 @@ mod ext_json {
     test_algebrize!(
         bindata_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Binary(
             bson::Binary {
                 subtype: bson::spec::BinarySubtype::Uuid,
@@ -168,7 +168,7 @@ mod ext_json {
     test_algebrize!(
         boolean_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
         input = ast::Expression::StringConstructor("true".to_string()),
     );
@@ -176,7 +176,7 @@ mod ext_json {
     test_algebrize!(
         datetime_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::DateTime(
             "2019-08-11T17:54:14.692Z"
                 .parse::<chrono::DateTime<chrono::prelude::Utc>>()
@@ -191,7 +191,7 @@ mod ext_json {
     test_algebrize!(
         decimal128_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Decimal128(
             "10.99".parse().unwrap()
         ))),
@@ -201,7 +201,7 @@ mod ext_json {
     test_algebrize!(
                 document_string_to_ext_json,
                 method = algebrize_expression,
-                in_implicit_type_conversion_context = true,
+                expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
                 expected = Ok(mir::Expression::Document(
                     unchecked_unique_linked_hash_map! {
                         "x".into() => mir::Expression::Literal(mir::LiteralValue::Integer(3)),
@@ -214,7 +214,7 @@ mod ext_json {
     test_algebrize!(
         double_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Double(10.5))),
         input = ast::Expression::StringConstructor("10.5".to_string()),
     );
@@ -222,7 +222,7 @@ mod ext_json {
     test_algebrize!(
         int_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Long(3))),
         input = ast::Expression::StringConstructor("{\"$numberLong\": \"3\"}".to_string()),
     );
@@ -230,7 +230,7 @@ mod ext_json {
     test_algebrize!(
         javascript_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::JavaScriptCode(
             "code here".to_string()
         ))),
@@ -240,7 +240,7 @@ mod ext_json {
     test_algebrize!(
         javascript_with_scope_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(
             mir::LiteralValue::JavaScriptCodeWithScope(bson::JavaScriptCodeWithScope {
                 code: "code here".to_string(),
@@ -255,7 +255,7 @@ mod ext_json {
     test_algebrize!(
         maxkey_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::MaxKey)),
         input = ast::Expression::StringConstructor("{\"$maxKey\": 1}".to_string()),
     );
@@ -263,7 +263,7 @@ mod ext_json {
     test_algebrize!(
         minkey_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::MinKey)),
         input = ast::Expression::StringConstructor("{\"$minKey\": 1}".to_string()),
     );
@@ -271,7 +271,7 @@ mod ext_json {
     test_algebrize!(
         null_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Null)),
         input = ast::Expression::StringConstructor("null".to_string()),
     );
@@ -279,7 +279,7 @@ mod ext_json {
     test_algebrize!(
         objectid_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::ObjectId(
             bson::oid::ObjectId::parse_str("5ab9c3da31c2ab715d421285").unwrap()
         ))),
@@ -291,7 +291,7 @@ mod ext_json {
     test_algebrize!(
         regular_expression_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(
             mir::LiteralValue::RegularExpression(bson::Regex {
                 pattern: "pattern".to_string(),
@@ -306,7 +306,7 @@ mod ext_json {
     test_algebrize!(
         regular_string_stays_string_with_implicit_casting_true,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::String(
             "abc".to_string()
         ))),
@@ -316,7 +316,7 @@ mod ext_json {
     test_algebrize!(
         json_string_stays_string_with_implicit_casting_true,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::String(
             "'{this_doc_is_actually_a_string: 1}'".to_string()
         ))),
@@ -327,7 +327,7 @@ mod ext_json {
     test_algebrize!(
         symbol_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Symbol(
             "symbol".to_string()
         ))),
@@ -337,7 +337,7 @@ mod ext_json {
     test_algebrize!(
         timestamp_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Timestamp(
             bson::Timestamp {
                 time: 1,
@@ -352,7 +352,7 @@ mod ext_json {
     test_algebrize!(
         undefined_string_to_ext_json,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = true,
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Undefined)),
         input = ast::Expression::StringConstructor("{\"$undefined\": true}".to_string()),
     );
@@ -360,7 +360,7 @@ mod ext_json {
     test_algebrize!(
         ext_json_not_converted_when_conversion_false,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
+        expression_context = ExpressionContext::default(),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::String(
             "{\"$numberLong\": \"3\"}".to_string()
         ))),

--- a/mongosql/src/algebrizer/test/expressions/literal.rs
+++ b/mongosql/src/algebrizer/test/expressions/literal.rs
@@ -139,7 +139,7 @@ mod ext_json {
     test_algebrize!(
         array_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Array(
             vec![
                 mir::Expression::Literal(mir::LiteralValue::Integer(1)),
@@ -153,7 +153,7 @@ mod ext_json {
     test_algebrize!(
         bindata_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Binary(
             bson::Binary {
                 subtype: bson::spec::BinarySubtype::Uuid,
@@ -168,7 +168,7 @@ mod ext_json {
     test_algebrize!(
         boolean_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
         input = ast::Expression::StringConstructor("true".to_string()),
     );
@@ -176,7 +176,7 @@ mod ext_json {
     test_algebrize!(
         datetime_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::DateTime(
             "2019-08-11T17:54:14.692Z"
                 .parse::<chrono::DateTime<chrono::prelude::Utc>>()
@@ -191,7 +191,7 @@ mod ext_json {
     test_algebrize!(
         decimal128_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Decimal128(
             "10.99".parse().unwrap()
         ))),
@@ -201,7 +201,7 @@ mod ext_json {
     test_algebrize!(
                 document_string_to_ext_json,
                 method = algebrize_expression,
-                expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+                expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
                 expected = Ok(mir::Expression::Document(
                     unchecked_unique_linked_hash_map! {
                         "x".into() => mir::Expression::Literal(mir::LiteralValue::Integer(3)),
@@ -214,7 +214,7 @@ mod ext_json {
     test_algebrize!(
         double_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Double(10.5))),
         input = ast::Expression::StringConstructor("10.5".to_string()),
     );
@@ -222,7 +222,7 @@ mod ext_json {
     test_algebrize!(
         int_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Long(3))),
         input = ast::Expression::StringConstructor("{\"$numberLong\": \"3\"}".to_string()),
     );
@@ -230,7 +230,7 @@ mod ext_json {
     test_algebrize!(
         javascript_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::JavaScriptCode(
             "code here".to_string()
         ))),
@@ -240,7 +240,7 @@ mod ext_json {
     test_algebrize!(
         javascript_with_scope_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(
             mir::LiteralValue::JavaScriptCodeWithScope(bson::JavaScriptCodeWithScope {
                 code: "code here".to_string(),
@@ -255,7 +255,7 @@ mod ext_json {
     test_algebrize!(
         maxkey_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::MaxKey)),
         input = ast::Expression::StringConstructor("{\"$maxKey\": 1}".to_string()),
     );
@@ -263,7 +263,7 @@ mod ext_json {
     test_algebrize!(
         minkey_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::MinKey)),
         input = ast::Expression::StringConstructor("{\"$minKey\": 1}".to_string()),
     );
@@ -271,7 +271,7 @@ mod ext_json {
     test_algebrize!(
         null_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Null)),
         input = ast::Expression::StringConstructor("null".to_string()),
     );
@@ -279,7 +279,7 @@ mod ext_json {
     test_algebrize!(
         objectid_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::ObjectId(
             bson::oid::ObjectId::parse_str("5ab9c3da31c2ab715d421285").unwrap()
         ))),
@@ -291,7 +291,7 @@ mod ext_json {
     test_algebrize!(
         regular_expression_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(
             mir::LiteralValue::RegularExpression(bson::Regex {
                 pattern: "pattern".to_string(),
@@ -306,7 +306,7 @@ mod ext_json {
     test_algebrize!(
         regular_string_stays_string_with_implicit_casting_true,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::String(
             "abc".to_string()
         ))),
@@ -316,7 +316,7 @@ mod ext_json {
     test_algebrize!(
         json_string_stays_string_with_implicit_casting_true,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::String(
             "'{this_doc_is_actually_a_string: 1}'".to_string()
         ))),
@@ -327,7 +327,7 @@ mod ext_json {
     test_algebrize!(
         symbol_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Symbol(
             "symbol".to_string()
         ))),
@@ -337,7 +337,7 @@ mod ext_json {
     test_algebrize!(
         timestamp_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Timestamp(
             bson::Timestamp {
                 time: 1,
@@ -352,7 +352,7 @@ mod ext_json {
     test_algebrize!(
         undefined_string_to_ext_json,
         method = algebrize_expression,
-        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(),
+        expression_context = ExpressionContext::default().with_implicit_type_conversion_ctx(true),
         expected = Ok(mir::Expression::Literal(mir::LiteralValue::Undefined)),
         input = ast::Expression::StringConstructor("{\"$undefined\": true}".to_string()),
     );

--- a/mongosql/src/algebrizer/test/expressions/scalar_function.rs
+++ b/mongosql/src/algebrizer/test/expressions/scalar_function.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     standard_scalar_function,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Lower,
@@ -25,7 +25,7 @@ test_algebrize!(
 test_algebrize!(
     lower_scalar_function_does_not_implicit_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Lower,
@@ -47,7 +47,7 @@ test_algebrize!(
 test_algebrize!(
     replace,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Replace,
@@ -73,7 +73,7 @@ test_algebrize!(
 test_algebrize!(
     replace_null_one,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Replace,
@@ -99,7 +99,7 @@ test_algebrize!(
 test_algebrize!(
     replace_null_two,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Replace,
@@ -125,7 +125,7 @@ test_algebrize!(
 test_algebrize!(
     replace_null_three,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Replace,
@@ -151,7 +151,7 @@ test_algebrize!(
 test_algebrize!(
     replace_does_not_implicit_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Replace,
@@ -181,7 +181,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     replace_args_must_be_string_or_null,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Replace",
         required: STRING_OR_NULLISH.clone().into(),
@@ -203,7 +203,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     log_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Log,
@@ -227,7 +227,7 @@ test_algebrize!(
 test_algebrize!(
     log_bin_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Log,
@@ -251,7 +251,7 @@ test_algebrize!(
 test_algebrize!(
     round_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Round,
@@ -275,7 +275,7 @@ test_algebrize!(
 test_algebrize!(
     round_bin_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Round,
@@ -299,7 +299,7 @@ test_algebrize!(
 test_algebrize!(
     cos_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Cos,
@@ -319,7 +319,7 @@ test_algebrize!(
 test_algebrize!(
     cos_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Cos,
@@ -339,7 +339,7 @@ test_algebrize!(
 test_algebrize!(
     sin_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Sin,
@@ -359,7 +359,7 @@ test_algebrize!(
 test_algebrize!(
     sin_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Sin,
@@ -379,7 +379,7 @@ test_algebrize!(
 test_algebrize!(
     tan_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Tan,
@@ -399,7 +399,7 @@ test_algebrize!(
 test_algebrize!(
     tan_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Tan,
@@ -419,7 +419,7 @@ test_algebrize!(
 test_algebrize!(
     radians_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Radians,
@@ -439,7 +439,7 @@ test_algebrize!(
 test_algebrize!(
     radians_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Radians,
@@ -459,7 +459,7 @@ test_algebrize!(
 test_algebrize!(
     sqrt_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Sqrt,
@@ -479,7 +479,7 @@ test_algebrize!(
 test_algebrize!(
     sqrt_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Sqrt,
@@ -499,7 +499,7 @@ test_algebrize!(
 test_algebrize!(
     abs_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Abs,
@@ -519,7 +519,7 @@ test_algebrize!(
 test_algebrize!(
     abs_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Abs,
@@ -539,7 +539,7 @@ test_algebrize!(
 test_algebrize!(
     ceil_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Ceil,
@@ -559,7 +559,7 @@ test_algebrize!(
 test_algebrize!(
     ceil_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Ceil,
@@ -579,7 +579,7 @@ test_algebrize!(
 test_algebrize!(
     degrees_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Degrees,
@@ -599,7 +599,7 @@ test_algebrize!(
 test_algebrize!(
     degrees_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Degrees,
@@ -619,7 +619,7 @@ test_algebrize!(
 test_algebrize!(
     floor_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Floor,
@@ -639,7 +639,7 @@ test_algebrize!(
 test_algebrize!(
     floor_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Floor,
@@ -659,7 +659,7 @@ test_algebrize!(
 test_algebrize!(
     mod_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Mod,
@@ -683,7 +683,7 @@ test_algebrize!(
 test_algebrize!(
     mod_bin_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Mod,
@@ -707,7 +707,7 @@ test_algebrize!(
 test_algebrize!(
     pow_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Pow,
@@ -731,7 +731,7 @@ test_algebrize!(
 test_algebrize!(
     pow_bin_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Pow,
@@ -755,7 +755,7 @@ test_algebrize!(
 test_algebrize!(
     split_only_implicit_converts_third_arg,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Split,
@@ -785,7 +785,7 @@ test_algebrize!(
 test_algebrize!(
     substring_implicit_converts_last_two_args,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Substring,
@@ -813,7 +813,7 @@ test_algebrize!(
 test_algebrize!(
     nullif_two_strings_does_not_implicit_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::NullIf,
@@ -841,7 +841,7 @@ test_algebrize!(
 test_algebrize!(
     nullif_first_arg_string_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::NullIf,
@@ -865,7 +865,7 @@ test_algebrize!(
 test_algebrize!(
     nullif_second_arg_string_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::NullIf,
@@ -889,7 +889,7 @@ test_algebrize!(
 test_algebrize!(
     coalesce,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication::new(
             mir::ScalarFunction::Coalesce,
@@ -912,7 +912,7 @@ test_algebrize!(
 test_algebrize!(
     coalesce_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication::new(
             mir::ScalarFunction::Coalesce,
@@ -935,7 +935,7 @@ test_algebrize!(
 test_algebrize!(
     size_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Size,
@@ -957,7 +957,7 @@ test_algebrize!(
 test_algebrize!(
     size_unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Size,
@@ -979,7 +979,7 @@ test_algebrize!(
 test_algebrize!(
     slice_bin_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Slice,
@@ -1006,7 +1006,7 @@ test_algebrize!(
 test_algebrize!(
     slice_bin_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Slice,
@@ -1033,7 +1033,7 @@ test_algebrize!(
 test_algebrize!(
     day_of_week,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::DayOfWeek,
@@ -1053,7 +1053,7 @@ test_algebrize!(
 test_algebrize!(
     day_of_week_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::DayOfWeek,
@@ -1073,7 +1073,7 @@ test_algebrize!(
 test_algebrize!(
     bit_length_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::BitLength,
@@ -1093,7 +1093,7 @@ test_algebrize!(
 test_algebrize!(
     bit_length_unary_op_does_not_implicit_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::BitLength,
@@ -1115,7 +1115,7 @@ test_algebrize!(
 test_algebrize!(
     char_length_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::CharLength,
@@ -1135,7 +1135,7 @@ test_algebrize!(
 test_algebrize!(
     char_length_unary_op_does_not_implicit_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::CharLength,
@@ -1157,7 +1157,7 @@ test_algebrize!(
 test_algebrize!(
     octet_length_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::OctetLength,
@@ -1177,7 +1177,7 @@ test_algebrize!(
 test_algebrize!(
     octet_length_unary_op_does_not_implicit_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::OctetLength,
@@ -1199,7 +1199,7 @@ test_algebrize!(
 test_algebrize!(
     position_binary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Position,
@@ -1223,7 +1223,7 @@ test_algebrize!(
 test_algebrize!(
     position_binary_op_does_not_implicit_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Position,
@@ -1251,7 +1251,7 @@ test_algebrize!(
 test_algebrize!(
     upper_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Upper,
@@ -1273,7 +1273,7 @@ test_algebrize!(
 test_algebrize!(
     upper_unary_op_does_not_implicit_convert_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Upper,

--- a/mongosql/src/algebrizer/test/expressions/trim.rs
+++ b/mongosql/src/algebrizer/test/expressions/trim.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     ltrim,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::LTrim,
@@ -24,7 +24,7 @@ test_algebrize!(
 test_algebrize!(
     rtrim,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::RTrim,
@@ -45,7 +45,7 @@ test_algebrize!(
 test_algebrize!(
     btrim,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::BTrim,
@@ -66,7 +66,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     trim_arg_must_be_string_or_null,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "BTrim",
         required: STRING_OR_NULLISH.clone().into(),
@@ -84,7 +84,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize_expr_and_schema_check!(
     trim_escape_must_be_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "BTrim",
         required: STRING_OR_NULLISH.clone().into(),

--- a/mongosql/src/algebrizer/test/expressions/type_operators.rs
+++ b/mongosql/src/algebrizer/test/expressions/type_operators.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     cast_full,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Cast(mir::CastExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(42))),
         to: mir::Type::String,
@@ -30,7 +30,7 @@ test_algebrize!(
 test_algebrize!(
     cast_simple,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Cast(mir::CastExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(42))),
         to: mir::Type::String,
@@ -49,7 +49,7 @@ test_algebrize!(
 test_algebrize!(
     type_assert_success,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::TypeAssertion(mir::TypeAssertionExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(42))),
         target_type: mir::Type::Int32,
@@ -63,7 +63,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     type_assert_fail,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "::!",
         required: Schema::Atomic(Atomic::String).into(),
@@ -80,7 +80,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     type_assert_ext_json_string_does_not_convert_if_target_type_is_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::TypeAssertion(mir::TypeAssertionExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::String(
             "{\"$numberInt\": \"42\"}".to_string()
@@ -98,7 +98,7 @@ test_algebrize!(
 test_algebrize!(
     type_assert_ext_json_string_converts_if_target_type_is_not_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::TypeAssertion(mir::TypeAssertionExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(42))),
         target_type: mir::Type::Int32,
@@ -114,7 +114,7 @@ test_algebrize!(
 test_algebrize!(
     is_success,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Is(mir::IsExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(42))),
         target_type: mir::TypeOrMissing::Type(mir::Type::Int32),
@@ -128,7 +128,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     is_recursive_failure,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Add",
         required: NUMERIC_OR_NULLISH.clone().into(),
@@ -149,7 +149,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     is_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::Is(mir::IsExpr {
         expr: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(42))),
         target_type: mir::TypeOrMissing::Type(mir::Type::Int32),

--- a/mongosql/src/algebrizer/test/expressions/unary.rs
+++ b/mongosql/src/algebrizer/test/expressions/unary.rs
@@ -3,7 +3,7 @@ use super::*;
 test_algebrize!(
     neg_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Neg,
@@ -20,7 +20,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     neg_wrong_type,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Neg",
         required: NUMERIC_OR_NULLISH.clone().into(),
@@ -37,7 +37,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     pos_unary_op,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Pos,
@@ -54,7 +54,7 @@ test_algebrize!(
 test_algebrize_expr_and_schema_check!(
     pos_wrong_type,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::SchemaChecking(mir::schema::Error::SchemaChecking {
         name: "Pos",
         required: NUMERIC_OR_NULLISH.clone().into(),
@@ -71,7 +71,7 @@ test_algebrize_expr_and_schema_check!(
 test_algebrize!(
     unary_op_implicit_converts_ext_json,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::ScalarFunction(
         mir::ScalarFunctionApplication {
             function: mir::ScalarFunction::Neg,

--- a/mongosql/src/algebrizer/test/mod.rs
+++ b/mongosql/src/algebrizer/test/mod.rs
@@ -34,9 +34,10 @@ macro_rules! test_algebrize {
 
             #[allow(unused_mut, unused_assignments)]
             let mut algebrizer = Algebrizer::new("test".into(), &catalog, 0u16, schema_checking_mode, false, ClauseType::Unintialized);
-            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized);)?
+            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default());)?
+            $(algebrizer = algebrizer.with_expression_context($expression_context);)?
 
-            let res: Result<_, Error> = algebrizer.$method($ast $(, $source)? $(, $expression_context)? $(, $is_add_fields)?);
+            let res: Result<_, Error> = algebrizer.$method($ast $(, $source)? $(, $is_add_fields)?);
             $(assert!(matches!(res, $expected_pat));)?
             $(assert_eq!($expected, res);)?
 
@@ -71,9 +72,10 @@ macro_rules! test_algebrize_expr_and_schema_check {
 
             #[allow(unused_mut, unused_assignments)]
             let mut algebrizer = Algebrizer::new("test".into(), &catalog, 0u16, schema_checking_mode, false, ClauseType::Unintialized);
-            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized);)?
+            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default());)?
+            $(algebrizer = algebrizer.with_expression_context($expression_context);)?
 
-            let res: Result<_, Error> = algebrizer.$method($ast $(, $source)? $(, $expression_context)?);
+            let res: Result<_, Error> = algebrizer.$method($ast $(, $source)?);
             let res = res.unwrap().schema(&algebrizer.schema_inference_state()).map_err(|e|Error::SchemaChecking(e));
             $(assert_eq!($expected, res);)?
 

--- a/mongosql/src/algebrizer/test/mod.rs
+++ b/mongosql/src/algebrizer/test/mod.rs
@@ -14,12 +14,12 @@ use mongosql_datastructures::binding_tuple::Key;
 
 #[macro_export]
 macro_rules! test_algebrize {
-    ($func_name:ident, method = $method:ident, $(in_implicit_type_conversion_context = $in_implicit_type_conversion_context:expr,)? $(expected = $expected:expr,)? $(expected_pat = $expected_pat:pat,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)? $(is_add_fields = $is_add_fields:expr, )?) => {
+    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_pat = $expected_pat:pat,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)? $(is_add_fields = $is_add_fields:expr, )?) => {
         #[test]
         fn $func_name() {
             #[allow(unused_imports)]
             use $crate::{
-                algebrizer::{Algebrizer, Error, ClauseType},
+                algebrizer::{Algebrizer, ExpressionContext, Error, ClauseType},
                 catalog::Catalog,
                 SchemaCheckingMode,
             };
@@ -36,7 +36,7 @@ macro_rules! test_algebrize {
             let mut algebrizer = Algebrizer::new("test".into(), &catalog, 0u16, schema_checking_mode, false, ClauseType::Unintialized);
             $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized);)?
 
-            let res: Result<_, Error> = algebrizer.$method($ast $(, $source)? $(, $in_implicit_type_conversion_context)? $(, $is_add_fields)?);
+            let res: Result<_, Error> = algebrizer.$method($ast $(, $source)? $(, $expression_context)? $(, $is_add_fields)?);
             $(assert!(matches!(res, $expected_pat));)?
             $(assert_eq!($expected, res);)?
 
@@ -50,12 +50,12 @@ macro_rules! test_algebrize {
 
 #[macro_export]
 macro_rules! test_algebrize_expr_and_schema_check {
-    ($func_name:ident, method = $method:ident, $(in_implicit_type_conversion_context = $in_implicit_type_conversion_context:expr,)? $(expected = $expected:expr,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)?) => {
+    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)?) => {
         #[test]
         fn $func_name() {
             #[allow(unused)]
             use $crate::{
-                algebrizer::{Algebrizer, Error, ClauseType},
+                algebrizer::{Algebrizer, ExpressionContext, Error, ClauseType},
                 catalog::Catalog,
                 SchemaCheckingMode,
                 mir::schema::CachedSchema,
@@ -73,7 +73,7 @@ macro_rules! test_algebrize_expr_and_schema_check {
             let mut algebrizer = Algebrizer::new("test".into(), &catalog, 0u16, schema_checking_mode, false, ClauseType::Unintialized);
             $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized);)?
 
-            let res: Result<_, Error> = algebrizer.$method($ast $(, $source)? $(, $in_implicit_type_conversion_context)?);
+            let res: Result<_, Error> = algebrizer.$method($ast $(, $source)? $(, $expression_context)?);
             let res = res.unwrap().schema(&algebrizer.schema_inference_state()).map_err(|e|Error::SchemaChecking(e));
             $(assert_eq!($expected, res);)?
 

--- a/mongosql/src/algebrizer/test/subquery/mod.rs
+++ b/mongosql/src/algebrizer/test/subquery/mod.rs
@@ -39,7 +39,7 @@ lazy_static! {
 test_algebrize!(
     uncorrelated_exists,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::Exists(Box::new(Stage::Project(Project {
                         is_add_fields: false,
         source: Box::new(mir_array(1u16)),
@@ -71,7 +71,7 @@ test_algebrize!(
 test_algebrize!(
     correlated_exists,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::Exists(Box::new(Stage::Project(Project {
                         is_add_fields: false,
         source: Box::new(mir_array(2u16)),
@@ -117,7 +117,7 @@ test_algebrize!(
 test_algebrize!(
     exists_cardinality_gt_1,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::Exists(Box::new(Stage::Project(Project {
                         is_add_fields: false,
         source: Box::new(Stage::Array(ArraySource {
@@ -164,7 +164,7 @@ test_algebrize!(
 test_algebrize!(
     exists_degree_gt_1,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::Exists(
         Box::new(Stage::Project(Project {
             is_add_fields: false,
@@ -209,7 +209,7 @@ test_algebrize!(
 test_algebrize!(
     uncorrelated_subquery_expr,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::Subquery(SubqueryExpr {
         output_expr: Box::new(Expression::FieldAccess(FieldAccess {
             expr: Box::new(Expression::Reference((DatasourceName::Bottom, 1u16).into())),
@@ -253,7 +253,7 @@ test_algebrize!(
 test_algebrize!(
     correlated_subquery_expr,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::Subquery(SubqueryExpr {
         output_expr: Box::new(Expression::FieldAccess(FieldAccess {
             expr: Box::new(Expression::Reference((DatasourceName::Bottom, 2u16).into())),
@@ -307,7 +307,7 @@ test_algebrize!(
 test_algebrize!(
     degree_zero_unsat_output,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::InvalidSubqueryDegree),
     expected_error_code = 3022,
     input = ast::Expression::Subquery(Box::new(ast::Query::Select(Box::new(ast::SelectQuery {
@@ -330,7 +330,7 @@ test_algebrize!(
 test_algebrize!(
     substar_degree_eq_1,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::Subquery(SubqueryExpr {
         output_expr: Box::new(Expression::FieldAccess(FieldAccess {
             expr: Box::new(Expression::Reference(("arr", 1u16).into())),
@@ -368,7 +368,7 @@ test_algebrize!(
 test_algebrize!(
     select_values_degree_gt_1,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::InvalidSubqueryDegree),
     expected_error_code = 3022,
     input = ast::Expression::Subquery(Box::new(ast::Query::Select(Box::new(ast::SelectQuery {
@@ -403,7 +403,7 @@ test_algebrize!(
 test_algebrize!(
     star_degree_eq_1,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::Subquery(SubqueryExpr {
         output_expr: Box::new(Expression::FieldAccess(FieldAccess {
             expr: Box::new(Expression::Reference(("arr", 1u16).into())),
@@ -430,7 +430,7 @@ test_algebrize!(
 test_algebrize!(
     select_star_degree_gt_1,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::InvalidSubqueryDegree),
     expected_error_code = 3022,
     input = ast::Expression::Subquery(Box::new(ast::Query::Select(Box::new(ast::SelectQuery {
@@ -456,7 +456,7 @@ test_algebrize!(
 test_algebrize!(
     substar_degree_gt_1,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::InvalidSubqueryDegree),
     expected_error_code = 3022,
     input = ast::Expression::Subquery(Box::new(ast::Query::Select(Box::new(ast::SelectQuery {
@@ -486,7 +486,7 @@ test_algebrize!(
 test_algebrize!(
     uncorrelated_subquery_comparison_all,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::SubqueryComparison(SubqueryComparison {
         operator: SubqueryComparisonOp::Eq,
         modifier: SubqueryModifier::All,
@@ -543,7 +543,7 @@ test_algebrize!(
 test_algebrize!(
     uncorrelated_subquery_comparison_any,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::SubqueryComparison(SubqueryComparison {
         operator: SubqueryComparisonOp::Eq,
         modifier: SubqueryModifier::Any,
@@ -598,7 +598,7 @@ test_algebrize!(
 test_algebrize!(
     subquery_comparison_ext_json_arg_converted_if_subquery_is_not_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::SubqueryComparison(SubqueryComparison {
         operator: SubqueryComparisonOp::Eq,
         modifier: SubqueryModifier::Any,
@@ -655,7 +655,7 @@ test_algebrize!(
 test_algebrize!(
     subquery_comparison_ext_json_arg_not_converted_if_subquery_is_string,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::SubqueryComparison(SubqueryComparison {
         operator: SubqueryComparisonOp::Eq,
         modifier: SubqueryModifier::Any,
@@ -731,7 +731,7 @@ test_algebrize!(
 test_algebrize!(
     argument_from_super_scope,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::SubqueryComparison(SubqueryComparison {
         operator: SubqueryComparisonOp::Eq,
         modifier: SubqueryModifier::All,
@@ -800,7 +800,7 @@ test_algebrize!(
 test_algebrize!(
     argument_only_evaluated_in_super_scope,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Err(Error::FieldNotFound(
         "a".into(),
         None,
@@ -834,7 +834,7 @@ test_algebrize!(
 test_algebrize!(
     potentially_missing_column,
     method = algebrize_expression,
-    in_implicit_type_conversion_context = false,
+    expression_context = ExpressionContext::default(),
     expected = Ok(Expression::Subquery(SubqueryExpr {
         output_expr: Box::new(Expression::FieldAccess(FieldAccess {
             expr: Box::new(Expression::Reference((DatasourceName::Bottom, 1u16).into())),


### PR DESCRIPTION
This PR refactors the `algebrizer/definitions.rs` file so that expression-related context is passed via a field on the `Algebrizer` struct (`expression_context: ExpressionContext`) instead of via the `algebrize_*` method api (e.g., `algebrize_expression(&self, ast_node: ast::Expression, in_implicit_type_conversion_context: bool)`). This PR is a preliminary PR for the actual work of SQL-3293 which will introduce algebrization for the new higher order functions.

The reason this change is useful is because for higher order function algebrization I need to introduce additional expression-related context to the `Algebrizer`. The new context is whether or not we are in a higher order function's function argument, in which unqualified `ast::Expression::Identifier`s may be considered variables instead of fields. Instead of blowing up the `algebrize_*` method signatures with additional boolean arguments, I decided to create an `ExpressionContext` struct which will store expression-level context in the `Algebrizer` itself. I have work done locally already that extends `ExpressionContext` to support this new flag, but I omitted that from this PR since it is purely related to higher order function algebrization (which will be put up as a follow-up to this).

In the interest of keeping PRs more focused and keeping reviews a bit smaller, I am putting this up first and separately. This PR will block the follow-up until it is merged.