### PR TITLE
SQL-3293: Implement algebrization for HigherOrderFunction expressions

### DIFF
--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -2782,11 +2782,11 @@ impl<'a> Algebrizer<'a> {
     fn algebrize_hof_common(
         &self,
         name: &'static str,
-        array: Box<ast::Expression>,
-        f: Box<ast::FunctionArgument>,
+        array: ast::Expression,
+        f: ast::FunctionArgument,
         hof_ctx: HigherOrderFunctionCtx,
     ) -> Result<(mir::Expression, mir::Expression, bool)> {
-        let array = self.algebrize_expression(*array).map_err(|e| {
+        let array = self.algebrize_expression(array).map_err(|e| {
             Self::wrap_error_in_hof_context(name, e, HigherOrderFunctionErrorCause::ArrayArg)
         })?;
 
@@ -2813,7 +2813,7 @@ impl<'a> Algebrizer<'a> {
         // Nullability is based only on the array argument. The function argument being nullable
         // does not affect the nullability of the Map expression, just the nullability of the
         // elements of the output array.
-        let is_nullable = Self::args_are_nullable(&[array.clone()]);
+        let is_nullable = Self::args_are_nullable(std::slice::from_ref(&array));
 
         Ok((array, f, is_nullable))
     }
@@ -2821,9 +2821,9 @@ impl<'a> Algebrizer<'a> {
     fn algebrize_hof_function_argument(
         &self,
         name: &'static str,
-        f: Box<ast::FunctionArgument>,
+        f: ast::FunctionArgument,
     ) -> Result<mir::Expression> {
-        match *f {
+        match f {
             ast::FunctionArgument::Expr(e) => self.algebrize_expression(e).map_err(|e| {
                 Self::wrap_error_in_hof_context(name, e, HigherOrderFunctionErrorCause::FunctionArg)
             }),
@@ -2835,7 +2835,7 @@ impl<'a> Algebrizer<'a> {
 
     fn algebrize_map(&self, expr: ast::MapExpr) -> Result<mir::Expression> {
         let (array, f, is_nullable) =
-            self.algebrize_hof_common("Map", expr.array, expr.f, HigherOrderFunctionCtx::Map)?;
+            self.algebrize_hof_common("Map", *expr.array, *expr.f, HigherOrderFunctionCtx::Map)?;
 
         Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
@@ -2849,8 +2849,8 @@ impl<'a> Algebrizer<'a> {
     fn algebrize_filter_expr(&self, expr: ast::FilterExpr) -> Result<mir::Expression> {
         let (array, f, is_nullable) = self.algebrize_hof_common(
             "Filter",
-            expr.array,
-            expr.f,
+            *expr.array,
+            *expr.f,
             HigherOrderFunctionCtx::Filter,
         )?;
 
@@ -2916,7 +2916,7 @@ impl<'a> Algebrizer<'a> {
             .with_variables(variables.clone());
 
         // Finally, algebrize the function argument.
-        let mut f = fn_algebrizer.algebrize_hof_function_argument("Reduce", expr.f.clone())?;
+        let mut f = fn_algebrizer.algebrize_hof_function_argument("Reduce", *expr.f.clone())?;
 
         // Now that we've algebrized the function argument, we may need to update the nullability of
         // any `value` Variable expressions in the function argument. This is because `value` only
@@ -2953,7 +2953,7 @@ impl<'a> Algebrizer<'a> {
             fn_algebrizer = fn_algebrizer.with_variables(variables);
 
             // Re-algebrize the function argument.
-            f = fn_algebrizer.algebrize_hof_function_argument("Reduce", expr.f)?;
+            f = fn_algebrizer.algebrize_hof_function_argument("Reduce", *expr.f)?;
         }
 
         // Nullability is based on all arguments. If any of them are nullable, the Reduce expression

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -283,6 +283,7 @@ impl ExpressionContext {
     pub(crate) fn with_implicit_type_conversion_ctx(self, value: bool) -> Self {
         Self {
             in_implicit_type_conversion_ctx: value,
+            ..self
         }
     }
 

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -1,4 +1,5 @@
 use crate::mir::ArrayExpr;
+use crate::schema::Schema;
 use crate::{
     algebrizer::errors::{Error, HigherOrderFunctionErrorCause},
     ast::{self, pretty_print::PrettyPrint},
@@ -242,24 +243,12 @@ pub struct Algebrizer<'a> {
     allow_order_by_missing_columns: bool,
     clause_type: RefCell<ClauseType>,
     expression_context: ExpressionContext,
-    variables: BTreeMap<&'static str, schema::Schema>,
-}
-
-/// HigherOrderFunctionCtx indicates the higher order function in which an expression is being
-/// algebrized, if any.
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Default)]
-pub(crate) enum HigherOrderFunctionCtx {
-    #[default]
-    None,
-    Map,
-    Filter,
-    Reduce,
 }
 
 /// ExpressionContext contains information about the context in which an expression is being
 /// algebrized. In certain contexts, certain ast::Expressions are resolved differently. See fields
 /// for more information.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct ExpressionContext {
     // Indicates if the expression is being algebrized in an implicit type conversion context.
     // An expression is "in an implicit type conversion context" whenever it appears in a place
@@ -268,15 +257,23 @@ pub(crate) struct ExpressionContext {
     // encoded string literals to the corresponding BSON type in these contexts.
     in_implicit_type_conversion_ctx: bool,
 
-    // Indicates if the expression is being algebrized in the context of a higher order function
-    // function-argument. For example, in the expression MAP(array, this + 1), when algebrizing the
-    // function-argument `this + 1`, we set this value to HigherOrderFunctionCtx::Map. When in a
-    // non-None context, certain unqualified identifiers are resolved to variables instead of field
-    // references. Specifically, in the Map and Filter contexts, unqualified identifiers with the
-    // value "this" are resolved to the variable `this`; in the Reduce context, unqualified
-    // identifiers with the value "this" or "value" are resolved to the variables `this` or `value`,
-    // respectively.
-    in_higher_order_function_arg_ctx: HigherOrderFunctionCtx,
+    // Tracks the variables available within the context of the expression being algebrized. An
+    // expression inherits its parent's variables. An expression may introduce new variables.
+    //
+    // Inherently, if an unqualified identifier is present in an ExpressionContext's variables
+    // mapping, it is assumed to be a variable. For example, in the expression MAP(array, this + 1),
+    // when algebrizing the function-argument `this + 1` we add the variable key "this" to this map.
+    //
+    // In the context of higher order functions, certain unqualified identifiers are resolved to
+    // variables instead of field references. Specifically, in Map and Filter contexts, unqualified
+    // identifiers with the value "this" are resolved to the variable `this`; in the Reduce context,
+    // unqualified identifiers with the value "this" or "value" are resolved to the variables `this`
+    // or `value`, respectively. It is possibly for higher order functions to be nested within each
+    // other. If they are nested, the innermost function's variables shadow the outer functions'
+    // variables, if they redefine those variables. For example, Filter does not redefine `value`,
+    // so if a Filter is nested in a Reduce, the `value` variable is still available in the context
+    // of the Filter and uses the inherited schema from the Reduce.
+    variables: BTreeMap<&'static str, schema::Schema>,
 }
 
 impl ExpressionContext {
@@ -287,11 +284,13 @@ impl ExpressionContext {
         }
     }
 
-    pub(crate) fn with_higher_order_function_arg_ctx(self, value: HigherOrderFunctionCtx) -> Self {
-        Self {
-            in_higher_order_function_arg_ctx: value,
-            ..self
-        }
+    pub(crate) fn with_variables(
+        self,
+        new_variables: &mut BTreeMap<&'static str, schema::Schema>,
+    ) -> Self {
+        let mut variables = self.variables.clone();
+        variables.append(new_variables);
+        Self { variables, ..self }
     }
 }
 
@@ -313,7 +312,6 @@ impl<'a> Algebrizer<'a> {
             allow_order_by_missing_columns,
             clause_type,
             ExpressionContext::default(),
-            map! {},
         )
     }
 
@@ -327,7 +325,6 @@ impl<'a> Algebrizer<'a> {
         allow_order_by_missing_columns: bool,
         clause_type: ClauseType,
         expression_context: ExpressionContext,
-        variables: BTreeMap<&'static str, schema::Schema>,
     ) -> Self {
         Self {
             current_db,
@@ -338,7 +335,6 @@ impl<'a> Algebrizer<'a> {
             allow_order_by_missing_columns,
             clause_type: RefCell::new(clause_type),
             expression_context,
-            variables,
         }
     }
 
@@ -348,7 +344,7 @@ impl<'a> Algebrizer<'a> {
             catalog: self.catalog,
             scope_level: self.scope_level,
             schema_checking_mode: self.schema_checking_mode,
-            variables: self.variables.clone(),
+            variables: self.expression_context.variables.clone(),
         }
     }
 
@@ -364,31 +360,8 @@ impl<'a> Algebrizer<'a> {
             // parent. It probably does not matter, but we do not want subqueries to modify parent
             // state.
             clause_type: RefCell::new(*self.clause_type.borrow()),
-            expression_context: self.expression_context,
-            variables: self.variables.clone(),
+            expression_context: self.expression_context.clone(),
         }
-    }
-
-    pub(crate) fn with_variables(&self, variables: BTreeMap<&'static str, schema::Schema>) -> Self {
-        Self {
-            current_db: self.current_db,
-            schema_env: self.schema_env.clone(),
-            catalog: self.catalog,
-            scope_level: self.scope_level,
-            schema_checking_mode: self.schema_checking_mode,
-            allow_order_by_missing_columns: self.allow_order_by_missing_columns,
-            clause_type: RefCell::new(*self.clause_type.borrow()),
-            expression_context: self.expression_context,
-            variables,
-        }
-    }
-
-    /// Gets the nullability of a variable. If the variable is not present, `true` is returned.
-    fn variable_is_nullable(&self, variable: &'static str) -> bool {
-        self.variables
-            .get(variable)
-            .map(|s| s.satisfies(&NULLISH) != Satisfaction::Not)
-            .unwrap_or(true)
     }
 
     pub(crate) fn with_expression_context(&self, context: ExpressionContext) -> Self {
@@ -401,22 +374,31 @@ impl<'a> Algebrizer<'a> {
             allow_order_by_missing_columns: self.allow_order_by_missing_columns,
             clause_type: RefCell::new(*self.clause_type.borrow()),
             expression_context: context,
-            variables: self.variables.clone(),
         }
     }
 
     fn with_implicit_type_conversion_ctx(&self, value: bool) -> Self {
         self.with_expression_context(
             self.expression_context
+                .clone()
                 .with_implicit_type_conversion_ctx(value),
         )
     }
 
-    fn with_higher_order_function_arg_ctx(&self, value: HigherOrderFunctionCtx) -> Self {
-        self.with_expression_context(
-            self.expression_context
-                .with_higher_order_function_arg_ctx(value),
-        )
+    fn with_variables(&self, variables: &mut BTreeMap<&'static str, schema::Schema>) -> Self {
+        self.with_expression_context(self.expression_context.clone().with_variables(variables))
+    }
+
+    /// Returns whether a variable is present in the ExpressionContext's variables map, and, if so,
+    /// if that variable is nullable.
+    fn contains_variable(&self, variable: &'static str) -> (bool, bool) {
+        let var_schema = self.expression_context.variables.get(variable);
+
+        if let Some(schema) = var_schema {
+            (true, schema.satisfies(&NULLISH) != Satisfaction::Not)
+        } else {
+            (false, false)
+        }
     }
 
     fn args_are_nullable(args: &[mir::Expression]) -> bool {
@@ -469,7 +451,7 @@ impl<'a> Algebrizer<'a> {
         Ok(Self {
             schema_env: Rc::new(merged_env),
             clause_type: RefCell::new(*self.clause_type.borrow()),
-            variables: self.variables.clone(),
+            expression_context: self.expression_context.clone(),
             ..*self
         })
     }
@@ -1087,8 +1069,7 @@ impl<'a> Algebrizer<'a> {
             self.schema_checking_mode,
             self.allow_order_by_missing_columns,
             *self.clause_type.borrow(),
-            self.expression_context,
-            self.variables.clone(),
+            self.expression_context.clone(),
         );
 
         let path = match path {
@@ -2597,27 +2578,27 @@ impl<'a> Algebrizer<'a> {
 
     fn algebrize_unqualified_identifier(&self, i: String) -> Result<mir::Expression> {
         // If we are in the context of a Higher Order Function, unqualified identifiers may be
-        // variables instead of fields. Specifically, an unqualified "this" is always considered a
-        // variable in the context of any Higher Order Function, and an unqualified "value" is
-        // considered a variable in the context of Reduce.
-        let (is_hof_variable, is_nullable) =
-            match self.expression_context.in_higher_order_function_arg_ctx {
-                HigherOrderFunctionCtx::Map | HigherOrderFunctionCtx::Filter => {
-                    (i == THIS_VARIABLE, self.variable_is_nullable(THIS_VARIABLE))
-                }
-
-                HigherOrderFunctionCtx::Reduce => (
-                    i == THIS_VARIABLE || i == VALUE_VARIABLE,
-                    (i == THIS_VARIABLE && self.variable_is_nullable(THIS_VARIABLE))
-                        || (i == VALUE_VARIABLE && self.variable_is_nullable(VALUE_VARIABLE)),
-                ),
-                HigherOrderFunctionCtx::None => (false, false),
-            };
-        if is_hof_variable {
-            return Ok(mir::Expression::Variable(mir::Variable {
-                name: i,
-                is_nullable,
-            }));
+        // variables instead of fields. If the identifier is present in the ExpressionContext's
+        // variables map, then we return a Variable expression. For now, we only support "this" and
+        // "value" as variables. For the sake of minor memory efficiency, we store variables as
+        // &'static str keys in the variables map. Since `i` is a `String`, we compare it to const
+        // values to do the lookup. Eventually, if we ever support user-provided variable names, we
+        // will update the variables mapping to use String keys and can do the lookup directly.
+        let var_lookup_name = if i == THIS_VARIABLE {
+            Some(THIS_VARIABLE)
+        } else if i == VALUE_VARIABLE {
+            Some(VALUE_VARIABLE)
+        } else {
+            None
+        };
+        if let Some(var_lookup_name) = var_lookup_name {
+            let (is_variable, is_nullable) = self.contains_variable(var_lookup_name);
+            if is_variable {
+                return Ok(mir::Expression::Variable(mir::Variable {
+                    name: i,
+                    is_nullable,
+                }));
+            }
         }
 
         // Attempt to find a datasource for this unqualified reference
@@ -2770,10 +2751,17 @@ impl<'a> Algebrizer<'a> {
         &self,
         expr: ast::HigherOrderFunctionExpr,
     ) -> Result<mir::Expression> {
+        // In general, we do not want to aglebrize higher order functions in an implicit type
+        // conversion context. We will not attempt to convert strings that represent arrays into
+        // actual arrays, as that may result in inadvertantly converting string _elements_ of arrays
+        // into their underlying types, which is unintended.
+        let expr_algebrizer = self.with_implicit_type_conversion_ctx(false);
         match expr {
-            ast::HigherOrderFunctionExpr::Map(expr) => self.algebrize_map(expr),
-            ast::HigherOrderFunctionExpr::Filter(expr) => self.algebrize_filter_expr(expr),
-            ast::HigherOrderFunctionExpr::Reduce(expr) => self.algebrize_reduce(expr),
+            ast::HigherOrderFunctionExpr::Map(expr) => expr_algebrizer.algebrize_map(expr),
+            ast::HigherOrderFunctionExpr::Filter(expr) => {
+                expr_algebrizer.algebrize_filter_expr(expr)
+            }
+            ast::HigherOrderFunctionExpr::Reduce(expr) => expr_algebrizer.algebrize_reduce(expr),
         }
     }
 
@@ -2785,7 +2773,6 @@ impl<'a> Algebrizer<'a> {
         name: &'static str,
         array: ast::Expression,
         f: ast::FunctionArgument,
-        hof_ctx: HigherOrderFunctionCtx,
     ) -> Result<(mir::Expression, mir::Expression, bool)> {
         let array = self.algebrize_expression(array).map_err(|e| {
             Self::wrap_error_in_hof_context(name, e, HigherOrderFunctionErrorCause::ArrayArg)
@@ -2803,16 +2790,14 @@ impl<'a> Algebrizer<'a> {
                     HigherOrderFunctionErrorCause::ArrayArg,
                 )
             })?
-            .get_array_item_schema();
+            .get_array_item_schema()
+            .unwrap_or(Schema::Any);
 
-        let mut fn_algebrizer = self.with_higher_order_function_arg_ctx(hof_ctx);
-        if let Some(this_schema) = this_schema {
-            fn_algebrizer = fn_algebrizer.with_variables(map! { THIS_VARIABLE => this_schema });
-        }
+        let fn_algebrizer = self.with_variables(&mut map! { THIS_VARIABLE => this_schema });
         let f = fn_algebrizer.algebrize_hof_function_argument(name, f)?;
 
         // Nullability is based only on the array argument. The function argument being nullable
-        // does not affect the nullability of the Map expression, just the nullability of the
+        // does not affect the nullability of the HOF expression, just the nullability of the
         // elements of the output array.
         let is_nullable = Self::args_are_nullable(std::slice::from_ref(&array));
 
@@ -2835,8 +2820,7 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_map(&self, expr: ast::MapExpr) -> Result<mir::Expression> {
-        let (array, f, is_nullable) =
-            self.algebrize_hof_common("Map", *expr.array, *expr.f, HigherOrderFunctionCtx::Map)?;
+        let (array, f, is_nullable) = self.algebrize_hof_common("Map", *expr.array, *expr.f)?;
 
         Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
@@ -2848,12 +2832,7 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_filter_expr(&self, expr: ast::FilterExpr) -> Result<mir::Expression> {
-        let (array, f, is_nullable) = self.algebrize_hof_common(
-            "Filter",
-            *expr.array,
-            *expr.f,
-            HigherOrderFunctionCtx::Filter,
-        )?;
+        let (array, f, is_nullable) = self.algebrize_hof_common("Filter", *expr.array, *expr.f)?;
 
         Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
@@ -2882,7 +2861,8 @@ impl<'a> Algebrizer<'a> {
                     HigherOrderFunctionErrorCause::ArrayArg,
                 )
             })?
-            .get_array_item_schema();
+            .get_array_item_schema()
+            .unwrap_or(Schema::Any);
 
         // Next, algebrize the initial value.
         let init_value = self.algebrize_expression(*expr.init_value).map_err(|e| {
@@ -2907,14 +2887,11 @@ impl<'a> Algebrizer<'a> {
             })?;
 
         // Create an Algebrizer with the appropriate state for algebrizing the function argument.
-        let mut variables: BTreeMap<&'static str, schema::Schema> =
-            map! { VALUE_VARIABLE => init_value_schema.clone() };
-        if let Some(this_schema) = this_schema {
-            variables.insert(THIS_VARIABLE, this_schema);
-        }
-        let mut fn_algebrizer = self
-            .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce)
-            .with_variables(variables.clone());
+        let mut variables: BTreeMap<&'static str, schema::Schema> = map! {
+            THIS_VARIABLE => this_schema.clone(),
+            VALUE_VARIABLE => init_value_schema.clone()
+        };
+        let mut fn_algebrizer = self.with_variables(&mut variables);
 
         // Finally, algebrize the function argument.
         let mut f = fn_algebrizer.algebrize_hof_function_argument("Reduce", *expr.f.clone())?;
@@ -2948,10 +2925,13 @@ impl<'a> Algebrizer<'a> {
             && f_value_schema.satisfies(&NULLISH) != Satisfaction::Not
         {
             // Overwrite the `value` variable schema with the `f` schema.
-            variables.insert(VALUE_VARIABLE, f_value_schema.clone());
+            let mut variables: BTreeMap<&'static str, schema::Schema> = map! {
+                THIS_VARIABLE => this_schema.clone(),
+                VALUE_VARIABLE => f_value_schema.clone()
+            };
 
             // Update the function algebrizer with the updated variables.
-            fn_algebrizer = fn_algebrizer.with_variables(variables);
+            fn_algebrizer = fn_algebrizer.with_variables(&mut variables);
 
             // Re-algebrize the function argument.
             f = fn_algebrizer.algebrize_hof_function_argument("Reduce", *expr.f)?;

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -2776,33 +2776,39 @@ impl<'a> Algebrizer<'a> {
         }
     }
 
-    fn algebrize_map(&self, expr: ast::MapExpr) -> Result<mir::Expression> {
-        let array = self.algebrize_expression(*expr.array).map_err(|e| {
-            Self::wrap_error_in_hof_context("Map", e, HigherOrderFunctionErrorCause::ArrayArg)
+    fn algebrize_hof_common(
+        &self,
+        name: &'static str,
+        array: Box<ast::Expression>,
+        f: Box<ast::FunctionArgument>,
+        hof_ctx: HigherOrderFunctionCtx,
+    ) -> Result<(mir::Expression, mir::Expression, bool)> {
+        let array = self.algebrize_expression(*array).map_err(|e| {
+            Self::wrap_error_in_hof_context(name, e, HigherOrderFunctionErrorCause::ArrayArg)
         })?;
 
-        // Determine the schema of the `this` variable in the function argument.
+        // Determine the schema of the `this` variable in the function argument. This is used to
+        // determine the `is_nullable` value for any `this` Variable expressions.
         let this_schema = array
             .schema(&self.schema_inference_state())
             .map_err(|e| {
                 Self::wrap_error_in_hof_context(
-                    "Map",
+                    name,
                     e.into(),
                     HigherOrderFunctionErrorCause::ArrayArg,
                 )
             })?
             .get_array_item_schema();
 
-        let mut fn_algebrizer =
-            self.with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map);
+        let mut fn_algebrizer = self.with_higher_order_function_arg_ctx(hof_ctx);
         if let Some(this_schema) = this_schema {
             fn_algebrizer = fn_algebrizer.with_variables(map! { THIS_VARIABLE => this_schema });
         }
-        let f = match *expr.f {
+        let f = match *f {
             ast::FunctionArgument::Expr(e) => {
                 fn_algebrizer.algebrize_expression(e).map_err(|e| {
                     Self::wrap_error_in_hof_context(
-                        "Map",
+                        name,
                         e,
                         HigherOrderFunctionErrorCause::FunctionArg,
                     )
@@ -2817,6 +2823,13 @@ impl<'a> Algebrizer<'a> {
         // does not affect the nullability of the Map expression, just the nullability of the
         // elements of the output array.
         let is_nullable = Self::args_are_nullable(&[array.clone()]);
+
+        Ok((array, f, is_nullable))
+    }
+
+    fn algebrize_map(&self, expr: ast::MapExpr) -> Result<mir::Expression> {
+        let (array, f, is_nullable) =
+            self.algebrize_hof_common("Map", expr.array, expr.f, HigherOrderFunctionCtx::Map)?;
 
         Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
@@ -2828,46 +2841,12 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_filter_expr(&self, expr: ast::FilterExpr) -> Result<mir::Expression> {
-        let array = self.algebrize_expression(*expr.array).map_err(|e| {
-            Self::wrap_error_in_hof_context("Filter", e, HigherOrderFunctionErrorCause::ArrayArg)
-        })?;
-
-        // Determine the schema of the `this` variable in the function argument.
-        let this_schema = array
-            .schema(&self.schema_inference_state())
-            .map_err(|e| {
-                Self::wrap_error_in_hof_context(
-                    "Map",
-                    e.into(),
-                    HigherOrderFunctionErrorCause::ArrayArg,
-                )
-            })?
-            .get_array_item_schema();
-
-        let mut fn_algebrizer =
-            self.with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map);
-        if let Some(this_schema) = this_schema {
-            fn_algebrizer = fn_algebrizer.with_variables(map! { THIS_VARIABLE => this_schema });
-        }
-        let f = match *expr.f {
-            ast::FunctionArgument::Expr(e) => {
-                fn_algebrizer.algebrize_expression(e).map_err(|e| {
-                    Self::wrap_error_in_hof_context(
-                        "Filter",
-                        e,
-                        HigherOrderFunctionErrorCause::FunctionArg,
-                    )
-                })?
-            }
-            ast::FunctionArgument::NamedFunction(f) => {
-                unreachable!("{:?} should have been rewritten", f)
-            }
-        };
-
-        // Nullability is based only on the array argument. The function argument being nullable
-        // does not affect the nullability of the Map expression, just the nullability of the
-        // elements of the output array.
-        let is_nullable = Self::args_are_nullable(&[array.clone()]);
+        let (array, f, is_nullable) = self.algebrize_hof_common(
+            "Filter",
+            expr.array,
+            expr.f,
+            HigherOrderFunctionCtx::Filter,
+        )?;
 
         Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -17,7 +17,11 @@ use crate::{
     util::unique_linked_hash_map::UniqueLinkedHashMap,
     SchemaCheckingMode,
 };
-use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet},
+    rc::Rc,
+};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -238,19 +242,18 @@ pub struct Algebrizer<'a> {
     allow_order_by_missing_columns: bool,
     clause_type: RefCell<ClauseType>,
     expression_context: ExpressionContext,
+    variables: BTreeMap<&'static str, schema::Schema>,
 }
 
 /// HigherOrderFunctionCtx indicates the higher order function in which an expression is being
-/// algebrized, if any. For `Map` and `Filter` contexts, the boolean value indicates the nullability
-/// of the `this` variable; for `Reduce` contexts, the boolean values indicate the nullability of
-/// the `this` and `value` variables, respectively.
+/// algebrized, if any.
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Default)]
 pub(crate) enum HigherOrderFunctionCtx {
     #[default]
     None,
-    Map(bool),
-    Filter(bool),
-    Reduce(bool, bool),
+    Map,
+    Filter,
+    Reduce,
 }
 
 /// ExpressionContext contains information about the context in which an expression is being
@@ -309,6 +312,7 @@ impl<'a> Algebrizer<'a> {
             allow_order_by_missing_columns,
             clause_type,
             ExpressionContext::default(),
+            map! {},
         )
     }
 
@@ -322,6 +326,7 @@ impl<'a> Algebrizer<'a> {
         allow_order_by_missing_columns: bool,
         clause_type: ClauseType,
         expression_context: ExpressionContext,
+        variables: BTreeMap<&'static str, schema::Schema>,
     ) -> Self {
         Self {
             current_db,
@@ -332,6 +337,7 @@ impl<'a> Algebrizer<'a> {
             allow_order_by_missing_columns,
             clause_type: RefCell::new(clause_type),
             expression_context,
+            variables,
         }
     }
 
@@ -341,7 +347,7 @@ impl<'a> Algebrizer<'a> {
             catalog: self.catalog,
             scope_level: self.scope_level,
             schema_checking_mode: self.schema_checking_mode,
-            variables: map! {},
+            variables: self.variables.clone(),
         }
     }
 
@@ -358,7 +364,30 @@ impl<'a> Algebrizer<'a> {
             // state.
             clause_type: RefCell::new(*self.clause_type.borrow()),
             expression_context: self.expression_context,
+            variables: self.variables.clone(),
         }
+    }
+
+    pub(crate) fn with_variables(&self, variables: BTreeMap<&'static str, schema::Schema>) -> Self {
+        Self {
+            current_db: self.current_db,
+            schema_env: self.schema_env.clone(),
+            catalog: self.catalog,
+            scope_level: self.scope_level,
+            schema_checking_mode: self.schema_checking_mode,
+            allow_order_by_missing_columns: self.allow_order_by_missing_columns,
+            clause_type: RefCell::new(*self.clause_type.borrow()),
+            expression_context: self.expression_context,
+            variables,
+        }
+    }
+
+    /// Gets the nullability of a variable. If the variable is not present, `true` is returned.
+    fn variable_is_nullable(&self, variable: &'static str) -> bool {
+        self.variables
+            .get(variable)
+            .map(|s| s.satisfies(&NULLISH) != Satisfaction::Not)
+            .unwrap_or(true)
     }
 
     pub(crate) fn with_expression_context(&self, context: ExpressionContext) -> Self {
@@ -371,6 +400,7 @@ impl<'a> Algebrizer<'a> {
             allow_order_by_missing_columns: self.allow_order_by_missing_columns,
             clause_type: RefCell::new(*self.clause_type.borrow()),
             expression_context: context,
+            variables: self.variables.clone(),
         }
     }
 
@@ -438,6 +468,7 @@ impl<'a> Algebrizer<'a> {
         Ok(Self {
             schema_env: Rc::new(merged_env),
             clause_type: RefCell::new(*self.clause_type.borrow()),
+            variables: self.variables.clone(),
             ..*self
         })
     }
@@ -1056,6 +1087,7 @@ impl<'a> Algebrizer<'a> {
             self.allow_order_by_missing_columns,
             *self.clause_type.borrow(),
             self.expression_context,
+            self.variables.clone(),
         );
 
         let path = match path {
@@ -2569,12 +2601,14 @@ impl<'a> Algebrizer<'a> {
         // considered a variable in the context of Reduce.
         let (is_hof_variable, is_nullable) =
             match self.expression_context.in_higher_order_function_arg_ctx {
-                HigherOrderFunctionCtx::Map(is_nullable)
-                | HigherOrderFunctionCtx::Filter(is_nullable) => (i == THIS_VARIABLE, is_nullable),
-                HigherOrderFunctionCtx::Reduce(this_is_nullable, value_is_nullable) => (
+                HigherOrderFunctionCtx::Map | HigherOrderFunctionCtx::Filter => {
+                    (i == THIS_VARIABLE, self.variable_is_nullable(THIS_VARIABLE))
+                }
+
+                HigherOrderFunctionCtx::Reduce => (
                     i == THIS_VARIABLE || i == VALUE_VARIABLE,
-                    (i == THIS_VARIABLE && this_is_nullable)
-                        || (i == VALUE_VARIABLE && value_is_nullable),
+                    (i == THIS_VARIABLE && self.variable_is_nullable(THIS_VARIABLE))
+                        || (i == VALUE_VARIABLE && self.variable_is_nullable(VALUE_VARIABLE)),
                 ),
                 HigherOrderFunctionCtx::None => (false, false),
             };
@@ -2747,9 +2781,8 @@ impl<'a> Algebrizer<'a> {
             Self::wrap_error_in_hof_context("Map", e, HigherOrderFunctionErrorCause::ArrayArg)
         })?;
 
-        // Determine the nullability of the `this` variable in the function argument. If the array
-        // item schema is nullable, the `this` variable is nullable.
-        let this_nullability = array
+        // Determine the schema of the `this` variable in the function argument.
+        let this_schema = array
             .schema(&self.schema_inference_state())
             .map_err(|e| {
                 Self::wrap_error_in_hof_context(
@@ -2758,12 +2791,13 @@ impl<'a> Algebrizer<'a> {
                     HigherOrderFunctionErrorCause::ArrayArg,
                 )
             })?
-            .get_array_item_schema()
-            .map(|s| s.satisfies(&NULLISH) != Satisfaction::Not)
-            .unwrap_or(false);
+            .get_array_item_schema();
 
-        let fn_algebrizer =
-            self.with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map(this_nullability));
+        let mut fn_algebrizer =
+            self.with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map);
+        if let Some(this_schema) = this_schema {
+            fn_algebrizer = fn_algebrizer.with_variables(map! { THIS_VARIABLE => this_schema });
+        }
         let f = match *expr.f {
             ast::FunctionArgument::Expr(e) => {
                 fn_algebrizer.algebrize_expression(e).map_err(|e| {
@@ -2794,7 +2828,54 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_filter_expr(&self, expr: ast::FilterExpr) -> Result<mir::Expression> {
-        todo!()
+        let array = self.algebrize_expression(*expr.array).map_err(|e| {
+            Self::wrap_error_in_hof_context("Filter", e, HigherOrderFunctionErrorCause::ArrayArg)
+        })?;
+
+        // Determine the schema of the `this` variable in the function argument.
+        let this_schema = array
+            .schema(&self.schema_inference_state())
+            .map_err(|e| {
+                Self::wrap_error_in_hof_context(
+                    "Map",
+                    e.into(),
+                    HigherOrderFunctionErrorCause::ArrayArg,
+                )
+            })?
+            .get_array_item_schema();
+
+        let mut fn_algebrizer =
+            self.with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map);
+        if let Some(this_schema) = this_schema {
+            fn_algebrizer = fn_algebrizer.with_variables(map! { THIS_VARIABLE => this_schema });
+        }
+        let f = match *expr.f {
+            ast::FunctionArgument::Expr(e) => {
+                fn_algebrizer.algebrize_expression(e).map_err(|e| {
+                    Self::wrap_error_in_hof_context(
+                        "Filter",
+                        e,
+                        HigherOrderFunctionErrorCause::FunctionArg,
+                    )
+                })?
+            }
+            ast::FunctionArgument::NamedFunction(f) => {
+                unreachable!("{:?} should have been rewritten", f)
+            }
+        };
+
+        // Nullability is based only on the array argument. The function argument being nullable
+        // does not affect the nullability of the Map expression, just the nullability of the
+        // elements of the output array.
+        let is_nullable = Self::args_are_nullable(&[array.clone()]);
+
+        Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
+                array: Box::new(array),
+                f: Box::new(f),
+                is_nullable,
+            }),
+        ))
     }
 
     fn algebrize_reduce(&self, expr: ast::ReduceExpr) -> Result<mir::Expression> {

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -1488,7 +1488,7 @@ impl<'a> Algebrizer<'a> {
             ast::Expression::Subquery(s) => self.algebrize_subquery(*s),
             ast::Expression::SubqueryComparison(s) => self.algebrize_subquery_comparison(s),
             ast::Expression::Exists(e) => self.algebrize_exists(*e),
-            ast::Expression::HigherOrderFunction(_) => unimplemented!("SQL-3293"),
+            ast::Expression::HigherOrderFunction(h) => self.algebrize_higher_order_function(h),
         }
     }
 
@@ -2670,6 +2670,29 @@ impl<'a> Algebrizer<'a> {
             // Otherwise, check the next highest scope.
             current_scope -= 1;
         }
+    }
+
+    fn algebrize_higher_order_function(
+        &self,
+        expr: ast::HigherOrderFunctionExpr,
+    ) -> Result<mir::Expression> {
+        match expr {
+            ast::HigherOrderFunctionExpr::Map(expr) => self.algebrize_map(expr),
+            ast::HigherOrderFunctionExpr::Filter(expr) => self.algebrize_filter_expr(expr),
+            ast::HigherOrderFunctionExpr::Reduce(expr) => self.algebrize_reduce(expr),
+        }
+    }
+
+    fn algebrize_map(&self, expr: ast::MapExpr) -> Result<mir::Expression> {
+        todo!()
+    }
+
+    fn algebrize_filter_expr(&self, expr: ast::FilterExpr) -> Result<mir::Expression> {
+        todo!()
+    }
+
+    fn algebrize_reduce(&self, expr: ast::ReduceExpr) -> Result<mir::Expression> {
+        todo!()
     }
 }
 

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -2776,6 +2776,9 @@ impl<'a> Algebrizer<'a> {
         }
     }
 
+    /// Common algebrization for Map and Filter. Reduce requires some extra steps, such as initial
+    /// value algebrization and potential function argument re-algebrization. Given that, Reduce
+    /// does not use this method.
     fn algebrize_hof_common(
         &self,
         name: &'static str,
@@ -2788,7 +2791,8 @@ impl<'a> Algebrizer<'a> {
         })?;
 
         // Determine the schema of the `this` variable in the function argument. This is used to
-        // determine the `is_nullable` value for any `this` Variable expressions.
+        // determine the `is_nullable` value for any `this` Variable expressions in the function
+        // argument.
         let this_schema = array
             .schema(&self.schema_inference_state())
             .map_err(|e| {
@@ -2804,20 +2808,7 @@ impl<'a> Algebrizer<'a> {
         if let Some(this_schema) = this_schema {
             fn_algebrizer = fn_algebrizer.with_variables(map! { THIS_VARIABLE => this_schema });
         }
-        let f = match *f {
-            ast::FunctionArgument::Expr(e) => {
-                fn_algebrizer.algebrize_expression(e).map_err(|e| {
-                    Self::wrap_error_in_hof_context(
-                        name,
-                        e,
-                        HigherOrderFunctionErrorCause::FunctionArg,
-                    )
-                })?
-            }
-            ast::FunctionArgument::NamedFunction(f) => {
-                unreachable!("{:?} should have been rewritten", f)
-            }
-        };
+        let f = fn_algebrizer.algebrize_hof_function_argument(name, f)?;
 
         // Nullability is based only on the array argument. The function argument being nullable
         // does not affect the nullability of the Map expression, just the nullability of the
@@ -2825,6 +2816,21 @@ impl<'a> Algebrizer<'a> {
         let is_nullable = Self::args_are_nullable(&[array.clone()]);
 
         Ok((array, f, is_nullable))
+    }
+
+    fn algebrize_hof_function_argument(
+        &self,
+        name: &'static str,
+        f: Box<ast::FunctionArgument>,
+    ) -> Result<mir::Expression> {
+        match *f {
+            ast::FunctionArgument::Expr(e) => self.algebrize_expression(e).map_err(|e| {
+                Self::wrap_error_in_hof_context(name, e, HigherOrderFunctionErrorCause::FunctionArg)
+            }),
+            ast::FunctionArgument::NamedFunction(f) => {
+                unreachable!("{:?} should have been rewritten in {name}", f)
+            }
+        }
     }
 
     fn algebrize_map(&self, expr: ast::MapExpr) -> Result<mir::Expression> {
@@ -2858,7 +2864,110 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_reduce(&self, expr: ast::ReduceExpr) -> Result<mir::Expression> {
-        todo!()
+        // First, algebrize the array.
+        let array = self.algebrize_expression(*expr.array).map_err(|e| {
+            Self::wrap_error_in_hof_context("Reduce", e, HigherOrderFunctionErrorCause::ArrayArg)
+        })?;
+
+        // Determine the schema of that `this` variable in the function argument. This is used to
+        // determine the `is_nullable` value for any `this` Variable expressions in the function
+        // argument.
+        let this_schema = array
+            .schema(&self.schema_inference_state())
+            .map_err(|e| {
+                Self::wrap_error_in_hof_context(
+                    "Reduce",
+                    e.into(),
+                    HigherOrderFunctionErrorCause::ArrayArg,
+                )
+            })?
+            .get_array_item_schema();
+
+        // Next, algebrize the initial value.
+        let init_value = self.algebrize_expression(*expr.init_value).map_err(|e| {
+            Self::wrap_error_in_hof_context(
+                "Reduce",
+                e,
+                HigherOrderFunctionErrorCause::InitialValue,
+            )
+        })?;
+
+        // Determine the initial schema of the `value` variable in the function argument. This is
+        // used to determine the `is_nullable` value for any `value` Variable expressions in the
+        // function argument. We may need to update those variables later. See the comments below.
+        let init_value_schema = init_value
+            .schema(&self.schema_inference_state())
+            .map_err(|e| {
+                Self::wrap_error_in_hof_context(
+                    "Reduce",
+                    e.into(),
+                    HigherOrderFunctionErrorCause::InitialValue,
+                )
+            })?;
+
+        // Create an Algebrizer with the appropriate state for algebrizing the function argument.
+        let mut variables: BTreeMap<&'static str, schema::Schema> =
+            map! { VALUE_VARIABLE => init_value_schema.clone() };
+        if let Some(this_schema) = this_schema {
+            variables.insert(THIS_VARIABLE, this_schema);
+        }
+        let mut fn_algebrizer = self
+            .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce)
+            .with_variables(variables.clone());
+
+        // Finally, algebrize the function argument.
+        let mut f = fn_algebrizer.algebrize_hof_function_argument("Reduce", expr.f.clone())?;
+
+        // Now that we've algebrized the function argument, we may need to update the nullability of
+        // any `value` Variable expressions in the function argument. This is because `value` only
+        // uses the `init_value` schema initially, and then takes on the `f` schema. The following
+        // truth table indicates the nullability of `value` variables:
+        //
+        //   init_value_schema    |    f_schema  |  value var is_nullable
+        //   ---------------------+--------------+------------------------
+        //    nullable            | nullable     | true
+        //    nullable            | not nullable | true
+        //    not nullable        | nullable     | true
+        //    not nullable        | not nullable | false
+        //
+        // That is, if either the `init_value` schema or the `f` schema is nullable, all `value`
+        // Variable expressions in the function argument are nullable. We only need to re-algebrize
+        // if the `init_value` schema is not nullable and the `f` schema is nullable.
+        let f_value_schema = f
+            .schema(&fn_algebrizer.schema_inference_state())
+            .map_err(|e| {
+                Self::wrap_error_in_hof_context(
+                    "Reduce",
+                    e.into(),
+                    HigherOrderFunctionErrorCause::FunctionArg,
+                )
+            })?;
+
+        if init_value_schema.satisfies(&NULLISH) == Satisfaction::Not
+            && f_value_schema.satisfies(&NULLISH) != Satisfaction::Not
+        {
+            // Overwrite the `value` variable schema with the `f` schema.
+            variables.insert(VALUE_VARIABLE, f_value_schema.clone());
+
+            // Update the function algebrizer with the updated variables.
+            fn_algebrizer = fn_algebrizer.with_variables(variables);
+
+            // Re-algebrize the function argument.
+            f = fn_algebrizer.algebrize_hof_function_argument("Reduce", expr.f)?;
+        }
+
+        // Nullability is based on all arguments. If any of them are nullable, the Reduce expression
+        // is nullable.
+        let is_nullable = Self::args_are_nullable(&[array.clone(), init_value.clone(), f.clone()]);
+
+        Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(array),
+                init_value: Box::new(init_value),
+                f: Box::new(f),
+                is_nullable,
+            }),
+        ))
     }
 
     fn wrap_error_in_hof_context(

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -1,13 +1,13 @@
 use crate::mir::ArrayExpr;
 use crate::{
-    algebrizer::errors::Error,
+    algebrizer::errors::{Error, HigherOrderFunctionErrorCause},
     ast::{self, pretty_print::PrettyPrint},
     catalog::Catalog,
     map,
     mir::{
         self,
         binding_tuple::{BindingTuple, DatasourceName, Key},
-        schema::{CachedSchema, SchemaCache, SchemaInferenceState},
+        schema::{CachedSchema, SchemaCache, SchemaInferenceState, THIS_VARIABLE, VALUE_VARIABLE},
         AliasedExpr, Expression, FieldAccess, OptionallyAliasedExpr, ReferenceExpr,
     },
     schema::{
@@ -240,6 +240,19 @@ pub struct Algebrizer<'a> {
     expression_context: ExpressionContext,
 }
 
+/// HigherOrderFunctionCtx indicates the higher order function in which an expression is being
+/// algebrized, if any. For `Map` and `Filter` contexts, the boolean value indicates the nullability
+/// of the `this` variable; for `Reduce` contexts, the boolean values indicate the nullability of
+/// the `this` and `value` variables, respectively.
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Default)]
+pub(crate) enum HigherOrderFunctionCtx {
+    #[default]
+    None,
+    Map(bool),
+    Filter(bool),
+    Reduce(bool, bool),
+}
+
 /// ExpressionContext contains information about the context in which an expression is being
 /// algebrized. In certain contexts, certain ast::Expressions are resolved differently. See fields
 /// for more information.
@@ -251,12 +264,29 @@ pub(crate) struct ExpressionContext {
     // unexpected to be strings. MongoSQL supports implicit type conversion from extended-JSON
     // encoded string literals to the corresponding BSON type in these contexts.
     in_implicit_type_conversion_ctx: bool,
+
+    // Indicates if the expression is being algebrized in the context of a higher order function
+    // function-argument. For example, in the expression MAP(array, this + 1), when algebrizing the
+    // function-argument `this + 1`, we set this value to HigherOrderFunctionCtx::Map. When in a
+    // non-None context, certain unqualified identifiers are resolved to variables instead of field
+    // references. Specifically, in the Map and Filter contexts, unqualified identifiers with the
+    // value "this" are resolved to the variable `this`; in the Reduce context, unqualified
+    // identifiers with the value "this" or "value" are resolved to the variables `this` or `value`,
+    // respectively.
+    in_higher_order_function_arg_ctx: HigherOrderFunctionCtx,
 }
 
 impl ExpressionContext {
     pub(crate) fn with_implicit_type_conversion_ctx(self, value: bool) -> Self {
         Self {
             in_implicit_type_conversion_ctx: value,
+        }
+    }
+
+    pub(crate) fn with_higher_order_function_arg_ctx(self, value: HigherOrderFunctionCtx) -> Self {
+        Self {
+            in_higher_order_function_arg_ctx: value,
+            ..self
         }
     }
 }
@@ -348,6 +378,13 @@ impl<'a> Algebrizer<'a> {
         self.with_expression_context(
             self.expression_context
                 .with_implicit_type_conversion_ctx(value),
+        )
+    }
+
+    fn with_higher_order_function_arg_ctx(&self, value: HigherOrderFunctionCtx) -> Self {
+        self.with_expression_context(
+            self.expression_context
+                .with_higher_order_function_arg_ctx(value),
         )
     }
 
@@ -2526,6 +2563,28 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_unqualified_identifier(&self, i: String) -> Result<mir::Expression> {
+        // If we are in the context of a Higher Order Function, unqualified identifiers may be
+        // variables instead of fields. Specifically, an unqualified "this" is always considered a
+        // variable in the context of any Higher Order Function, and an unqualified "value" is
+        // considered a variable in the context of Reduce.
+        let (is_hof_variable, is_nullable) =
+            match self.expression_context.in_higher_order_function_arg_ctx {
+                HigherOrderFunctionCtx::Map(is_nullable)
+                | HigherOrderFunctionCtx::Filter(is_nullable) => (i == THIS_VARIABLE, is_nullable),
+                HigherOrderFunctionCtx::Reduce(this_is_nullable, value_is_nullable) => (
+                    i == THIS_VARIABLE || i == VALUE_VARIABLE,
+                    (i == THIS_VARIABLE && this_is_nullable)
+                        || (i == VALUE_VARIABLE && value_is_nullable),
+                ),
+                HigherOrderFunctionCtx::None => (false, false),
+            };
+        if is_hof_variable {
+            return Ok(mir::Expression::Variable(mir::Variable {
+                name: i,
+                is_nullable,
+            }));
+        }
+
         // Attempt to find a datasource for this unqualified reference
         // at _any_ scope level.
         // If we find exactly one datasource that May or Must contain
@@ -2684,7 +2743,54 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_map(&self, expr: ast::MapExpr) -> Result<mir::Expression> {
-        todo!()
+        let array = self.algebrize_expression(*expr.array).map_err(|e| {
+            Self::wrap_error_in_hof_context("Map", e, HigherOrderFunctionErrorCause::ArrayArg)
+        })?;
+
+        // Determine the nullability of the `this` variable in the function argument. If the array
+        // item schema is nullable, the `this` variable is nullable.
+        let this_nullability = array
+            .schema(&self.schema_inference_state())
+            .map_err(|e| {
+                Self::wrap_error_in_hof_context(
+                    "Map",
+                    e.into(),
+                    HigherOrderFunctionErrorCause::ArrayArg,
+                )
+            })?
+            .get_array_item_schema()
+            .map(|s| s.satisfies(&NULLISH) != Satisfaction::Not)
+            .unwrap_or(false);
+
+        let fn_algebrizer =
+            self.with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map(this_nullability));
+        let f = match *expr.f {
+            ast::FunctionArgument::Expr(e) => {
+                fn_algebrizer.algebrize_expression(e).map_err(|e| {
+                    Self::wrap_error_in_hof_context(
+                        "Map",
+                        e,
+                        HigherOrderFunctionErrorCause::FunctionArg,
+                    )
+                })?
+            }
+            ast::FunctionArgument::NamedFunction(f) => {
+                unreachable!("{:?} should have been rewritten", f)
+            }
+        };
+
+        // Nullability is based only on the array argument. The function argument being nullable
+        // does not affect the nullability of the Map expression, just the nullability of the
+        // elements of the output array.
+        let is_nullable = Self::args_are_nullable(&[array.clone()]);
+
+        Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
+                array: Box::new(array),
+                f: Box::new(f),
+                is_nullable,
+            }),
+        ))
     }
 
     fn algebrize_filter_expr(&self, expr: ast::FilterExpr) -> Result<mir::Expression> {
@@ -2693,6 +2799,18 @@ impl<'a> Algebrizer<'a> {
 
     fn algebrize_reduce(&self, expr: ast::ReduceExpr) -> Result<mir::Expression> {
         todo!()
+    }
+
+    fn wrap_error_in_hof_context(
+        name: &'static str,
+        error: Error,
+        cause: HigherOrderFunctionErrorCause,
+    ) -> Error {
+        Error::HigherOrderFunctionWrapper {
+            name,
+            cause,
+            error: Box::new(error),
+        }
     }
 }
 

--- a/mongosql/src/algebrizer/errors.rs
+++ b/mongosql/src/algebrizer/errors.rs
@@ -42,6 +42,11 @@ pub enum Error {
     InvalidUnwindPath,
     InvalidCast(ast::Type),
     InvalidSortKey(mir::Expression),
+    HigherOrderFunctionWrapper {
+        name: &'static str,
+        cause: HigherOrderFunctionErrorCause,
+        error: Box<Error>,
+    },
 }
 
 impl From<mir::schema::Error> for Error {
@@ -56,6 +61,13 @@ impl From<mir::Error> for Error {
             mir::Error::InvalidType(t) => Error::InvalidCast(t),
         }
     }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum HigherOrderFunctionErrorCause {
+    ArrayArg,
+    InitialValue,
+    FunctionArg,
 }
 
 impl UserError for Error {
@@ -86,6 +98,7 @@ impl UserError for Error {
             Error::InvalidUnwindPath => 3029,
             Error::InvalidCast(_) => 3030,
             Error::InvalidSortKey(_) => 3034,
+            Error::HigherOrderFunctionWrapper { .. } => 3035,
         }
     }
 
@@ -166,6 +179,17 @@ impl UserError for Error {
             Error::InvalidSortKey(_) => {
                 Some("expressions are not allowed in sort key field paths".to_string())
             }
+            Error::HigherOrderFunctionWrapper { name, cause, error } => {
+                let (cause_desc, cause_message) = match cause {
+                    HigherOrderFunctionErrorCause::ArrayArg => ("array", "The first argument must be semantically valid, and must evaluate to either an Array, Null, or Missing."),
+                    HigherOrderFunctionErrorCause::InitialValue => ("initial value", "The second argument, the initial value, must be semantically valid but was not."),
+                    HigherOrderFunctionErrorCause::FunctionArg => ("function", "Ensure the function argument is semantically valid. It must have the correct number of arguments and the arguments must have the correct type."),
+                };
+                let sub_error_message = error
+                    .user_message()
+                    .unwrap_or_else(|| error.technical_message());
+                Some(format!("Invalid {cause_desc} argument for `{name}`: {cause_message} Sub-Error Code {}: {}", error.code(), sub_error_message))
+            }
         }
     }
 
@@ -199,6 +223,9 @@ impl UserError for Error {
             Error::InvalidCast(ast_type) => format!("invalid CAST target type '{ast_type:?}'"),
             Error::InvalidSortKey(e) =>
                 format!("sort key field path must be a pure field path with no expressions in this context. found {e:?}"),
+            Error::HigherOrderFunctionWrapper { name, cause, error } => {
+                format!("`{name}` with cause {cause:?}: sub-error: {}", error.technical_message())
+            },
         }
     }
 }

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -1122,3 +1122,473 @@ mod reduce {
         )),
     );
 }
+
+mod shadowing_variables {
+    use super::*;
+
+    test_algebrize!(
+        map_shadows_outer_this,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default().with_variables(&mut map! {
+            // Note that the outer "this" is not nullable, but the expectation is that it is
+            // shadowed by the Map's `this` variable which is nullable.
+            "this" => Schema::Atomic(Atomic::Integer),
+        }),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Null)]
+                })),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "this".to_string(),
+                    is_nullable: true,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input =
+            ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Null
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "this".to_string()
+                ))),
+            })),
+    );
+
+    test_algebrize!(
+        filter_shadows_outer_this,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default().with_variables(&mut map! {
+            // Note that the outer "this" is not a boolean, which is invalid in the context of the
+            // Filter's function argument. The expectation is that it is  shadowed by the Filter's
+            // `this` variable which is a boolean.
+            "this" => Schema::Atomic(Atomic::Integer),
+        }),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Boolean(true))]
+                })),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "this".to_string(),
+                    is_nullable: false,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
+            ast::FilterExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Boolean(true)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "this".to_string()
+                ))),
+            }
+        )),
+    );
+
+    test_algebrize!(
+        reduce_shadows_outer_this_and_value,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default().with_variables(&mut map! {
+            // Note that the outer "this" and "value" are not numeric, but the expectation is that
+            // they are shadowed by the Reduce's `this` and `value` variables which are numeric.
+            "this" => Schema::Atomic(Atomic::String),
+            "value" => Schema::Atomic(Atomic::String),
+        }),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                f: Box::new(mir::Expression::ScalarFunction(
+                    mir::ScalarFunctionApplication {
+                        function: mir::ScalarFunction::Add,
+                        args: vec![
+                            mir::Expression::Variable(mir::Variable {
+                                name: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                            mir::Expression::Variable(mir::Variable {
+                                name: "value".to_string(),
+                                is_nullable: false,
+                            }),
+                        ],
+                        is_nullable: false,
+                    }
+                )),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Add,
+                        right: Box::new(ast::Expression::Identifier("value".to_string())),
+                    }
+                ))),
+            }
+        )),
+    );
+
+    // This test demonstrates how shadowing works for variables in nested higher order functions. At the
+    // time of writing, MongoSQL does not support user-provided variable names. Instead, it requires use
+    // of the variables `this` and `value` in higher order functions. This test demonstrates that in the
+    // context of a nested higher order function, the variables `this` and `value` refer to the most
+    // local higher order function that defines them.
+    //
+    // This is a very large test, but it is useful to cover all the shadowing rules in one test that
+    // represents a real query. The previous tests are smaller, more targeted tests that demonstrate
+    // shadowing per higher order function type.
+    //
+    // REDUCE(
+    //   [1],
+    //   1,
+    //   SIZE(
+    //     MAP(
+    //       ['1'],
+    //       CAST(
+    //         this || '0' AS INT,  // `this` refers to the STRING elements of the MAP array arg since
+    //                              // MAP defines (overwrites) the `this` from REDUCE
+    //         0 ON NULL,
+    //         0 ON ERROR
+    //       )
+    //       + value // `value` refers to the INTEGER value of the REDUCE accumulated result since MAP
+    //               // does not define (overwrite) `value`
+    //       + SIZE(
+    //           FILTER(
+    //             [false],
+    //             this // `this` refers to the BOOLEAN elements of the FILTER array arg since FILTER
+    //                  // defines (overwrites) `this` from MAP
+    //             OR value::BOOL // `value` refers to the INTEGER value of the REDUCE accumulated
+    //                            // result since FILTER does not define (overwrite) `value`
+    //           )
+    //         )
+    //     )
+    //   )
+    //   + this  // `this` refers to the INTEGER elements of the REDUCE array arg
+    //   + value // `value` refers to the INTEGER value of the REDUCE accumulated result
+    //   + REDUCE(
+    //       ["1"],
+    //       "1",
+    //       CAST(
+    //         this::INT + value::INT // `this` and `value` refer to the STRING elements of the
+    //         AS STRING              // nested REDUCE
+    //       )
+    //     )::INT
+    // )
+    test_algebrize!(
+        shadowing_variables,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                f: Box::new(mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                    function: mir::ScalarFunction::Add,
+                    args: vec![
+                        mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                            function: mir::ScalarFunction::Add,
+                            args: vec![
+                                mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                    function: mir::ScalarFunction::Add,
+                                    args: vec![
+                                        mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                            function: mir::ScalarFunction::Size,
+                                            args: vec![
+                                                mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
+                                                    array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                                                        array: vec![mir::Expression::Literal(mir::LiteralValue::String("1".to_string()))]
+                                                    })),
+                                                    f: Box::new(mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                                        function: mir::ScalarFunction::Add,
+                                                        args: vec![
+                                                            mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                                                function: mir::ScalarFunction::Add,
+                                                                args: vec![
+                                                                    mir::Expression::Cast(mir::CastExpr {
+                                                                        expr: Box::new(mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                                                            function: mir::ScalarFunction::Concat,
+                                                                            args: vec![
+                                                                                mir::Expression::Variable(mir::Variable {
+                                                                                    name: "this".to_string(),
+                                                                                    is_nullable: false,
+                                                                                }),
+                                                                                mir::Expression::Literal(mir::LiteralValue::String("0".to_string())),
+                                                                            ],
+                                                                            is_nullable: false,
+                                                                        })),
+                                                                        to: mir::Type::Int32,
+                                                                        on_null: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(0))),
+                                                                        on_error: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(0))),
+                                                                        is_nullable: false,
+                                                                    }),
+                                                                    mir::Expression::Variable(mir::Variable {
+                                                                        name: "value".to_string(),
+                                                                        is_nullable: false,
+                                                                    }),
+                                                                ],
+                                                                is_nullable: false,
+                                                            }),
+                                                            mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                                                function: mir::ScalarFunction::Size,
+                                                                args: vec![
+                                                                    mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
+                                                                        array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                                                                            array: vec![mir::Expression::Literal(mir::LiteralValue::Boolean(false))]
+                                                                        })),
+                                                                        f: Box::new(mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                                                            function: mir::ScalarFunction::Or,
+                                                                            args: vec![
+                                                                                mir::Expression::Variable(mir::Variable {
+                                                                                    name: "this".to_string(),
+                                                                                    is_nullable: false,
+                                                                                }),
+                                                                                mir::Expression::Cast(mir::CastExpr {
+                                                                                    expr: Box::new(mir::Expression::Variable(mir::Variable {
+                                                                                        name: "value".to_string(),
+                                                                                        is_nullable: false,
+                                                                                    })),
+                                                                                    to: mir::Type::Boolean,
+                                                                                    on_null: Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(false))),
+                                                                                    on_error: Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(false))),
+                                                                                    is_nullable: false,
+                                                                                }),
+                                                                            ],
+                                                                            is_nullable: false,
+                                                                        })),
+                                                                        is_nullable: false,
+                                                                    })),
+                                                                ],
+                                                                is_nullable: false,
+                                                            }),
+                                                        ],
+                                                        is_nullable: false,
+                                                    })),
+                                                    is_nullable: false,
+                                                }))
+                                            ],
+                                            is_nullable: false,
+                                        }),
+                                        mir::Expression::Variable(mir::Variable {
+                                            name: "this".to_string(),
+                                            is_nullable: false,
+                                        })
+                                    ],
+                                    is_nullable: false,
+                                }),
+                                mir::Expression::Variable(mir::Variable {
+                                    name: "value".to_string(),
+                                    is_nullable: false,
+                                }),
+                            ],
+                            is_nullable: false,
+                        }),
+                        mir::Expression::Cast(mir::CastExpr {
+                            expr: Box::new(mir::Expression::HigherOrderFunction(mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                                    array: vec![mir::Expression::Literal(mir::LiteralValue::String("1".to_string()))]
+                                })),
+                                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::String("1".to_string()))),
+                                f: Box::new(mir::Expression::Cast(mir::CastExpr {
+                                    expr: Box::new(mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                        function: mir::ScalarFunction::Add,
+                                        args: vec![
+                                            mir::Expression::Cast(mir::CastExpr {
+                                                expr: Box::new(mir::Expression::Variable(mir::Variable {
+                                                    name: "this".to_string(),
+                                                    is_nullable: false,
+                                                })),
+                                                to: mir::Type::Int32,
+                                                on_null: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(0))),
+                                                on_error: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(0))),
+                                                is_nullable: false,
+                                            }),
+                                            mir::Expression::Cast(mir::CastExpr {
+                                                expr: Box::new(mir::Expression::Variable(mir::Variable {
+                                                    name: "value".to_string(),
+                                                    is_nullable: false,
+                                                })),
+                                                to: mir::Type::Int32,
+                                                on_null: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(0))),
+                                                on_error: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(0))),
+                                                is_nullable: false,
+                                            }),
+                                        ],
+                                        is_nullable: false,
+                                    })),
+                                    to: mir::Type::String,
+                                    on_null: Box::new(mir::Expression::Literal(mir::LiteralValue::String("0".to_string()))),
+                                    on_error: Box::new(mir::Expression::Literal(mir::LiteralValue::String("0".to_string()))),
+                                    is_nullable: false,
+                                })),
+                                is_nullable: false,
+                            }))),
+                            to: mir::Type::Int32,
+                            on_null: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(0))),
+                            on_error: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(0))),
+                            is_nullable: false,
+                        }),
+                    ],
+                    is_nullable: false,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1),
+                )])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(ast::BinaryExpr {
+                    left: Box::new(ast::Expression::Binary(
+                        ast::BinaryExpr {
+                            left: Box::new(ast::Expression::Binary(ast::BinaryExpr {
+                                left: Box::new(ast::Expression::Function(ast::FunctionExpr {
+                                    function: ast::FunctionName::Size,
+                                    args: ast::FunctionArguments::Args(vec![
+                                        ast::Expression::HigherOrderFunction(
+                                            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                                                array: Box::new(ast::Expression::Array(vec![
+                                                    ast::Expression::StringConstructor("1".to_string()),
+                                                ])),
+                                                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(ast::BinaryExpr {
+                                                    left: Box::new(ast::Expression::Binary(ast::BinaryExpr {
+                                                        left: Box::new(ast::Expression::Cast(ast::CastExpr {
+                                                            expr: Box::new(ast::Expression::Binary(
+                                                                ast::BinaryExpr {
+                                                                    left: Box::new(ast::Expression::Identifier(
+                                                                        "this".to_string(),
+                                                                    )),
+                                                                    op: ast::BinaryOp::Concat,
+                                                                    right: Box::new(
+                                                                        ast::Expression::StringConstructor(
+                                                                            "0".to_string()
+                                                                        )
+                                                                    ),
+                                                                }
+                                                            )),
+                                                            to: ast::Type::Int32,
+                                                            on_null: Some(ast::Expression::Literal(
+                                                                ast::Literal::Integer(0)
+                                                            ).into()),
+                                                            on_error: Some(ast::Expression::Literal(
+                                                                ast::Literal::Integer(0)
+                                                            ).into()),
+                                                        })),
+                                                        op: ast::BinaryOp::Add,
+                                                        right: Box::new(ast::Expression::Identifier(
+                                                            "value".to_string()
+                                                        )),
+                                                    })),
+                                                    op: ast::BinaryOp::Add,
+                                                    right: Box::new(ast::Expression::Function(ast::FunctionExpr {
+                                                        function: ast::FunctionName::Size,
+                                                        args: ast::FunctionArguments::Args(vec![
+                                                            ast::Expression::HigherOrderFunction(
+                                                                ast::HigherOrderFunctionExpr::Filter(
+                                                                    ast::FilterExpr {
+                                                                        array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                                                                            ast::Literal::Boolean(false)
+                                                                        )])),
+                                                                        f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                                                                            ast::BinaryExpr {
+                                                                                left: Box::new(ast::Expression::Identifier(
+                                                                                    "this".to_string()
+                                                                                )),
+                                                                                op: ast::BinaryOp::Or,
+                                                                                right: Box::new(ast::Expression::Cast(ast::CastExpr {
+                                                                                    expr: Box::new(ast::Expression::Identifier(
+                                                                                        "value".to_string()
+                                                                                    )),
+                                                                                    to: ast::Type::Boolean,
+                                                                                    on_null: Some(ast::Expression::Literal(
+                                                                                        ast::Literal::Boolean(false)
+                                                                                    ).into()),
+                                                                                    on_error: Some(ast::Expression::Literal(
+                                                                                        ast::Literal::Boolean(false)
+                                                                                    ).into()),
+                                                                                })),
+                                                                            }
+                                                                        ))),
+                                                                    }))
+                                                        ]),
+                                                        set_quantifier: None,
+                                                    })),
+                                                }))),
+                                            }))
+                                    ]),
+                                    set_quantifier: None,
+                                })),
+                                op: ast::BinaryOp::Add,
+                                right: Box::new(ast::Expression::Identifier("this".to_string())),
+                            })),
+                            op: ast::BinaryOp::Add,
+                            right: Box::new(ast::Expression::Identifier("value".to_string()))
+                        }
+                    )),
+                    op: ast::BinaryOp::Add,
+                    right: Box::new(ast::Expression::Cast(ast::CastExpr {
+                        expr: Box::new(ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+                            ast::ReduceExpr {
+                                array: Box::new(ast::Expression::Array(vec![ast::Expression::StringConstructor(
+                                    "1".to_string(),
+                                )])),
+                                init_value: Box::new(ast::Expression::StringConstructor("1".to_string())),
+                                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Cast(ast::CastExpr {
+                                    expr: Box::new(ast::Expression::Binary(
+                                        ast::BinaryExpr {
+                                            left: Box::new(ast::Expression::Cast(ast::CastExpr {
+                                                expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                                                to: ast::Type::Int32,
+                                                on_null: Some(ast::Expression::Literal(
+                                                    ast::Literal::Integer(0)
+                                                ).into()),
+                                                on_error: Some(ast::Expression::Literal(
+                                                    ast::Literal::Integer(0)
+                                                ).into()),
+                                            })),
+                                            op: ast::BinaryOp::Add,
+                                            right: Box::new(ast::Expression::Cast(ast::CastExpr {
+                                                expr: Box::new(ast::Expression::Identifier(
+                                                    "value".to_string()
+                                                )),
+                                                to: ast::Type::Int32,
+                                                on_null: Some(ast::Expression::Literal(
+                                                    ast::Literal::Integer(0)
+                                                ).into()),
+                                                on_error: Some(ast::Expression::Literal(
+                                                    ast::Literal::Integer(0)
+                                                ).into()),
+                                            })),
+                                        }
+                                    )),
+                                    to: ast::Type::String,
+                                    on_null: Some(ast::Expression::StringConstructor("0".to_string()).into()),
+                                    on_error: Some(ast::Expression::StringConstructor("0".to_string()).into()),
+                                }))),
+                            }
+                        ))),
+                        to: ast::Type::Int32,
+                        on_null: Some(ast::Expression::Literal(ast::Literal::Integer(0)).into()),
+                        on_error: Some(ast::Expression::Literal(ast::Literal::Integer(0)).into()),
+                    })),
+                }))),
+            }
+        )),
+    );
+}

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -231,4 +231,62 @@ mod map {
             }),
         },
     );
