### PR TITLE
SQL-3363: Lateral join fix

### DIFF
--- a/mongosql/src/mir/optimizer/stage_movement/mod.rs
+++ b/mongosql/src/mir/optimizer/stage_movement/mod.rs
@@ -582,7 +582,12 @@ impl StageMovementVisitor<'_> {
             // Recall that the LHS (source) datasources are considered in-scope
             // inside the RHS (subquery) so this is safe.
             Stage::MqlIntrinsic(MqlStage::LateralJoin(ref n)) => {
-                let right_schema = n.subquery.schema(self.schema_state).unwrap();
+                let source_result_set = n.source.schema(self.schema_state).unwrap();
+                let state = self
+                    .schema_state
+                    .with_merged_schema_env(source_result_set.schema_env.clone());
+                let right_schema = n.subquery.schema(&state).unwrap();
+
                 // If this is a filter, we cannot move it, if the Join's JoinType is Left and any use is in the RHS.
                 // It is not semantically correct to merge WHERE conditions into lateral JOIN RHS clauses.
                 if (node.is_filter() && n.join_type == JoinType::Left) || node.is_sort() {

--- a/mongosql/src/mir/optimizer/stage_movement/mod.rs
+++ b/mongosql/src/mir/optimizer/stage_movement/mod.rs
@@ -712,10 +712,15 @@ impl StageMovementVisitor<'_> {
                         (_, true) => {
                             side = BubbleUpSide::Right;
                         }
-                        // This case is when we have a TRUE or FALSE filter, we want this to bubble
-                        // up both sides.
+
+                        // While there may be a few cases in which we could bubble up both sides,
+                        // there are also cases where the data sources are masked behind
+                        // multiple joins with correlated conditions.
+                        //
+                        // So to avoid the ambiguity, we always short out here if
+                        // neither side has the data source.
                         (false, false) => {
-                            side = BubbleUpSide::Both;
+                            return (node, false);
                         }
                     }
                 }

--- a/mongosql/src/mir/optimizer/stage_movement/test.rs
+++ b/mongosql/src/mir/optimizer/stage_movement/test.rs
@@ -1702,12 +1702,12 @@ test_move_stage_no_op!(
     cannot_move_filter_above_lateral_left_join_if_correlated_conditions,
     Stage::MqlIntrinsic(MqlStage::LateralJoin(LateralJoin {
         join_type: JoinType::Left,
-        source: mir_collection("foo", "bar"), // "Table3"
+        source: mir_collection("foo", "bar"),
         subquery: Box::new(Stage::Filter(Filter {
             source: Box::new(Stage::MqlIntrinsic(MqlStage::EquiJoin(EquiJoin {
                 join_type: JoinType::Inner,
-                source: mir_collection("foo", "bar2"), // "Table2"
-                from: mir_collection("foo", "bar3"),   // "Table7"
+                source: mir_collection("foo", "bar2"),
+                from: mir_collection("foo", "bar3"),
                 local_field: Box::new(mir_field_path("bar2", vec!["x", "a", "b"])),
                 foreign_field: Box::new(mir_field_path("bar3", vec!["d"])),
                 cache: SchemaCache::new(),

--- a/mongosql/src/mir/optimizer/stage_movement/test.rs
+++ b/mongosql/src/mir/optimizer/stage_movement/test.rs
@@ -41,7 +41,7 @@ lazy_static! {
                 required: set!{"x".to_string()},
                 additional_properties: false,
                 ..Default::default()
-                }
+            }
         ),
         ("foo", "bar2").into() => Schema::Document(
             schema::Document {
@@ -72,8 +72,18 @@ lazy_static! {
                 required: set!{"x".to_string()},
                 additional_properties: false,
                 ..Default::default()
-                }
-        )
+            }
+        ),
+        ("foo", "bar3").into() => Schema::Document(
+            schema::Document {
+                keys: map! {
+                    "d".to_string() => schema::Schema::Atomic(schema::Atomic::Integer),
+                },
+                required: set!{"d".to_string()},
+                additional_properties: false,
+                ..Default::default()
+            }
+        ),
     });
 }
 
@@ -1686,6 +1696,34 @@ test_move_stage_no_op!(
         specs: vec![SortSpecification::Asc(mir_field_path("bar", vec!["y"]))],
         cache: SchemaCache::new(),
     })
+);
+
+test_move_stage_no_op!(
+    cannot_move_filter_above_lateral_left_join_if_correlated_conditions,
+    Stage::MqlIntrinsic(MqlStage::LateralJoin(LateralJoin {
+        join_type: JoinType::Left,
+        source: mir_collection("foo", "bar"), // "Table3"
+        subquery: Box::new(Stage::Filter(Filter {
+            source: Box::new(Stage::MqlIntrinsic(MqlStage::EquiJoin(EquiJoin {
+                join_type: JoinType::Inner,
+                source: mir_collection("foo", "bar2"), // "Table2"
+                from: mir_collection("foo", "bar3"),   // "Table7"
+                local_field: Box::new(mir_field_path("bar2", vec!["x", "a", "b"])),
+                foreign_field: Box::new(mir_field_path("bar3", vec!["d"])),
+                cache: SchemaCache::new(),
+            }))),
+            condition: Expression::ScalarFunction(ScalarFunctionApplication {
+                function: ScalarFunction::Eq,
+                args: vec![
+                    *mir_field_access_multi_part("bar2", vec!["x", "a", "b"], false),
+                    *mir_field_access("bar", "y", false),
+                ],
+                is_nullable: false,
+            }),
+            cache: SchemaCache::new(),
+        })),
+        cache: SchemaCache::new(),
+    }))
 );
 
 test_move_stage!(


### PR DESCRIPTION
This PR fixes two somewhat related issues that may appear when chaining multiple `LateralJoin`s together with correlated conditions:

## `LateralJoin` Invalid Invariant

`LateralJoin`s might have the data source defined in only the left branch but used in the right branch. This caused a panic due to a "missing" schema definition for the data source.

## `StageMovement` Source Bubbling Non-Determinism

When deciding which branch of a multi-data-source stage to bubble up, the original code iterated over a `HashSet` (which does not have stable iteration guarantees) in a stateful way which caused queries to bubble non-deterministically. This caused the pipeline to differ between runs on the same query. 