+
+    test_algebrize!(
+        invalid_array_arg,
+        method = algebrize_expression,
+        expected = Err(Error::HigherOrderFunctionWrapper {
+            name: "Map",
+            cause: HigherOrderFunctionErrorCause::ArrayArg,
+            error: Box::new(Error::FieldNotFound(
+                "foo".to_string(),
+                None,
+                ClauseType::Unintialized,
+                0u16
+            )),
+        }),
+        expected_error_code = 3035,
+        input =
+            ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    subpath: "a".to_string(),
+                })),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                ))),
+            })),
+    );
+
+    test_algebrize!(
+        invalid_function_arg,
+        method = algebrize_expression,
+        expected = Err(Error::HigherOrderFunctionWrapper {
+            name: "Map",
+            cause: HigherOrderFunctionErrorCause::FunctionArg,
+            error: Box::new(Error::FieldNotFound(
+                "foo".to_string(),
+                None,
+                ClauseType::Unintialized,
+                0u16
+            )),
+        }),
+        expected_error_code = 3035,
+        input =
+            ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Add,
+                        right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            subpath: "this".to_string(),
+                        })),
+                    }
+                ))),
+            })),
+    );
 }

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -713,7 +713,7 @@ mod reduce {
                     name: "this".to_string(),
                     is_nullable: true,
                 })),
-                is_nullable: false,
+                is_nullable: true,
             })
         )),
         input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
@@ -851,7 +851,7 @@ mod reduce {
                         key: ("foo", 0u16).into(),
                     })),
                     field: "field".to_string(),
-                    is_nullable: false,
+                    is_nullable: true,
                 })),
                 f: Box::new(mir::Expression::ScalarFunction(
                     mir::ScalarFunctionApplication {

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -7,7 +7,6 @@ mod map {
     test_algebrize!(
         no_variables,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
         expected = Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
                 array: Box::new(mir::Expression::Array(mir::ArrayExpr {
@@ -32,7 +31,6 @@ mod map {
     test_algebrize!(
         nullable,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
         expected = Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
                 array: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
@@ -72,7 +70,6 @@ mod map {
     test_algebrize!(
         with_this_variable,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
         expected = Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
                 array: Box::new(mir::Expression::Array(mir::ArrayExpr {
@@ -100,7 +97,6 @@ mod map {
     test_algebrize!(
         with_nullable_this_variable,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
         expected = Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
                 array: Box::new(mir::Expression::Array(mir::ArrayExpr {
@@ -132,7 +128,6 @@ mod map {
     test_algebrize!(
         with_this_variable_multiple_times,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
         expected = Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
                 array: Box::new(mir::Expression::Array(mir::ArrayExpr {
@@ -176,7 +171,6 @@ mod map {
     test_algebrize!(
         with_this_variable_and_field_access,
         method = algebrize_expression,
-        in_implicit_type_conversion_context = false,
         expected = Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
                 array: Box::new(mir::Expression::Array(mir::ArrayExpr {

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -589,3 +589,542 @@ mod filter {
         )),
     );
 }
+
+mod reduce {
+    use super::*;
+
+    // REDUCE([1], 1, 1)
+    test_algebrize!(
+        no_variables,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                f: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                ))),
+            }
+        )),
+    );
+
+    // REDUCE(foo.a, 1, 1)
+    test_algebrize!(
+        nullable_because_of_array,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
+                    expr: Box::new(mir::Expression::Reference(mir::ReferenceExpr {
+                        key: ("foo", 0u16).into(),
+                    })),
+                    field: "a".to_string(),
+                    is_nullable: true,
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                f: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                is_nullable: true,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    subpath: "a".to_string(),
+                })),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                ))),
+            }
+        )),
+        env = map! {
+            ("foo", 0u16).into() => Schema::Document( Document {
+                keys: map! {
+                    "a".into() => Schema::Array(Box::new(Schema::Atomic(Atomic::Integer))),
+                },
+                required: set!{},
+                additional_properties: false,
+                ..Default::default()
+            }),
+        },
+    );
+
+    // REDUCE([1], 1, this)
+    test_algebrize!(
+        with_this_variable,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "this".to_string(),
+                    is_nullable: false,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "this".to_string()
+                ))),
+            }
+        )),
+    );
+
+    // REDUCE([1, NULL], 1, this)
+    test_algebrize!(
+        with_nullable_this_variable,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![
+                        mir::Expression::Literal(mir::LiteralValue::Integer(1)),
+                        mir::Expression::Literal(mir::LiteralValue::Null),
+                    ]
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "this".to_string(),
+                    is_nullable: true,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![
+                    ast::Expression::Literal(ast::Literal::Integer(1)),
+                    ast::Expression::Literal(ast::Literal::Null),
+                ])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "this".to_string()
+                ))),
+            }
+        )),
+    );
+
+    // REDUCE([NULL], 1, value)
+    test_algebrize!(
+        with_value_variable,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Null)]
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "value".to_string(),
+                    is_nullable: false,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Null
+                )])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "value".to_string()
+                ))),
+            }
+        )),
+    );
+
+    // REDUCE([1], null, value)
+    test_algebrize!(
+        with_nullable_value_variable_because_of_init_value,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1)),]
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Null)),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "value".to_string(),
+                    is_nullable: true,
+                })),
+                is_nullable: true,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                ),])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Null)),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "value".to_string()
+                ))),
+            }
+        )),
+    );
+
+    // REDUCE([1], 1, value + null)
+    test_algebrize!(
+        with_nullable_value_variable_because_of_function_argument,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1)),]
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                f: Box::new(mir::Expression::ScalarFunction(
+                    mir::ScalarFunctionApplication {
+                        function: mir::ScalarFunction::Add,
+                        args: vec![
+                            mir::Expression::Variable(mir::Variable {
+                                name: "value".to_string(),
+                                is_nullable: true,
+                            }),
+                            mir::Expression::Literal(mir::LiteralValue::Null),
+                        ],
+                        is_nullable: true,
+                    }
+                )),
+                is_nullable: true,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                ),])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("value".to_string())),
+                        op: ast::BinaryOp::Add,
+                        right: Box::new(ast::Expression::Literal(ast::Literal::Null)),
+                    }
+                ))),
+            }
+        )),
+    );
+
+    // REDUCE([1], field, this + value + this + value)
+    test_algebrize!(
+        with_variables_multiple_times,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                init_value: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
+                    expr: Box::new(mir::Expression::Reference(mir::ReferenceExpr {
+                        key: ("foo", 0u16).into(),
+                    })),
+                    field: "field".to_string(),
+                    is_nullable: false,
+                })),
+                f: Box::new(mir::Expression::ScalarFunction(
+                    mir::ScalarFunctionApplication {
+                        function: mir::ScalarFunction::Add,
+                        args: vec![
+                            mir::Expression::Variable(mir::Variable {
+                                name: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                            mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                function: mir::ScalarFunction::Add,
+                                args: vec![
+                                    mir::Expression::Variable(mir::Variable {
+                                        name: "value".to_string(),
+                                        is_nullable: true,
+                                    }),
+                                    mir::Expression::ScalarFunction(
+                                        mir::ScalarFunctionApplication {
+                                            function: mir::ScalarFunction::Add,
+                                            args: vec![
+                                                mir::Expression::Variable(mir::Variable {
+                                                    name: "this".to_string(),
+                                                    is_nullable: false,
+                                                }),
+                                                mir::Expression::Variable(mir::Variable {
+                                                    name: "value".to_string(),
+                                                    is_nullable: true,
+                                                }),
+                                            ],
+                                            is_nullable: true,
+                                        }
+                                    )
+                                ],
+                                is_nullable: true,
+                            })
+                        ],
+                        is_nullable: true,
+                    }
+                )),
+                is_nullable: true,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                init_value: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    subpath: "field".to_string(),
+                })),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Add,
+                        right: Box::new(ast::Expression::Binary(ast::BinaryExpr {
+                            left: Box::new(ast::Expression::Identifier("value".to_string())),
+                            op: ast::BinaryOp::Add,
+                            right: Box::new(ast::Expression::Binary(ast::BinaryExpr {
+                                left: Box::new(ast::Expression::Identifier("this".to_string())),
+                                op: ast::BinaryOp::Add,
+                                right: Box::new(ast::Expression::Identifier("value".to_string())),
+                            })),
+                        })),
+                    }
+                ))),
+            }
+        )),
+        env = map! {
+            ("foo", 0u16).into() => Schema::Document( Document {
+                keys: map! {
+                    "field".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! { },
+                additional_properties: false,
+                ..Default::default()
+            }),
+        },
+    );
+
+    // REDUCE([1], 1, this + foo.this + value + this.value)
+    test_algebrize!(
+        with_variable_and_field_accesses_of_same_names,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Reduce(mir::ReduceExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                init_value: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                f: Box::new(mir::Expression::ScalarFunction(
+                    mir::ScalarFunctionApplication {
+                        function: mir::ScalarFunction::Add,
+                        args: vec![
+                            mir::Expression::Variable(mir::Variable {
+                                name: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                            mir::Expression::ScalarFunction(mir::ScalarFunctionApplication {
+                                function: mir::ScalarFunction::Add,
+                                args: vec![
+                                    mir::Expression::FieldAccess(mir::FieldAccess {
+                                        expr: Box::new(mir::Expression::Reference(
+                                            mir::ReferenceExpr {
+                                                key: ("foo", 0u16).into(),
+                                            }
+                                        )),
+                                        field: "this".to_string(),
+                                        is_nullable: false,
+                                    }),
+                                    mir::Expression::ScalarFunction(
+                                        mir::ScalarFunctionApplication {
+                                            function: mir::ScalarFunction::Add,
+                                            args: vec![
+                                                mir::Expression::Variable(mir::Variable {
+                                                    name: "value".to_string(),
+                                                    is_nullable: false,
+                                                }),
+                                                mir::Expression::FieldAccess(mir::FieldAccess {
+                                                    expr: Box::new(mir::Expression::Reference(
+                                                        mir::ReferenceExpr {
+                                                            key: ("foo", 0u16).into(),
+                                                        }
+                                                    )),
+                                                    field: "value".to_string(),
+                                                    is_nullable: false,
+                                                }),
+                                            ],
+                                            is_nullable: false,
+                                        }
+                                    )
+                                ],
+                                is_nullable: false,
+                            })
+                        ],
+                        is_nullable: false,
+                    }
+                )),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Add,
+                        right: Box::new(ast::Expression::Binary(ast::BinaryExpr {
+                            left: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                                expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                                subpath: "this".to_string(),
+                            })),
+                            op: ast::BinaryOp::Add,
+                            right: Box::new(ast::Expression::Binary(ast::BinaryExpr {
+                                left: Box::new(ast::Expression::Identifier("value".to_string())),
+                                op: ast::BinaryOp::Add,
+                                right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                                    subpath: "value".to_string(),
+                                })),
+                            })),
+                        })),
+                    }
+                ))),
+            }
+        )),
+        env = map! {
+            ("foo", 0u16).into() => Schema::Document( Document {
+                keys: map! {
+                    "this".into() => Schema::Atomic(Atomic::Integer),
+                    "value".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! { "this".to_string(), "value".to_string() },
+                additional_properties: false,
+                ..Default::default()
+            }),
+        },
+    );
+
+    test_algebrize!(
+        invalid_array_arg,
+        method = algebrize_expression,
+        expected = Err(Error::HigherOrderFunctionWrapper {
+            name: "Reduce",
+            cause: HigherOrderFunctionErrorCause::ArrayArg,
+            error: Box::new(Error::FieldNotFound(
+                "foo".to_string(),
+                None,
+                ClauseType::Unintialized,
+                0u16
+            )),
+        }),
+        expected_error_code = 3035,
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    subpath: "a".to_string(),
+                })),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                ))),
+            }
+        )),
+    );
+
+    test_algebrize!(
+        invalid_init_value,
+        method = algebrize_expression,
+        expected = Err(Error::HigherOrderFunctionWrapper {
+            name: "Reduce",
+            cause: HigherOrderFunctionErrorCause::InitialValue,
+            error: Box::new(Error::FieldNotFound(
+                "foo".to_string(),
+                None,
+                ClauseType::Unintialized,
+                0u16
+            )),
+        }),
+        expected_error_code = 3035,
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                init_value: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    subpath: "a".to_string(),
+                })),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                ))),
+            }
+        )),
+    );
+
+    test_algebrize!(
+        invalid_function_arg,
+        method = algebrize_expression,
+        expected = Err(Error::HigherOrderFunctionWrapper {
+            name: "Reduce",
+            cause: HigherOrderFunctionErrorCause::FunctionArg,
+            error: Box::new(Error::FieldNotFound(
+                "foo".to_string(),
+                None,
+                ClauseType::Unintialized,
+                0u16
+            )),
+        }),
+        expected_error_code = 3035,
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
+            ast::ReduceExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Add,
+                        right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            subpath: "this".to_string(),
+                        })),
+                    }
+                ))),
+            }
+        )),
+    );
+}

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -3,6 +3,7 @@ use super::*;
 mod map {
     use super::*;
 
+    // MAP([1], 1)
     test_algebrize!(
         no_variables,
         method = algebrize_expression,
@@ -27,6 +28,7 @@ mod map {
             })),
     );
 
+    // MAP(foo.a, 1)
     test_algebrize!(
         nullable,
         method = algebrize_expression,
@@ -46,9 +48,10 @@ mod map {
         )),
         input =
             ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
-                    ast::Literal::Integer(1)
-                )])),
+                array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    subpath: "a".to_string(),
+                })),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
                     ast::Literal::Integer(1)
                 ))),
@@ -65,6 +68,7 @@ mod map {
         },
     );
 
+    // MAP([1], this)
     test_algebrize!(
         with_this_variable,
         method = algebrize_expression,
@@ -92,6 +96,7 @@ mod map {
             })),
     );
 
+    // MAP([1, NULL], this)
     test_algebrize!(
         with_nullable_this_variable,
         method = algebrize_expression,
@@ -99,7 +104,10 @@ mod map {
         expected = Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
                 array: Box::new(mir::Expression::Array(mir::ArrayExpr {
-                    array: vec![mir::Expression::Literal(mir::LiteralValue::Null)]
+                    array: vec![
+                        mir::Expression::Literal(mir::LiteralValue::Integer(1)),
+                        mir::Expression::Literal(mir::LiteralValue::Null),
+                    ]
                 })),
                 f: Box::new(mir::Expression::Variable(mir::Variable {
                     name: "this".to_string(),
@@ -110,15 +118,17 @@ mod map {
         )),
         input =
             ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
-                    ast::Literal::Integer(1)
-                )])),
+                array: Box::new(ast::Expression::Array(vec![
+                    ast::Expression::Literal(ast::Literal::Integer(1)),
+                    ast::Expression::Literal(ast::Literal::Null),
+                ])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
                     "this".to_string()
                 ))),
             })),
     );
 
+    // MAP([1], this + this)
     test_algebrize!(
         with_this_variable_multiple_times,
         method = algebrize_expression,
@@ -162,18 +172,15 @@ mod map {
             })),
     );
 
+    // MAP([1], this + foo.this)
     test_algebrize!(
         with_this_variable_and_field_access,
         method = algebrize_expression,
         in_implicit_type_conversion_context = false,
         expected = Ok(mir::Expression::HigherOrderFunction(
             mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
-                array: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
-                    expr: Box::new(mir::Expression::Reference(mir::ReferenceExpr {
-                        key: ("foo", 0u16).into(),
-                    })),
-                    field: "a".to_string(),
-                    is_nullable: true,
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
                 })),
                 f: Box::new(mir::Expression::ScalarFunction(
                     mir::ScalarFunctionApplication {
@@ -194,7 +201,7 @@ mod map {
                         is_nullable: false,
                     }
                 )),
-                is_nullable: true,
+                is_nullable: false,
             })
         )),
         input =

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -1,0 +1,227 @@
+use super::*;
+
+mod map {
+    use super::*;
+
+    test_algebrize!(
+        no_variables,
+        method = algebrize_expression,
+        in_implicit_type_conversion_context = false,
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                f: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                is_nullable: false,
+            })
+        )),
+        input =
+            ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                ))),
+            })),
+    );
+
+    test_algebrize!(
+        nullable,
+        method = algebrize_expression,
+        in_implicit_type_conversion_context = false,
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
+                array: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
+                    expr: Box::new(mir::Expression::Reference(mir::ReferenceExpr {
+                        key: ("foo", 0u16).into(),
+                    })),
+                    field: "a".to_string(),
+                    is_nullable: true,
+                })),
+                f: Box::new(mir::Expression::Literal(mir::LiteralValue::Integer(1))),
+                is_nullable: true,
+            })
+        )),
+        input =
+            ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                ))),
+            })),
+        env = map! {
+            ("foo", 0u16).into() => Schema::Document( Document {
+                keys: map! {
+                    "a".into() => Schema::Array(Box::new(Schema::Atomic(Atomic::Integer))),
+                },
+                required: set!{},
+                additional_properties: false,
+                ..Default::default()
+            }),
+        },
+    );
+
+    test_algebrize!(
+        with_this_variable,
+        method = algebrize_expression,
+        in_implicit_type_conversion_context = false,
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "this".to_string(),
+                    is_nullable: false,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input =
+            ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "this".to_string()
+                ))),
+            })),
+    );
+
+    test_algebrize!(
+        with_nullable_this_variable,
+        method = algebrize_expression,
+        in_implicit_type_conversion_context = false,
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Null)]
+                })),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "this".to_string(),
+                    is_nullable: true,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input =
+            ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "this".to_string()
+                ))),
+            })),
+    );
+
+    test_algebrize!(
+        with_this_variable_multiple_times,
+        method = algebrize_expression,
+        in_implicit_type_conversion_context = false,
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                f: Box::new(mir::Expression::ScalarFunction(
+                    mir::ScalarFunctionApplication {
+                        function: mir::ScalarFunction::Add,
+                        args: vec![
+                            mir::Expression::Variable(mir::Variable {
+                                name: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                            mir::Expression::Variable(mir::Variable {
+                                name: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                        ],
+                        is_nullable: false,
+                    }
+                )),
+                is_nullable: false,
+            })
+        )),
+        input =
+            ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Add,
+                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })),
+    );
+
+    test_algebrize!(
+        with_this_variable_and_field_access,
+        method = algebrize_expression,
+        in_implicit_type_conversion_context = false,
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Map(mir::MapExpr {
+                array: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
+                    expr: Box::new(mir::Expression::Reference(mir::ReferenceExpr {
+                        key: ("foo", 0u16).into(),
+                    })),
+                    field: "a".to_string(),
+                    is_nullable: true,
+                })),
+                f: Box::new(mir::Expression::ScalarFunction(
+                    mir::ScalarFunctionApplication {
+                        function: mir::ScalarFunction::Add,
+                        args: vec![
+                            mir::Expression::Variable(mir::Variable {
+                                name: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                            mir::Expression::FieldAccess(mir::FieldAccess {
+                                expr: Box::new(mir::Expression::Reference(mir::ReferenceExpr {
+                                    key: ("foo", 0u16).into(),
+                                })),
+                                field: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                        ],
+                        is_nullable: false,
+                    }
+                )),
+                is_nullable: true,
+            })
+        )),
+        input =
+            ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Add,
+                        right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            subpath: "this".to_string(),
+                        })),
+                    }
+                ))),
+            })),
+        env = map! {
+            ("foo", 0u16).into() => Schema::Document( Document {
+                keys: map! {
+                    "this".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! { "this".to_string() },
+                additional_properties: false,
+                ..Default::default()
+            }),
+        },
+    );
+}

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -290,3 +290,302 @@ mod map {
             })),
     );
 }
+
+mod filter {
+    use super::*;
+
+    // FILTER([1], true)
+    test_algebrize!(
+        no_variables,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                f: Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
+            ast::FilterExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Boolean(true)
+                ))),
+            }
+        )),
+    );
+
+    // FILTER(foo.a, 1)
+    test_algebrize!(
+        nullable,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
+                array: Box::new(mir::Expression::FieldAccess(mir::FieldAccess {
+                    expr: Box::new(mir::Expression::Reference(mir::ReferenceExpr {
+                        key: ("foo", 0u16).into(),
+                    })),
+                    field: "a".to_string(),
+                    is_nullable: true,
+                })),
+                f: Box::new(mir::Expression::Literal(mir::LiteralValue::Boolean(true))),
+                is_nullable: true,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
+            ast::FilterExpr {
+                array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    subpath: "a".to_string(),
+                })),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Boolean(true)
+                ))),
+            }
+        )),
+        env = map! {
+            ("foo", 0u16).into() => Schema::Document( Document {
+                keys: map! {
+                    "a".into() => Schema::Array(Box::new(Schema::Atomic(Atomic::Integer))),
+                },
+                required: set!{},
+                additional_properties: false,
+                ..Default::default()
+            }),
+        },
+    );
+
+    // FILTER([true], this)
+    test_algebrize!(
+        with_this_variable,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Boolean(true))]
+                })),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "this".to_string(),
+                    is_nullable: false,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
+            ast::FilterExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Boolean(true)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "this".to_string()
+                ))),
+            }
+        )),
+    );
+
+    // FILTER([true, NULL], this)
+    test_algebrize!(
+        with_nullable_this_variable,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![
+                        mir::Expression::Literal(mir::LiteralValue::Boolean(true)),
+                        mir::Expression::Literal(mir::LiteralValue::Null),
+                    ]
+                })),
+                f: Box::new(mir::Expression::Variable(mir::Variable {
+                    name: "this".to_string(),
+                    is_nullable: true,
+                })),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
+            ast::FilterExpr {
+                array: Box::new(ast::Expression::Array(vec![
+                    ast::Expression::Literal(ast::Literal::Boolean(true)),
+                    ast::Expression::Literal(ast::Literal::Null),
+                ])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
+                    "this".to_string()
+                ))),
+            }
+        )),
+    );
+
+    // FILTER([1], this = this)
+    test_algebrize!(
+        with_this_variable_multiple_times,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                f: Box::new(mir::Expression::ScalarFunction(
+                    mir::ScalarFunctionApplication {
+                        function: mir::ScalarFunction::Eq,
+                        args: vec![
+                            mir::Expression::Variable(mir::Variable {
+                                name: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                            mir::Expression::Variable(mir::Variable {
+                                name: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                        ],
+                        is_nullable: false,
+                    }
+                )),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
+            ast::FilterExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Comparison(ast::ComparisonOp::Eq),
+                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            }
+        )),
+    );
+
+    // FILTER([1], this = foo.this)
+    test_algebrize!(
+        with_this_variable_and_field_access,
+        method = algebrize_expression,
+        expression_context = ExpressionContext::default(),
+        expected = Ok(mir::Expression::HigherOrderFunction(
+            mir::HigherOrderFunctionApplication::Filter(mir::FilterExpr {
+                array: Box::new(mir::Expression::Array(mir::ArrayExpr {
+                    array: vec![mir::Expression::Literal(mir::LiteralValue::Integer(1))]
+                })),
+                f: Box::new(mir::Expression::ScalarFunction(
+                    mir::ScalarFunctionApplication {
+                        function: mir::ScalarFunction::Add,
+                        args: vec![
+                            mir::Expression::Variable(mir::Variable {
+                                name: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                            mir::Expression::FieldAccess(mir::FieldAccess {
+                                expr: Box::new(mir::Expression::Reference(mir::ReferenceExpr {
+                                    key: ("foo", 0u16).into(),
+                                })),
+                                field: "this".to_string(),
+                                is_nullable: false,
+                            }),
+                        ],
+                        is_nullable: false,
+                    }
+                )),
+                is_nullable: false,
+            })
+        )),
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
+            ast::FilterExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Comparison(ast::ComparisonOp::Eq),
+                        right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            subpath: "this".to_string(),
+                        })),
+                    }
+                ))),
+            }
+        )),
+        env = map! {
+            ("foo", 0u16).into() => Schema::Document( Document {
+                keys: map! {
+                    "this".into() => Schema::Atomic(Atomic::Integer),
+                },
+                required: set! { "this".to_string() },
+                additional_properties: false,
+                ..Default::default()
+            }),
+        },
+    );
+
+    test_algebrize!(
+        invalid_array_arg,
+        method = algebrize_expression,
+        expected = Err(Error::HigherOrderFunctionWrapper {
+            name: "Filter",
+            cause: HigherOrderFunctionErrorCause::ArrayArg,
+            error: Box::new(Error::FieldNotFound(
+                "foo".to_string(),
+                None,
+                ClauseType::Unintialized,
+                0u16
+            )),
+        }),
+        expected_error_code = 3035,
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
+            ast::FilterExpr {
+                array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    subpath: "a".to_string(),
+                })),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
+                    ast::Literal::Boolean(true)
+                ))),
+            }
+        )),
+    );
+
+    test_algebrize!(
+        invalid_function_arg,
+        method = algebrize_expression,
+        expected = Err(Error::HigherOrderFunctionWrapper {
+            name: "Filter",
+            cause: HigherOrderFunctionErrorCause::FunctionArg,
+            error: Box::new(Error::FieldNotFound(
+                "foo".to_string(),
+                None,
+                ClauseType::Unintialized,
+                0u16
+            )),
+        }),
+        expected_error_code = 3035,
+        input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
+            ast::FilterExpr {
+                array: Box::new(ast::Expression::Array(vec![ast::Expression::Literal(
+                    ast::Literal::Integer(1)
+                )])),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        op: ast::BinaryOp::Comparison(ast::ComparisonOp::Eq),
+                        right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
+                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            subpath: "this".to_string(),
+                        })),
+                    }
+                ))),
+            }
+        )),
+    );
+}

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -480,7 +480,7 @@ mod filter {
                 })),
                 f: Box::new(mir::Expression::ScalarFunction(
                     mir::ScalarFunctionApplication {
-                        function: mir::ScalarFunction::Add,
+                        function: mir::ScalarFunction::Eq,
                         args: vec![
                             mir::Expression::Variable(mir::Variable {
                                 name: "this".to_string(),

--- a/mongosql/src/algebrizer/test/expressions/identifier_and_subpath.rs
+++ b/mongosql/src/algebrizer/test/expressions/identifier_and_subpath.rs
@@ -551,10 +551,11 @@ test_algebrize!(
 );
 
 test_algebrize!(
-    unqualified_this_in_map_context_is_variable,
+    unqualified_this_with_this_in_context_is_variable,
     method = algebrize_expression,
-    expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map),
+    expression_context = ExpressionContext::default().with_variables(&mut map! {
+        "this" => Schema::Atomic(Atomic::Integer),
+    }),
     expected = Ok(mir::Expression::Variable(mir::Variable {
         name: "this".into(),
         is_nullable: false,
@@ -570,63 +571,12 @@ test_algebrize!(
             ..Default::default()
         }),
     },
-    variables = map! {
-        "this" => Schema::Atomic(Atomic::Integer),
-    },
 );
 
 test_algebrize!(
-    unqualified_this_in_filter_context_is_variable,
+    unqualified_this_without_this_in_context_is_field,
     method = algebrize_expression,
-    expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Filter),
-    expected = Ok(mir::Expression::Variable(mir::Variable {
-        name: "this".into(),
-        is_nullable: true,
-    })),
-    input = ast::Expression::Identifier("this".into()),
-    env = map! {
-        ("foo", 0u16).into() => Schema::Document(Document {
-            keys: map! {
-                "this".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"this".to_string()},
-            additional_properties: false,
-            ..Default::default()
-        }),
-    },
-);
-
-test_algebrize!(
-    unqualified_this_in_reduce_context_is_variable,
-    method = algebrize_expression,
-    expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce),
-    expected = Ok(mir::Expression::Variable(mir::Variable {
-        name: "this".into(),
-        is_nullable: false,
-    })),
-    input = ast::Expression::Identifier("this".into()),
-    env = map! {
-        ("foo", 0u16).into() => Schema::Document(Document {
-            keys: map! {
-                "this".into() => Schema::Atomic(Atomic::Integer),
-            },
-            required: set! {"this".to_string()},
-            additional_properties: false,
-            ..Default::default()
-        }),
-    },
-    variables = map! {
-        "this" => Schema::Atomic(Atomic::Integer),
-    },
-);
-
-test_algebrize!(
-    unqualified_this_is_field_when_no_hof_context,
-    method = algebrize_expression,
-    expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::None),
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(("foo", 0u16).into())),
         field: "this".into(),
@@ -646,40 +596,14 @@ test_algebrize!(
 );
 
 test_algebrize!(
-    unqualified_value_in_map_context_is_error_when_no_field_with_that_name_exists,
+    unqualified_value_with_value_in_context_is_variable,
     method = algebrize_expression,
-    expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map),
-    expected = Err(Error::FieldNotFound(
-        "value".into(),
-        None,
-        ClauseType::Unintialized,
-        0u16,
-    )),
-    expected_error_code = 3008,
-    input = ast::Expression::Identifier("value".into()),
-);
-
-test_algebrize!(
-    unqualified_value_in_filter_context_is_error_when_no_field_with_that_name_exists,
-    method = algebrize_expression,
-    expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Filter),
-    expected = Err(Error::FieldNotFound(
-        "value".into(),
-        None,
-        ClauseType::Unintialized,
-        0u16,
-    )),
-    expected_error_code = 3008,
-    input = ast::Expression::Identifier("value".into()),
-);
-
-test_algebrize!(
-    unqualified_value_in_reduce_context_is_variable,
-    method = algebrize_expression,
-    expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce),
+    expression_context = ExpressionContext::default().with_variables(&mut map! {
+        "value" => Schema::AnyOf(set! {
+            Schema::Atomic(Atomic::Null),
+            Schema::Atomic(Atomic::Integer)
+        }),
+    }),
     expected = Ok(mir::Expression::Variable(mir::Variable {
         name: "value".into(),
         is_nullable: true,
@@ -695,16 +619,12 @@ test_algebrize!(
             ..Default::default()
         }),
     },
-    variables = map! {
-        "value" => Schema::AnyOf(set! {Schema::Atomic(Atomic::Null), Schema::Atomic(Atomic::Integer)}),
-    },
 );
 
 test_algebrize!(
-    unqualified_value_is_field_when_no_hof_context,
+    unqualified_value_wihtou_value_in_context_is_field,
     method = algebrize_expression,
-    expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::None),
+    expression_context = ExpressionContext::default(),
     expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
         expr: Box::new(mir::Expression::Reference(("foo", 1u16).into())),
         field: "value".into(),

--- a/mongosql/src/algebrizer/test/expressions/identifier_and_subpath.rs
+++ b/mongosql/src/algebrizer/test/expressions/identifier_and_subpath.rs
@@ -549,3 +549,167 @@ test_algebrize!(
     expected_error_code = 3008,
     input = ast::Expression::Identifier("bar".into()),
 );
+
+test_algebrize!(
+    unqualified_this_in_map_context_is_variable,
+    method = algebrize_expression,
+    expression_context = ExpressionContext::default()
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map(true)),
+    expected = Ok(mir::Expression::Variable(mir::Variable {
+        name: "this".into(),
+        is_nullable: true,
+    })),
+    input = ast::Expression::Identifier("this".into()),
+    env = map! {
+        ("foo", 0u16).into() => Schema::Document( Document {
+            keys: map! {
+                "this".into() => Schema::Atomic( Atomic::Integer),
+            },
+            required: set! {"this".to_string()},
+            additional_properties: false,
+            ..Default::default()
+        }),
+    },
+);
+
+test_algebrize!(
+    unqualified_this_in_filter_context_is_variable,
+    method = algebrize_expression,
+    expression_context = ExpressionContext::default()
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Filter(false)),
+    expected = Ok(mir::Expression::Variable(mir::Variable {
+        name: "this".into(),
+        is_nullable: false,
+    })),
+    input = ast::Expression::Identifier("this".into()),
+    env = map! {
+        ("foo", 0u16).into() => Schema::Document( Document {
+            keys: map! {
+                "this".into() => Schema::Atomic( Atomic::Integer),
+            },
+            required: set! {"this".to_string()},
+            additional_properties: false,
+            ..Default::default()
+        }),
+    },
+);
+
+test_algebrize!(
+    unqualified_this_in_reduce_context_is_variable,
+    method = algebrize_expression,
+    expression_context = ExpressionContext::default()
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce(true, false)),
+    expected = Ok(mir::Expression::Variable(mir::Variable {
+        name: "this".into(),
+        is_nullable: true,
+    })),
+    input = ast::Expression::Identifier("this".into()),
+    env = map! {
+        ("foo", 0u16).into() => Schema::Document( Document {
+            keys: map! {
+                "this".into() => Schema::Atomic( Atomic::Integer),
+            },
+            required: set! {"this".to_string()},
+            additional_properties: false,
+            ..Default::default()
+        }),
+    },
+);
+
+test_algebrize!(
+    unqualified_this_is_field_when_no_hof_context,
+    method = algebrize_expression,
+    expression_context = ExpressionContext::default()
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::None),
+    expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
+        expr: Box::new(mir::Expression::Reference(("foo", 0u16).into())),
+        field: "this".into(),
+        is_nullable: false,
+    })),
+    input = ast::Expression::Identifier("this".into()),
+    env = map! {
+        ("foo", 0u16).into() => Schema::Document( Document {
+            keys: map! {
+                "this".into() => Schema::Atomic( Atomic::Integer),
+            },
+            required: set! {"this".to_string()},
+            additional_properties: false,
+            ..Default::default()
+        }),
+    },
+);
+
+test_algebrize!(
+    unqualified_value_in_map_context_is_error_when_no_field_with_that_name_exists,
+    method = algebrize_expression,
+    expression_context = ExpressionContext::default()
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map(true)),
+    expected = Err(Error::FieldNotFound(
+        "value".into(),
+        None,
+        ClauseType::Unintialized,
+        0u16,
+    )),
+    expected_error_code = 3008,
+    input = ast::Expression::Identifier("value".into()),
+);
+
+test_algebrize!(
+    unqualified_value_in_filter_context_is_error_when_no_field_with_that_name_exists,
+    method = algebrize_expression,
+    expression_context = ExpressionContext::default()
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Filter(true)),
+    expected = Err(Error::FieldNotFound(
+        "value".into(),
+        None,
+        ClauseType::Unintialized,
+        0u16,
+    )),
+    expected_error_code = 3008,
+    input = ast::Expression::Identifier("value".into()),
+);
+
+test_algebrize!(
+    unqualified_value_in_reduce_context_is_variable,
+    method = algebrize_expression,
+    expression_context = ExpressionContext::default()
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce(false, true)),
+    expected = Ok(mir::Expression::Variable(mir::Variable {
+        name: "value".into(),
+        is_nullable: true,
+    })),
+    input = ast::Expression::Identifier("value".into()),
+    env = map! {
+        ("foo", 0u16).into() => Schema::Document( Document {
+            keys: map! {
+                "value".into() => Schema::Atomic( Atomic::Integer),
+            },
+            required: set! {"value".to_string()},
+            additional_properties: false,
+            ..Default::default()
+        }),
+    },
+);
+
+test_algebrize!(
+    unqualified_value_is_field_when_no_hof_context,
+    method = algebrize_expression,
+    expression_context = ExpressionContext::default()
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::None),
+    expected = Ok(mir::Expression::FieldAccess(mir::FieldAccess {
+        expr: Box::new(mir::Expression::Reference(("foo", 1u16).into())),
+        field: "value".into(),
+        is_nullable: false,
+    })),
+    input = ast::Expression::Identifier("value".into()),
+    env = map! {
+        ("foo", 1u16).into() => Schema::Document( Document {
+            keys: map! {
+                "value".into() => Schema::Atomic( Atomic::Integer),
+            },
+            required: set! {"value".to_string()},
+            additional_properties: false,
+            ..Default::default()
+        }),
+    },
+);

--- a/mongosql/src/algebrizer/test/expressions/identifier_and_subpath.rs
+++ b/mongosql/src/algebrizer/test/expressions/identifier_and_subpath.rs
@@ -554,21 +554,24 @@ test_algebrize!(
     unqualified_this_in_map_context_is_variable,
     method = algebrize_expression,
     expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map(true)),
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map),
     expected = Ok(mir::Expression::Variable(mir::Variable {
         name: "this".into(),
-        is_nullable: true,
+        is_nullable: false,
     })),
     input = ast::Expression::Identifier("this".into()),
     env = map! {
-        ("foo", 0u16).into() => Schema::Document( Document {
+        ("foo", 0u16).into() => Schema::Document(Document {
             keys: map! {
-                "this".into() => Schema::Atomic( Atomic::Integer),
+                "this".into() => Schema::Atomic(Atomic::Integer),
             },
             required: set! {"this".to_string()},
             additional_properties: false,
             ..Default::default()
         }),
+    },
+    variables = map! {
+        "this" => Schema::Atomic(Atomic::Integer),
     },
 );
 
@@ -576,16 +579,16 @@ test_algebrize!(
     unqualified_this_in_filter_context_is_variable,
     method = algebrize_expression,
     expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Filter(false)),
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Filter),
     expected = Ok(mir::Expression::Variable(mir::Variable {
         name: "this".into(),
-        is_nullable: false,
+        is_nullable: true,
     })),
     input = ast::Expression::Identifier("this".into()),
     env = map! {
-        ("foo", 0u16).into() => Schema::Document( Document {
+        ("foo", 0u16).into() => Schema::Document(Document {
             keys: map! {
-                "this".into() => Schema::Atomic( Atomic::Integer),
+                "this".into() => Schema::Atomic(Atomic::Integer),
             },
             required: set! {"this".to_string()},
             additional_properties: false,
@@ -598,21 +601,24 @@ test_algebrize!(
     unqualified_this_in_reduce_context_is_variable,
     method = algebrize_expression,
     expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce(true, false)),
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce),
     expected = Ok(mir::Expression::Variable(mir::Variable {
         name: "this".into(),
-        is_nullable: true,
+        is_nullable: false,
     })),
     input = ast::Expression::Identifier("this".into()),
     env = map! {
-        ("foo", 0u16).into() => Schema::Document( Document {
+        ("foo", 0u16).into() => Schema::Document(Document {
             keys: map! {
-                "this".into() => Schema::Atomic( Atomic::Integer),
+                "this".into() => Schema::Atomic(Atomic::Integer),
             },
             required: set! {"this".to_string()},
             additional_properties: false,
             ..Default::default()
         }),
+    },
+    variables = map! {
+        "this" => Schema::Atomic(Atomic::Integer),
     },
 );
 
@@ -628,9 +634,9 @@ test_algebrize!(
     })),
     input = ast::Expression::Identifier("this".into()),
     env = map! {
-        ("foo", 0u16).into() => Schema::Document( Document {
+        ("foo", 0u16).into() => Schema::Document(Document {
             keys: map! {
-                "this".into() => Schema::Atomic( Atomic::Integer),
+                "this".into() => Schema::Atomic(Atomic::Integer),
             },
             required: set! {"this".to_string()},
             additional_properties: false,
@@ -643,7 +649,7 @@ test_algebrize!(
     unqualified_value_in_map_context_is_error_when_no_field_with_that_name_exists,
     method = algebrize_expression,
     expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map(true)),
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Map),
     expected = Err(Error::FieldNotFound(
         "value".into(),
         None,
@@ -658,7 +664,7 @@ test_algebrize!(
     unqualified_value_in_filter_context_is_error_when_no_field_with_that_name_exists,
     method = algebrize_expression,
     expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Filter(true)),
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Filter),
     expected = Err(Error::FieldNotFound(
         "value".into(),
         None,
@@ -673,21 +679,24 @@ test_algebrize!(
     unqualified_value_in_reduce_context_is_variable,
     method = algebrize_expression,
     expression_context = ExpressionContext::default()
-        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce(false, true)),
+        .with_higher_order_function_arg_ctx(HigherOrderFunctionCtx::Reduce),
     expected = Ok(mir::Expression::Variable(mir::Variable {
         name: "value".into(),
         is_nullable: true,
     })),
     input = ast::Expression::Identifier("value".into()),
     env = map! {
-        ("foo", 0u16).into() => Schema::Document( Document {
+        ("foo", 0u16).into() => Schema::Document(Document {
             keys: map! {
-                "value".into() => Schema::Atomic( Atomic::Integer),
+                "value".into() => Schema::Atomic(Atomic::Integer),
             },
             required: set! {"value".to_string()},
             additional_properties: false,
             ..Default::default()
         }),
+    },
+    variables = map! {
+        "value" => Schema::AnyOf(set! {Schema::Atomic(Atomic::Null), Schema::Atomic(Atomic::Integer)}),
     },
 );
 
@@ -703,9 +712,9 @@ test_algebrize!(
     })),
     input = ast::Expression::Identifier("value".into()),
     env = map! {
-        ("foo", 1u16).into() => Schema::Document( Document {
+        ("foo", 1u16).into() => Schema::Document(Document {
             keys: map! {
-                "value".into() => Schema::Atomic( Atomic::Integer),
+                "value".into() => Schema::Atomic(Atomic::Integer),
             },
             required: set! {"value".to_string()},
             additional_properties: false,

--- a/mongosql/src/algebrizer/test/expressions/mod.rs
+++ b/mongosql/src/algebrizer/test/expressions/mod.rs
@@ -16,6 +16,7 @@ mod binary;
 mod case;
 mod date_function;
 mod extract;
+mod higher_order_functions;
 mod identifier_and_subpath;
 mod literal;
 mod scalar_function;

--- a/mongosql/src/algebrizer/test/mod.rs
+++ b/mongosql/src/algebrizer/test/mod.rs
@@ -19,7 +19,7 @@ macro_rules! test_algebrize {
         fn $func_name() {
             #[allow(unused_imports)]
             use $crate::{
-                algebrizer::{Algebrizer, ExpressionContext, Error, ClauseType},
+                algebrizer::{Algebrizer, ExpressionContext, HigherOrderFunctionCtx, Error, ClauseType},
                 algebrizer::errors::HigherOrderFunctionErrorCause,
                 catalog::Catalog,
                 SchemaCheckingMode,

--- a/mongosql/src/algebrizer/test/mod.rs
+++ b/mongosql/src/algebrizer/test/mod.rs
@@ -20,6 +20,7 @@ macro_rules! test_algebrize {
             #[allow(unused_imports)]
             use $crate::{
                 algebrizer::{Algebrizer, ExpressionContext, Error, ClauseType},
+                algebrizer::errors::HigherOrderFunctionErrorCause,
                 catalog::Catalog,
                 SchemaCheckingMode,
             };
@@ -57,6 +58,7 @@ macro_rules! test_algebrize_expr_and_schema_check {
             #[allow(unused)]
             use $crate::{
                 algebrizer::{Algebrizer, ExpressionContext, Error, ClauseType},
+                algebrizer::errors::HigherOrderFunctionErrorCause,
                 catalog::Catalog,
                 SchemaCheckingMode,
                 mir::schema::CachedSchema,

--- a/mongosql/src/algebrizer/test/mod.rs
+++ b/mongosql/src/algebrizer/test/mod.rs
@@ -14,7 +14,7 @@ use mongosql_datastructures::binding_tuple::Key;
 
 #[macro_export]
 macro_rules! test_algebrize {
-    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_pat = $expected_pat:pat,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)? $(is_add_fields = $is_add_fields:expr, )?) => {
+    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_pat = $expected_pat:pat,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(variables = $variables:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)? $(is_add_fields = $is_add_fields:expr, )?) => {
         #[test]
         fn $func_name() {
             #[allow(unused_imports)]
@@ -23,7 +23,10 @@ macro_rules! test_algebrize {
                 algebrizer::errors::HigherOrderFunctionErrorCause,
                 catalog::Catalog,
                 SchemaCheckingMode,
+                schema::Schema,
             };
+
+            use std::collections::BTreeMap;
 
             #[allow(unused_mut, unused_assignments)]
             let mut catalog = Catalog::default();
@@ -33,9 +36,13 @@ macro_rules! test_algebrize {
             let mut schema_checking_mode = SchemaCheckingMode::Strict;
             $(schema_checking_mode = $schema_checking_mode;)?
 
+            #[allow(unused_mut, unused_assignments, unused_variables)]
+            let mut variables: BTreeMap<&'static str, Schema> = BTreeMap::new();
+            $(variables = $variables;)?
+
             #[allow(unused_mut, unused_assignments)]
             let mut algebrizer = Algebrizer::new("test".into(), &catalog, 0u16, schema_checking_mode, false, ClauseType::Unintialized);
-            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default());)?
+            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default(), variables);)?
             $(algebrizer = algebrizer.with_expression_context($expression_context);)?
 
             let res: Result<_, Error> = algebrizer.$method($ast $(, $source)? $(, $is_add_fields)?);
@@ -52,7 +59,7 @@ macro_rules! test_algebrize {
 
 #[macro_export]
 macro_rules! test_algebrize_expr_and_schema_check {
-    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)?) => {
+    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(variables = $variables:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)?) => {
         #[test]
         fn $func_name() {
             #[allow(unused)]
@@ -62,7 +69,10 @@ macro_rules! test_algebrize_expr_and_schema_check {
                 catalog::Catalog,
                 SchemaCheckingMode,
                 mir::schema::CachedSchema,
+                schema::Schema,
             };
+
+            use std::collections::BTreeMap;
 
             #[allow(unused_mut, unused_assignments)]
             let mut catalog = Catalog::default();
@@ -72,9 +82,13 @@ macro_rules! test_algebrize_expr_and_schema_check {
             let mut schema_checking_mode = SchemaCheckingMode::Strict;
             $(schema_checking_mode = $schema_checking_mode;)?
 
+            #[allow(unused_mut, unused_assignments, unused_variables)]
+            let mut variables: BTreeMap<&'static str, Schema> = BTreeMap::new();
+            $(variables = $variables;)?
+
             #[allow(unused_mut, unused_assignments)]
             let mut algebrizer = Algebrizer::new("test".into(), &catalog, 0u16, schema_checking_mode, false, ClauseType::Unintialized);
-            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default());)?
+            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default(), variables);)?
             $(algebrizer = algebrizer.with_expression_context($expression_context);)?
 
             let res: Result<_, Error> = algebrizer.$method($ast $(, $source)?);

--- a/mongosql/src/algebrizer/test/mod.rs
+++ b/mongosql/src/algebrizer/test/mod.rs
@@ -14,19 +14,17 @@ use mongosql_datastructures::binding_tuple::Key;
 
 #[macro_export]
 macro_rules! test_algebrize {
-    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_pat = $expected_pat:pat,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(variables = $variables:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)? $(is_add_fields = $is_add_fields:expr, )?) => {
+    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_pat = $expected_pat:pat,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)? $(is_add_fields = $is_add_fields:expr, )?) => {
         #[test]
         fn $func_name() {
             #[allow(unused_imports)]
             use $crate::{
-                algebrizer::{Algebrizer, ExpressionContext, HigherOrderFunctionCtx, Error, ClauseType},
+                algebrizer::{Algebrizer, ExpressionContext, Error, ClauseType},
                 algebrizer::errors::HigherOrderFunctionErrorCause,
                 catalog::Catalog,
                 SchemaCheckingMode,
                 schema::Schema,
             };
-
-            use std::collections::BTreeMap;
 
             #[allow(unused_mut, unused_assignments)]
             let mut catalog = Catalog::default();
@@ -36,13 +34,9 @@ macro_rules! test_algebrize {
             let mut schema_checking_mode = SchemaCheckingMode::Strict;
             $(schema_checking_mode = $schema_checking_mode;)?
 
-            #[allow(unused_mut, unused_assignments, unused_variables)]
-            let mut variables: BTreeMap<&'static str, Schema> = BTreeMap::new();
-            $(variables = $variables;)?
-
             #[allow(unused_mut, unused_assignments)]
             let mut algebrizer = Algebrizer::new("test".into(), &catalog, 0u16, schema_checking_mode, false, ClauseType::Unintialized);
-            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default(), variables);)?
+            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default());)?
             $(algebrizer = algebrizer.with_expression_context($expression_context);)?
 
             let res: Result<_, Error> = algebrizer.$method($ast $(, $source)? $(, $is_add_fields)?);
@@ -59,7 +53,7 @@ macro_rules! test_algebrize {
 
 #[macro_export]
 macro_rules! test_algebrize_expr_and_schema_check {
-    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(variables = $variables:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)?) => {
+    ($func_name:ident, method = $method:ident, $(expression_context = $expression_context:expr,)? $(expected = $expected:expr,)? $(expected_error_code = $expected_error_code:literal,)? input = $ast:expr, $(source = $source:expr,)? $(env = $env:expr,)? $(catalog = $catalog:expr,)? $(schema_checking_mode = $schema_checking_mode:expr,)?) => {
         #[test]
         fn $func_name() {
             #[allow(unused)]
@@ -72,8 +66,6 @@ macro_rules! test_algebrize_expr_and_schema_check {
                 schema::Schema,
             };
 
-            use std::collections::BTreeMap;
-
             #[allow(unused_mut, unused_assignments)]
             let mut catalog = Catalog::default();
             $(catalog = $catalog;)?
@@ -82,13 +74,9 @@ macro_rules! test_algebrize_expr_and_schema_check {
             let mut schema_checking_mode = SchemaCheckingMode::Strict;
             $(schema_checking_mode = $schema_checking_mode;)?
 
-            #[allow(unused_mut, unused_assignments, unused_variables)]
-            let mut variables: BTreeMap<&'static str, Schema> = BTreeMap::new();
-            $(variables = $variables;)?
-
             #[allow(unused_mut, unused_assignments)]
             let mut algebrizer = Algebrizer::new("test".into(), &catalog, 0u16, schema_checking_mode, false, ClauseType::Unintialized);
-            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default(), variables);)?
+            $(algebrizer = Algebrizer::with_schema_env("test".into(), $env, &catalog, 1u16, schema_checking_mode, false, ClauseType::Unintialized, ExpressionContext::default());)?
             $(algebrizer = algebrizer.with_expression_context($expression_context);)?
 
             let res: Result<_, Error> = algebrizer.$method($ast $(, $source)?);

--- a/mongosql/src/algebrizer/test/order_by_clause/mod.rs
+++ b/mongosql/src/algebrizer/test/order_by_clause/mod.rs
@@ -2,7 +2,7 @@ use super::catalog;
 use crate::{
     ast, map, mir,
     mir::schema::SchemaCache,
-    schema::{Atomic, Document, Schema},
+    schema::{Atomic, Document},
     set, unchecked_unique_linked_hash_map,
 };
 

--- a/mongosql/src/algebrizer/test/schema_checking_mode/mod.rs
+++ b/mongosql/src/algebrizer/test/schema_checking_mode/mod.rs
@@ -3,7 +3,6 @@ use crate::{
     ast,
     mir::{schema::SchemaCache, *},
     usererror::UserError,
-    Schema,
 };
 
 test_algebrize!(

--- a/mongosql/src/algebrizer/test/set_query/mod.rs
+++ b/mongosql/src/algebrizer/test/set_query/mod.rs
@@ -2,7 +2,7 @@ use super::{
     catalog, mir_source_bar, mir_source_collection_with_project, mir_source_foo, AST_QUERY_BAR,
     AST_QUERY_FOO, AST_SOURCE_BAR, AST_SOURCE_FOO,
 };
-use crate::schema::{Document, Schema};
+use crate::schema::Document;
 use crate::{ast, map, mir, mir::schema::SchemaCache, multimap, schema, set};
 use mongosql_datastructures::binding_tuple::DatasourceName;
 

--- a/mongosql/src/algebrizer/test/subquery/mod.rs
+++ b/mongosql/src/algebrizer/test/subquery/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     ast, map,
     mir::{binding_tuple::DatasourceName, schema::SchemaCache, *},
     multimap,
-    schema::{Atomic, Document, Schema},
+    schema::{Atomic, Document},
     set, unchecked_unique_linked_hash_map,
     usererror::UserError,
 };


### PR DESCRIPTION
This PR implements algebrization for `HigherOrderFunction` expressions (including the disambiguation of unqualified identifiers into `Variable`s), as described by the [design doc](https://docs.google.com/document/d/15bcFJ1wH6BcQYem7slPP8eG142BSvmjY3UuTNve8r7I/edit?tab=t.0#heading=h.ntgguxk2r0tf). This builds off of the refactor that was previously merged in #179 .

This PR touched 10 files, but 6 of those files are simply incidental changes because of updated test macro apis and imports.

The relevant changes are in `algebrizer/definitions.rs`, where the actual algebrization implementations are written, and in `algebrizer/tests/expressions/{higher_order_functions.rs, identifier_and_subpath.rs}`, where the unit tests for all new algebrization is written.

Similar to schema-checking for higher order functions, this implementation introduces a `HigherOrderFunctionWrapper` error variant that wraps algebrizer errors in some additional context to help users understand (1) that an issue happened _within_ a higher order function and (2) what specific component of the higher order function caused it. Fortunately, wrapping errors in the algebrizer is _much_ more straightforward than in the schema checking module.

Building off of #179 , I added an additional field to the `ExpressionContext` that tracks if we are in a higher order function argument context and, if so, which one. Recall from the design doc that since we are not allowing users to specify variable names (they must use `this` and `value`) we also implicitly accepted that shadowing will happen if higher order functions are nested within each other. Keep that in mind when you observe uses of the new context field! Notice that we never actually "restore" previous context since it will never really matter! A higher order function function argument is algebrized with a new algebrizer with properly set state, so subsequent algebrization afterwards is unaffected by its state since it uses a different algebrizer struct.