### PR TITLE
SQL-3297: Implement HigherOrderFunctionAliasVisitor

### DIFF
--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -106,7 +106,6 @@ impl TryFrom<ast::FunctionName> for mir::ScalarFunction {
             | ast::FunctionName::Minute
             | ast::FunctionName::Second
             | ast::FunctionName::Millisecond
-            | ast::FunctionName::ArrayCast
             | ast::FunctionName::ArrayExtract
             | ast::FunctionName::ArrayCompact
             | ast::FunctionName::ArrayRemove
@@ -196,7 +195,6 @@ impl TryFrom<ast::FunctionName> for mir::AggregationFunction {
             | ast::FunctionName::Minute
             | ast::FunctionName::Second
             | ast::FunctionName::Millisecond
-            | ast::FunctionName::ArrayCast
             | ast::FunctionName::ArrayExtract
             | ast::FunctionName::ArrayCompact
             | ast::FunctionName::ArrayRemove
@@ -1562,6 +1560,7 @@ impl<'a> Algebrizer<'a> {
             ast::Expression::SubqueryComparison(s) => self.algebrize_subquery_comparison(s),
             ast::Expression::Exists(e) => self.algebrize_exists(*e),
             ast::Expression::HigherOrderFunction(h) => self.algebrize_higher_order_function(h),
+            ast::Expression::ArrayCast(_) => unreachable!("ARRAY_CAST should have been rewritten"),
         }
     }
 
@@ -1925,7 +1924,6 @@ impl<'a> Algebrizer<'a> {
             | (ast::FunctionName::Minute, _)
             | (ast::FunctionName::Second, _)
             | (ast::FunctionName::Millisecond, _)
-            | (ast::FunctionName::ArrayCast, _)
             | (ast::FunctionName::ArrayExtract, _)
             | (ast::FunctionName::ArrayCompact, _)
             | (ast::FunctionName::ArrayRemove, _)

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -105,7 +105,18 @@ impl TryFrom<ast::FunctionName> for mir::ScalarFunction {
             | ast::FunctionName::Hour
             | ast::FunctionName::Minute
             | ast::FunctionName::Second
-            | ast::FunctionName::Millisecond => unreachable! {},
+            | ast::FunctionName::Millisecond
+            | ast::FunctionName::ArrayCast
+            | ast::FunctionName::ArrayExtract
+            | ast::FunctionName::ArrayCompact
+            | ast::FunctionName::ArrayRemove
+            | ast::FunctionName::ArrayCountIf
+            | ast::FunctionName::ArraySum
+            | ast::FunctionName::ArrayProduct
+            | ast::FunctionName::ArrayAverage
+            | ast::FunctionName::ArrayAll
+            | ast::FunctionName::ArrayAny
+            | ast::FunctionName::ArrayJoin => unreachable! {},
             ast::FunctionName::AddToArray
             | ast::FunctionName::AddToSet
             | ast::FunctionName::Avg
@@ -184,7 +195,18 @@ impl TryFrom<ast::FunctionName> for mir::AggregationFunction {
             | ast::FunctionName::Hour
             | ast::FunctionName::Minute
             | ast::FunctionName::Second
-            | ast::FunctionName::Millisecond => {
+            | ast::FunctionName::Millisecond
+            | ast::FunctionName::ArrayCast
+            | ast::FunctionName::ArrayExtract
+            | ast::FunctionName::ArrayCompact
+            | ast::FunctionName::ArrayRemove
+            | ast::FunctionName::ArrayCountIf
+            | ast::FunctionName::ArraySum
+            | ast::FunctionName::ArrayProduct
+            | ast::FunctionName::ArrayAverage
+            | ast::FunctionName::ArrayAll
+            | ast::FunctionName::ArrayAny
+            | ast::FunctionName::ArrayJoin => {
                 return Err(Error::ScalarInPlaceOfAggregation(f.pretty_print().unwrap()))
             }
         })
@@ -1902,7 +1924,18 @@ impl<'a> Algebrizer<'a> {
             | (ast::FunctionName::Hour, _)
             | (ast::FunctionName::Minute, _)
             | (ast::FunctionName::Second, _)
-            | (ast::FunctionName::Millisecond, _) => {
+            | (ast::FunctionName::Millisecond, _)
+            | (ast::FunctionName::ArrayCast, _)
+            | (ast::FunctionName::ArrayExtract, _)
+            | (ast::FunctionName::ArrayCompact, _)
+            | (ast::FunctionName::ArrayRemove, _)
+            | (ast::FunctionName::ArrayCountIf, _)
+            | (ast::FunctionName::ArraySum, _)
+            | (ast::FunctionName::ArrayProduct, _)
+            | (ast::FunctionName::ArrayAverage, _)
+            | (ast::FunctionName::ArrayAll, _)
+            | (ast::FunctionName::ArrayAny, _)
+            | (ast::FunctionName::ArrayJoin, _) => {
                 unreachable!("{:?} should have been rewritten", f.function)
             }
         };

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -112,7 +112,7 @@ impl TryFrom<ast::FunctionName> for mir::ScalarFunction {
             | ast::FunctionName::ArrayCountIf
             | ast::FunctionName::ArraySum
             | ast::FunctionName::ArrayProduct
-            | ast::FunctionName::ArrayAverage
+            | ast::FunctionName::ArrayAvg
             | ast::FunctionName::ArrayAll
             | ast::FunctionName::ArrayAny
             | ast::FunctionName::ArrayJoin => unreachable! {},
@@ -201,7 +201,7 @@ impl TryFrom<ast::FunctionName> for mir::AggregationFunction {
             | ast::FunctionName::ArrayCountIf
             | ast::FunctionName::ArraySum
             | ast::FunctionName::ArrayProduct
-            | ast::FunctionName::ArrayAverage
+            | ast::FunctionName::ArrayAvg
             | ast::FunctionName::ArrayAll
             | ast::FunctionName::ArrayAny
             | ast::FunctionName::ArrayJoin => {
@@ -1930,7 +1930,7 @@ impl<'a> Algebrizer<'a> {
             | (ast::FunctionName::ArrayCountIf, _)
             | (ast::FunctionName::ArraySum, _)
             | (ast::FunctionName::ArrayProduct, _)
-            | (ast::FunctionName::ArrayAverage, _)
+            | (ast::FunctionName::ArrayAvg, _)
             | (ast::FunctionName::ArrayAll, _)
             | (ast::FunctionName::ArrayAny, _)
             | (ast::FunctionName::ArrayJoin, _) => {

--- a/mongosql/src/ast/definitions.rs
+++ b/mongosql/src/ast/definitions.rs
@@ -289,6 +289,7 @@ pub enum Expression {
     Extract(ExtractExpr),
     Cast(CastExpr),
     Array(Vec<Expression>),
+    ArrayCast(ArrayCastExpr),
     Subquery(Box<Query>),
     Exists(Box<Query>),
     SubqueryComparison(SubqueryComparisonExpr),
@@ -326,6 +327,12 @@ pub struct CastExpr {
     pub to: Type,
     pub on_null: Option<Box<Expression>>,
     pub on_error: Option<Box<Expression>>,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct ArrayCastExpr {
+    pub expr: Box<Expression>,
+    pub to: Type,
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -490,7 +497,6 @@ pub enum FunctionName {
     Millisecond,
 
     // Higher Order Function aliases
-    ArrayCast,
     ArrayExtract,
     ArrayCompact,
     ArrayRemove,
@@ -646,7 +652,6 @@ impl TryFrom<&str> for FunctionName {
             "SECOND" => Ok(FunctionName::Second),
             "MILLISECOND" => Ok(FunctionName::Millisecond),
 
-            "ARRAY_CAST" => Ok(FunctionName::ArrayCast),
             "ARRAY_EXTRACT" => Ok(FunctionName::ArrayExtract),
             "ARRAY_COMPACT" => Ok(FunctionName::ArrayCompact),
             "ARRAY_REMOVE" => Ok(FunctionName::ArrayRemove),
@@ -722,7 +727,6 @@ impl FunctionName {
             FunctionName::Minute => "MINUTE",
             FunctionName::Second => "SECOND",
             FunctionName::Millisecond => "MILLISECOND",
-            FunctionName::ArrayCast => "ARRAY_CAST",
             FunctionName::ArrayExtract => "ARRAY_EXTRACT",
             FunctionName::ArrayCompact => "ARRAY_COMPACT",
             FunctionName::ArrayRemove => "ARRAY_REMOVE",
@@ -795,7 +799,6 @@ impl FunctionName {
             | FunctionName::Minute
             | FunctionName::Second
             | FunctionName::Millisecond
-            | FunctionName::ArrayCast
             | FunctionName::ArrayExtract
             | FunctionName::ArrayCompact
             | FunctionName::ArrayRemove

--- a/mongosql/src/ast/definitions.rs
+++ b/mongosql/src/ast/definitions.rs
@@ -1010,41 +1010,41 @@ pub enum Type {
 
 #[derive(PartialEq, Debug, Clone, VariantCount)]
 pub enum HigherOrderFunctionExpr {
-  Map(MapExpr),
-  Filter(FilterExpr),
-  Reduce(ReduceExpr),
+    Map(MapExpr),
+    Filter(FilterExpr),
+    Reduce(ReduceExpr),
 }
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct MapExpr {
-  pub array: Box<Expression>,
-  pub f: Box<FunctionArgument>,
+    pub array: Box<Expression>,
+    pub f: Box<FunctionArgument>,
 }
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct FilterExpr {
-  pub array: Box<Expression>,
-  pub f: Box<FunctionArgument>,
+    pub array: Box<Expression>,
+    pub f: Box<FunctionArgument>,
 }
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct ReduceExpr {
-  pub array: Box<Expression>,
-  pub init_value: Box<Expression>,
-  pub f: Box<FunctionArgument>,
+    pub array: Box<Expression>,
+    pub init_value: Box<Expression>,
+    pub f: Box<FunctionArgument>,
 }
 
 #[derive(PartialEq, Debug, Clone, VariantCount)]
 pub enum FunctionArgument {
-  Expr(Expression),
-  NamedFunction(NamedFunction)
+    Expr(Expression),
+    NamedFunction(NamedFunction)
 }
 
 #[derive(PartialEq, Debug, Clone, VariantCount)]
 pub enum NamedFunction {
-  UnaryOp(UnaryOp),
-  BinaryOp(BinaryOp),
-  Function(FunctionName),
+    UnaryOp(UnaryOp),
+    BinaryOp(BinaryOp),
+    Function(FunctionName),
 }
 
 } // end of generate_visitors! block

--- a/mongosql/src/ast/definitions.rs
+++ b/mongosql/src/ast/definitions.rs
@@ -488,6 +488,19 @@ pub enum FunctionName {
     Minute,
     Second,
     Millisecond,
+
+    // Higher Order Function aliases
+    ArrayCast,
+    ArrayExtract,
+    ArrayCompact,
+    ArrayRemove,
+    ArrayCountIf,
+    ArraySum,
+    ArrayProduct,
+    ArrayAverage,
+    ArrayAll,
+    ArrayAny,
+    ArrayJoin,
 }
 
 impl TryFrom<FunctionName> for TrimSpec {
@@ -632,6 +645,18 @@ impl TryFrom<&str> for FunctionName {
             "MINUTE" => Ok(FunctionName::Minute),
             "SECOND" => Ok(FunctionName::Second),
             "MILLISECOND" => Ok(FunctionName::Millisecond),
+
+            "ARRAY_CAST" => Ok(FunctionName::ArrayCast),
+            "ARRAY_EXTRACT" => Ok(FunctionName::ArrayExtract),
+            "ARRAY_COMPACT" => Ok(FunctionName::ArrayCompact),
+            "ARRAY_REMOVE" => Ok(FunctionName::ArrayRemove),
+            "ARRAY_COUNT_IF" => Ok(FunctionName::ArrayCountIf),
+            "ARRAY_SUM" => Ok(FunctionName::ArraySum),
+            "ARRAY_PRODUCT" => Ok(FunctionName::ArrayProduct),
+            "ARRAY_AVERAGE" => Ok(FunctionName::ArrayAverage),
+            "ARRAY_ALL" => Ok(FunctionName::ArrayAll),
+            "ARRAY_ANY" => Ok(FunctionName::ArrayAny),
+            "ARRAY_JOIN" => Ok(FunctionName::ArrayJoin),
             _ => Err(format!("unknown function {name}")),
         }
     }
@@ -697,6 +722,17 @@ impl FunctionName {
             FunctionName::Minute => "MINUTE",
             FunctionName::Second => "SECOND",
             FunctionName::Millisecond => "MILLISECOND",
+            FunctionName::ArrayCast => "ARRAY_CAST",
+            FunctionName::ArrayExtract => "ARRAY_EXTRACT",
+            FunctionName::ArrayCompact => "ARRAY_COMPACT",
+            FunctionName::ArrayRemove => "ARRAY_REMOVE",
+            FunctionName::ArrayCountIf => "ARRAY_COUNT_IF",
+            FunctionName::ArraySum => "ARRAY_SUM",
+            FunctionName::ArrayProduct => "ARRAY_PRODUCT",
+            FunctionName::ArrayAverage => "ARRAY_AVERAGE",
+            FunctionName::ArrayAll => "ARRAY_ALL",
+            FunctionName::ArrayAny => "ARRAY_ANY",
+            FunctionName::ArrayJoin => "ARRAY_JOIN",
         }
     }
 
@@ -758,7 +794,18 @@ impl FunctionName {
             | FunctionName::Hour
             | FunctionName::Minute
             | FunctionName::Second
-            | FunctionName::Millisecond => false,
+            | FunctionName::Millisecond
+            | FunctionName::ArrayCast
+            | FunctionName::ArrayExtract
+            | FunctionName::ArrayCompact
+            | FunctionName::ArrayRemove
+            | FunctionName::ArrayCountIf
+            | FunctionName::ArraySum
+            | FunctionName::ArrayProduct
+            | FunctionName::ArrayAverage
+            | FunctionName::ArrayAll
+            | FunctionName::ArrayAny
+            | FunctionName::ArrayJoin => false,
         }
     }
 }

--- a/mongosql/src/ast/definitions.rs
+++ b/mongosql/src/ast/definitions.rs
@@ -503,7 +503,7 @@ pub enum FunctionName {
     ArrayCountIf,
     ArraySum,
     ArrayProduct,
-    ArrayAverage,
+    ArrayAvg,
     ArrayAll,
     ArrayAny,
     ArrayJoin,
@@ -658,7 +658,7 @@ impl TryFrom<&str> for FunctionName {
             "ARRAY_COUNT_IF" => Ok(FunctionName::ArrayCountIf),
             "ARRAY_SUM" => Ok(FunctionName::ArraySum),
             "ARRAY_PRODUCT" => Ok(FunctionName::ArrayProduct),
-            "ARRAY_AVERAGE" => Ok(FunctionName::ArrayAverage),
+            "ARRAY_AVG" => Ok(FunctionName::ArrayAvg),
             "ARRAY_ALL" => Ok(FunctionName::ArrayAll),
             "ARRAY_ANY" => Ok(FunctionName::ArrayAny),
             "ARRAY_JOIN" => Ok(FunctionName::ArrayJoin),
@@ -733,7 +733,7 @@ impl FunctionName {
             FunctionName::ArrayCountIf => "ARRAY_COUNT_IF",
             FunctionName::ArraySum => "ARRAY_SUM",
             FunctionName::ArrayProduct => "ARRAY_PRODUCT",
-            FunctionName::ArrayAverage => "ARRAY_AVERAGE",
+            FunctionName::ArrayAvg => "ARRAY_AVG",
             FunctionName::ArrayAll => "ARRAY_ALL",
             FunctionName::ArrayAny => "ARRAY_ANY",
             FunctionName::ArrayJoin => "ARRAY_JOIN",
@@ -805,7 +805,7 @@ impl FunctionName {
             | FunctionName::ArrayCountIf
             | FunctionName::ArraySum
             | FunctionName::ArrayProduct
-            | FunctionName::ArrayAverage
+            | FunctionName::ArrayAvg
             | FunctionName::ArrayAll
             | FunctionName::ArrayAny
             | FunctionName::ArrayJoin => false,

--- a/mongosql/src/ast/pretty_print.rs
+++ b/mongosql/src/ast/pretty_print.rs
@@ -750,6 +750,7 @@ impl Expression {
             // formatting for all the following is handled specially and will never conditionally
             // wrap arguments in parentheses
             Array(_)
+            | ArrayCast(_)
             | Case(_)
             | Cast(_)
             | Document(_)
@@ -830,6 +831,7 @@ impl PrettyPrint for Expression {
             Exists(q) => Ok(format!("EXISTS({})", q.pretty_print()?)),
             SubqueryComparison(sc) => sc.pretty_print(),
             HigherOrderFunction(hof) => hof.pretty_print(),
+            ArrayCast(ac) => ac.pretty_print(),
         }
     }
 }
@@ -1335,5 +1337,15 @@ impl PrettyPrint for FunctionArgument {
             FunctionArgument::NamedFunction(NamedFunction::BinaryOp(b)) => b.pretty_print()?,
             FunctionArgument::NamedFunction(NamedFunction::Function(f)) => f.pretty_print()?,
         })
+    }
+}
+
+impl PrettyPrint for ArrayCastExpr {
+    fn pretty_print(&self) -> Result<String> {
+        Ok(format!(
+            "ARRAY_CAST({}, {})",
+            self.expr.pretty_print()?,
+            self.to.pretty_print()?
+        ))
     }
 }

--- a/mongosql/src/ast/pretty_print.rs
+++ b/mongosql/src/ast/pretty_print.rs
@@ -57,7 +57,7 @@ lazy_static! {
         r"(?i)inner$",
         r"(?i)int$",
         r"(?i)integer$",
-        r"(?i)is$",
+        r"(?i)^is$",
         r"(?i)javascript$",
         r"(?i)javascriptwithscope$",
         r"(?i)join$",

--- a/mongosql/src/ast/pretty_print_fuzz_test.rs
+++ b/mongosql/src/ast/pretty_print_fuzz_test.rs
@@ -646,8 +646,7 @@ mod arbitrary {
                 // TODO: SQL-3298: Replace `23 => TypeAssertion` with `23 => HigherOrderFunction`
                 23 => Self::TypeAssertion(TypeAssertionExpr::arbitrary(nested_g)),
                 // 23 => Self::HigherOrderFunction(HigherOrderFunctionExpr::arbitrary(nested_g)),
-                // TODO: SQL-3298: Replace `24 => TypeAssertion` with `24 => ArrayCastExpr`
-                // 24 => Self::ArrayCast(ArrayCastExpr::arbitrary(nested_g)),
+                24 => Self::ArrayCast(ArrayCastExpr::arbitrary(nested_g)),
                 _ => panic!("missing Expression variant(s)"),
             }
         }

--- a/mongosql/src/ast/pretty_print_fuzz_test.rs
+++ b/mongosql/src/ast/pretty_print_fuzz_test.rs
@@ -938,7 +938,7 @@ mod arbitrary {
                 55 => Self::ArrayCountIf,
                 56 => Self::ArraySum,
                 57 => Self::ArrayProduct,
-                58 => Self::ArrayAverage,
+                58 => Self::ArrayAvg,
                 59 => Self::ArrayAll,
                 60 => Self::ArrayAny,
                 61 => Self::ArrayJoin,

--- a/mongosql/src/ast/pretty_print_fuzz_test.rs
+++ b/mongosql/src/ast/pretty_print_fuzz_test.rs
@@ -646,6 +646,8 @@ mod arbitrary {
                 // TODO: SQL-3298: Replace `23 => TypeAssertion` with `23 => HigherOrderFunction`
                 23 => Self::TypeAssertion(TypeAssertionExpr::arbitrary(nested_g)),
                 // 23 => Self::HigherOrderFunction(HigherOrderFunctionExpr::arbitrary(nested_g)),
+                // TODO: SQL-3298: Replace `24 => TypeAssertion` with `24 => ArrayCastExpr`
+                // 24 => Self::ArrayCast(ArrayCastExpr::arbitrary(nested_g)),
                 _ => panic!("missing Expression variant(s)"),
             }
         }
@@ -928,6 +930,18 @@ mod arbitrary {
                 49 => Self::Second,
                 50 => Self::Millisecond,
                 51 => Self::Replace,
+
+                // Higher Order Function aliases
+                52 => Self::ArrayExtract,
+                53 => Self::ArrayCompact,
+                54 => Self::ArrayRemove,
+                55 => Self::ArrayCountIf,
+                56 => Self::ArraySum,
+                57 => Self::ArrayProduct,
+                58 => Self::ArrayAverage,
+                59 => Self::ArrayAll,
+                60 => Self::ArrayAny,
+                61 => Self::ArrayJoin,
                 _ => panic!("missing FunctionName variant(s)"),
             }
         }
@@ -1261,6 +1275,15 @@ mod arbitrary {
                 1 => Self::BinaryOp(BinaryOp::arbitrary(g)),
                 2 => Self::Function(FunctionName::arbitrary(g)),
                 _ => panic!("missing NamedFunction variant(s)"),
+            }
+        }
+    }
+
+    impl Arbitrary for ArrayCastExpr {
+        fn arbitrary(g: &mut Gen) -> Self {
+            Self {
+                expr: Box::new(Expression::arbitrary(g)),
+                to: Type::arbitrary(g),
             }
         }
     }

--- a/mongosql/src/ast/pretty_print_test.rs
+++ b/mongosql/src/ast/pretty_print_test.rs
@@ -744,6 +744,15 @@ mod cast_and_assert {
     );
 }
 
+mod array_cast {
+    use super::*;
+    expression_printer_test!(
+        array_cast,
+        expected = "ARRAY_CAST(x, STRING)",
+        input = "ARRAY_CAST(x, STRING)"
+    );
+}
+
 mod literal {
     use super::*;
     expression_printer_test!(null, expected = "NULL", input = "nUlL");

--- a/mongosql/src/ast/pretty_print_test.rs
+++ b/mongosql/src/ast/pretty_print_test.rs
@@ -544,6 +544,7 @@ mod identifier {
         input = "foo1"
     );
     expression_printer_test!(empty, expected = "``", input = "``");
+    expression_printer_test!(is_keyword, expected = "`is`", input = "`is`");
 }
 
 mod is {

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -18,6 +18,10 @@ impl Pass for HigherOrderFunctionsRewritePass {
         let mut func_alias_visitor = HigherOrderFunctionsAliasVisitor { error: None };
         let query = query.walk(&mut func_alias_visitor);
 
+        if let Some(error) = func_alias_visitor.error {
+            return Err(error);
+        }
+
         let mut func_arg_visitor = FunctionArgumentVisitor;
         let query = query.walk(&mut func_arg_visitor);
 

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     self,
-    rewrites::{Error, Pass, Result},
+    rewrites::{assert_arg_count, ArgCount, Error, Pass, Result},
     visitor::Visitor,
     AccessExpr, BinaryExpr, BinaryOp, ComparisonOp, Expression, FilterExpr, FunctionArgument,
     FunctionArguments, FunctionExpr, FunctionName, HigherOrderFunctionExpr, IsExpr, Literal,
@@ -43,11 +43,31 @@ impl Visitor for HigherOrderFunctionsAliasVisitor {
                     FunctionName::ArrayCompact => Self::rewrite_array_compact(args),
                     FunctionName::ArrayRemove => Self::rewrite_array_remove(args),
                     FunctionName::ArrayCountIf => Self::rewrite_array_count_if(args),
-                    FunctionName::ArraySum => Self::rewrite_array_sum(args),
-                    FunctionName::ArrayProduct => Self::rewrite_array_product(args),
+                    FunctionName::ArraySum => Self::rewrite_single_arg_reduce_alias(
+                        function.as_str(),
+                        args,
+                        Literal::Integer(0),
+                        BinaryOp::Add,
+                    ),
+                    FunctionName::ArrayProduct => Self::rewrite_single_arg_reduce_alias(
+                        function.as_str(),
+                        args,
+                        Literal::Integer(1),
+                        BinaryOp::Mul,
+                    ),
                     FunctionName::ArrayAverage => Self::rewrite_array_average(args),
-                    FunctionName::ArrayAll => Self::rewrite_array_all(args),
-                    FunctionName::ArrayAny => Self::rewrite_array_any(args),
+                    FunctionName::ArrayAll => Self::rewrite_single_arg_reduce_alias(
+                        function.as_str(),
+                        args,
+                        Literal::Boolean(true),
+                        BinaryOp::And,
+                    ),
+                    FunctionName::ArrayAny => Self::rewrite_single_arg_reduce_alias(
+                        function.as_str(),
+                        args,
+                        Literal::Boolean(false),
+                        BinaryOp::Or,
+                    ),
                     FunctionName::ArrayJoin => Self::rewrite_array_join(args),
                     _ => return node,
                 };
@@ -88,6 +108,32 @@ impl HigherOrderFunctionsAliasVisitor {
         }))
     }
 
+    /// Returns the `this` identifier expression used within higher order function bodies.
+    fn this() -> Expression {
+        Expression::Identifier(THIS.to_string())
+    }
+
+    /// Returns the `value` identifier expression used within higher order function bodies.
+    fn value() -> Expression {
+        Expression::Identifier(VALUE.to_string())
+    }
+
+    fn make_binary(left: Expression, op: BinaryOp, right: Expression) -> Expression {
+        Expression::Binary(BinaryExpr {
+            left: Box::new(left),
+            op,
+            right: Box::new(right),
+        })
+    }
+
+    fn make_size(array: Expression) -> Expression {
+        Expression::Function(FunctionExpr {
+            function: FunctionName::Size,
+            args: FunctionArguments::Args(vec![array]),
+            set_quantifier: None,
+        })
+    }
+
     fn rewrite_array_cast(args: &[Expression]) -> Result<Expression> {
         // TODO: need to handle array_cast specially since it takes a Type as an argument
         todo!()
@@ -95,13 +141,8 @@ impl HigherOrderFunctionsAliasVisitor {
 
     /// Rewrite `ARRAY_EXTRACT(a, expr)` into `MAP(a, this.expr)`.
     fn rewrite_array_extract(args: &[Expression]) -> Result<Expression> {
-        if args.len() != 2 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_EXTRACT",
-                required: "2",
-                found: args.len(),
-            });
-        }
+        assert_arg_count("ARRAY_EXTRACT", args.len(), ArgCount::Exactly(2))?;
+
         let array = &args[0];
         let extract_expr = &args[1];
 
@@ -109,7 +150,7 @@ impl HigherOrderFunctionsAliasVisitor {
         // If it is not, we should wrap it in an AccessExpr with "this" as the base.
         let f = prepend_parent_to_field_path_expr(THIS, extract_expr).unwrap_or_else(|| {
             Expression::Access(AccessExpr {
-                expr: Box::new(Expression::Identifier(THIS.to_string())),
+                expr: Box::new(Self::this()),
                 subfield: Box::new(extract_expr.clone()),
             })
         });
@@ -119,21 +160,16 @@ impl HigherOrderFunctionsAliasVisitor {
 
     /// Rewrite `ARRAY_COMPACT(a)` into `FILTER(a, NOT this IS NULL)`.
     fn rewrite_array_compact(args: &[Expression]) -> Result<Expression> {
-        if args.len() != 1 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_COMPACT",
-                required: "1",
-                found: args.len(),
-            });
-        }
+        assert_arg_count("ARRAY_COMPACT", args.len(), ArgCount::Exactly(1))?;
 
         let array = &args[0];
+
         Ok(Self::make_filter(
             array.clone(),
             Expression::Unary(UnaryExpr {
                 op: UnaryOp::Not,
                 expr: Box::new(Expression::Is(IsExpr {
-                    expr: Box::new(Expression::Identifier(THIS.to_string())),
+                    expr: Box::new(Self::this()),
                     target_type: TypeOrMissing::Type(Type::Null),
                 })),
             }),
@@ -142,155 +178,64 @@ impl HigherOrderFunctionsAliasVisitor {
 
     /// Rewrite `ARRAY_REMOVE(a, x)` into `FILTER(a, this <> x)`.
     fn rewrite_array_remove(args: &[Expression]) -> Result<Expression> {
-        if args.len() != 2 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_REMOVE",
-                required: "2",
-                found: args.len(),
-            });
-        }
+        assert_arg_count("ARRAY_REMOVE", args.len(), ArgCount::Exactly(2))?;
 
         let array = &args[0];
-        let x = &args[1];
+        let remove_expr = &args[1];
+
         Ok(Self::make_filter(
             array.clone(),
-            Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier(THIS.to_string())),
-                op: BinaryOp::Comparison(ComparisonOp::Neq),
-                right: Box::new(x.clone()),
-            }),
+            Self::make_binary(
+                Self::this(),
+                BinaryOp::Comparison(ComparisonOp::Neq),
+                remove_expr.clone(),
+            ),
         ))
     }
 
     /// Rewrite `ARRAY_COUNT_IF(a, f)` into `SIZE(FILTER(a, f))`.
     fn rewrite_array_count_if(args: &[Expression]) -> Result<Expression> {
-        if args.len() != 2 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_COUNT_IF",
-                required: "2",
-                found: args.len(),
-            });
-        }
+        assert_arg_count("ARRAY_COUNT_IF", args.len(), ArgCount::Exactly(2))?;
 
         let array = &args[0];
         let f = &args[1];
-        Ok(Expression::Function(FunctionExpr {
-            function: FunctionName::Size,
-            args: FunctionArguments::Args(vec![Self::make_filter(array.clone(), f.clone())]),
-            set_quantifier: None,
-        }))
+
+        Ok(Self::make_size(Self::make_filter(array.clone(), f.clone())))
     }
 
-    /// Rewrite `ARRAY_SUM(a)` into `REDUCE(a, 0, this + value)`.
-    fn rewrite_array_sum(args: &[Expression]) -> Result<Expression> {
-        if args.len() != 1 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_SUM",
-                required: "1",
-                found: args.len(),
-            });
-        }
+    /// Rewrite any single-argument reduce-alias function (e.g., `ARRAY_SUM(a)` into
+    /// `REDUCE(a, init_value, value op this)`.
+    fn rewrite_single_arg_reduce_alias(
+        name: &'static str,
+        args: &[Expression],
+        init_value: Literal,
+        op: BinaryOp,
+    ) -> Result<Expression> {
+        assert_arg_count(name, args.len(), ArgCount::Exactly(1))?;
 
         let array = &args[0];
+
         Ok(Self::make_reduce(
             array.clone(),
-            Expression::Literal(Literal::Integer(0)),
-            Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier(THIS.to_string())),
-                op: BinaryOp::Add,
-                right: Box::new(Expression::Identifier(VALUE.to_string())),
-            }),
-        ))
-    }
-
-    /// Rewrite `ARRAY_PRODUCT(a)` into `REDUCE(a, 1, this * value)`.
-    fn rewrite_array_product(args: &[Expression]) -> Result<Expression> {
-        if args.len() != 1 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_PRODUCT",
-                required: "1",
-                found: args.len(),
-            });
-        }
-
-        let array = &args[0];
-        Ok(Self::make_reduce(
-            array.clone(),
-            Expression::Literal(Literal::Integer(1)),
-            Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier(THIS.to_string())),
-                op: BinaryOp::Mul,
-                right: Box::new(Expression::Identifier(VALUE.to_string())),
-            }),
+            Expression::Literal(init_value),
+            Self::make_binary(Self::value(), op, Self::this()),
         ))
     }
 
     /// Rewrite `ARRAY_AVERAGE(a)` into `REDUCE(a, 0, this + value) / SIZE(a)`.
     fn rewrite_array_average(args: &[Expression]) -> Result<Expression> {
-        if args.len() != 1 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_AVERAGE",
-                required: "1",
-                found: args.len(),
-            });
-        }
-
-        let rewritten_sum = Self::rewrite_array_sum(args)?;
-        let array = &args[0];
-        Ok(Expression::Binary(BinaryExpr {
-            left: Box::new(rewritten_sum),
-            op: BinaryOp::Div,
-            right: Box::new(Expression::Function(FunctionExpr {
-                function: FunctionName::Size,
-                args: FunctionArguments::Args(vec![array.clone()]),
-                set_quantifier: None,
-            })),
-        }))
-    }
-
-    /// Rewrite `ARRAY_ALL(a)` into `REDUCE(a, true, value AND this)`.
-    fn rewrite_array_all(args: &[Expression]) -> Result<Expression> {
-        if args.len() != 1 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_ALL",
-                required: "1",
-                found: args.len(),
-            });
-        }
-
+        let rewritten_sum = Self::rewrite_single_arg_reduce_alias(
+            "ARRAY_AVERAGE",
+            args,
+            Literal::Integer(0),
+            BinaryOp::Add,
+        )?;
         let array = &args[0];
 
-        Ok(Self::make_reduce(
-            array.clone(),
-            Expression::Literal(Literal::Boolean(true)),
-            Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier(VALUE.to_string())),
-                op: BinaryOp::And,
-                right: Box::new(Expression::Identifier(THIS.to_string())),
-            }),
-        ))
-    }
-
-    /// Rewrite `ARRAY_ANY(a)` into `REDUCE(a, false, value OR this)`.
-    fn rewrite_array_any(args: &[Expression]) -> Result<Expression> {
-        if args.len() != 1 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_ANY",
-                required: "1",
-                found: args.len(),
-            });
-        }
-
-        let array = &args[0];
-
-        Ok(Self::make_reduce(
-            array.clone(),
-            Expression::Literal(Literal::Boolean(false)),
-            Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier(VALUE.to_string())),
-                op: BinaryOp::Or,
-                right: Box::new(Expression::Identifier(THIS.to_string())),
-            }),
+        Ok(Self::make_binary(
+            rewritten_sum,
+            BinaryOp::Div,
+            Self::make_size(array.clone()),
         ))
     }
 
@@ -298,13 +243,7 @@ impl HigherOrderFunctionsAliasVisitor {
     /// and rewrite `ARRAY_JOIN(a, sep)` into
     /// `TRIM(LEADING sep FROM REDUCE(a, '', value || sep || this))`.
     fn rewrite_array_join(args: &[Expression]) -> Result<Expression> {
-        if args.len() < 1 || args.len() > 2 {
-            return Err(Error::IncorrectArgumentCount {
-                name: "ARRAY_JOIN",
-                required: "1 or 2",
-                found: args.len(),
-            });
-        }
+        assert_arg_count("ARRAY_JOIN", args.len(), ArgCount::Either(1, 2))?;
 
         let array = &args[0];
         let mut sep = Expression::StringConstructor("".to_string());
@@ -316,11 +255,7 @@ impl HigherOrderFunctionsAliasVisitor {
             Ok(Self::make_reduce(
                 array.clone(),
                 Expression::StringConstructor("".to_string()),
-                Expression::Binary(BinaryExpr {
-                    left: Box::new(Expression::Identifier(VALUE.to_string())),
-                    op: BinaryOp::Concat,
-                    right: Box::new(Expression::Identifier(THIS.to_string())),
-                }),
+                Self::make_binary(Self::value(), BinaryOp::Concat, Self::this()),
             ))
         } else {
             Ok(Expression::Trim(TrimExpr {
@@ -329,15 +264,11 @@ impl HigherOrderFunctionsAliasVisitor {
                 arg: Box::new(Self::make_reduce(
                     array.clone(),
                     Expression::StringConstructor("".to_string()),
-                    Expression::Binary(BinaryExpr {
-                        left: Box::new(Expression::Binary(BinaryExpr {
-                            left: Box::new(Expression::Identifier(VALUE.to_string())),
-                            op: BinaryOp::Concat,
-                            right: Box::new(sep.clone()),
-                        })),
-                        op: BinaryOp::Concat,
-                        right: Box::new(Expression::Identifier(THIS.to_string())),
-                    }),
+                    Self::make_binary(
+                        Self::make_binary(Self::value(), BinaryOp::Concat, sep.clone()),
+                        BinaryOp::Concat,
+                        Self::this(),
+                    ),
                 )),
             }))
         }

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     self,
-    rewrites::{assert_arg_count, ArgCount, Error, Pass, Result},
+    rewrites::{try_exact_args, try_extract_either_args, Error, Pass, Result},
     visitor::Visitor,
     AccessExpr, ArrayCastExpr, BinaryExpr, BinaryOp, CastExpr, ComparisonOp, Expression,
     FilterExpr, FunctionArgument, FunctionArguments, FunctionExpr, FunctionName,
@@ -170,10 +170,7 @@ impl HigherOrderFunctionsAliasVisitor {
 
     /// Rewrite `ARRAY_EXTRACT(a, expr)` into `MAP(a, this.expr)`.
     fn rewrite_array_extract(args: &[Expression]) -> Result<Expression> {
-        assert_arg_count("ARRAY_EXTRACT", args.len(), ArgCount::Exactly(2))?;
-
-        let array = &args[0];
-        let extract_expr = &args[1];
+        let [array, extract_expr] = try_exact_args("ARRAY_EXTRACT", args)?;
 
         // If the second argument is a field-path-like Expression, we should prepend "this" to it.
         // If it is not, we should wrap it in an AccessExpr with "this" as the base.
@@ -189,9 +186,7 @@ impl HigherOrderFunctionsAliasVisitor {
 
     /// Rewrite `ARRAY_COMPACT(a)` into `FILTER(a, NOT this IS NULL)`.
     fn rewrite_array_compact(args: &[Expression]) -> Result<Expression> {
-        assert_arg_count("ARRAY_COMPACT", args.len(), ArgCount::Exactly(1))?;
-
-        let array = &args[0];
+        let [array] = try_exact_args("ARRAY_COMPACT", args)?;
 
         Ok(Self::make_filter(
             array.clone(),
@@ -207,10 +202,7 @@ impl HigherOrderFunctionsAliasVisitor {
 
     /// Rewrite `ARRAY_REMOVE(a, x)` into `FILTER(a, this <> x)`.
     fn rewrite_array_remove(args: &[Expression]) -> Result<Expression> {
-        assert_arg_count("ARRAY_REMOVE", args.len(), ArgCount::Exactly(2))?;
-
-        let array = &args[0];
-        let remove_expr = &args[1];
+        let [array, remove_expr] = try_exact_args("ARRAY_REMOVE", args)?;
 
         Ok(Self::make_filter(
             array.clone(),
@@ -224,10 +216,7 @@ impl HigherOrderFunctionsAliasVisitor {
 
     /// Rewrite `ARRAY_COUNT_IF(a, f)` into `SIZE(FILTER(a, f))`.
     fn rewrite_array_count_if(args: &[Expression]) -> Result<Expression> {
-        assert_arg_count("ARRAY_COUNT_IF", args.len(), ArgCount::Exactly(2))?;
-
-        let array = &args[0];
-        let f = &args[1];
+        let [array, f] = try_exact_args("ARRAY_COUNT_IF", args)?;
 
         Ok(Self::make_size(Self::make_filter(array.clone(), f.clone())))
     }
@@ -240,9 +229,7 @@ impl HigherOrderFunctionsAliasVisitor {
         init_value: Literal,
         op: BinaryOp,
     ) -> Result<Expression> {
-        assert_arg_count(name, args.len(), ArgCount::Exactly(1))?;
-
-        let array = &args[0];
+        let [array] = try_exact_args(name, args)?;
 
         Ok(Self::make_reduce(
             array.clone(),
@@ -272,13 +259,13 @@ impl HigherOrderFunctionsAliasVisitor {
     /// and rewrite `ARRAY_JOIN(a, sep)` into
     /// `TRIM(LEADING sep FROM REDUCE(a, '', value || sep || this))`.
     fn rewrite_array_join(args: &[Expression]) -> Result<Expression> {
-        assert_arg_count("ARRAY_JOIN", args.len(), ArgCount::Either(1, 2))?;
+        let ([array], rest_args) = try_extract_either_args::<1, 2>("ARRAY_JOIN", args)?;
 
-        let array = &args[0];
-        let mut sep = Expression::StringConstructor("".to_string());
-        if args.len() == 2 {
-            sep = args[1].clone();
-        }
+        let sep = if let [sep] = rest_args {
+            sep.clone()
+        } else {
+            Expression::StringConstructor("".to_string())
+        };
 
         if sep == Expression::StringConstructor("".to_string()) {
             Ok(Self::make_reduce(

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -100,6 +100,7 @@ impl Visitor for HigherOrderFunctionsAliasVisitor {
 }
 
 impl HigherOrderFunctionsAliasVisitor {
+    #[inline(always)]
     fn make_map(array: Expression, f: Expression) -> Expression {
         Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
             array: Box::new(array),
@@ -107,6 +108,7 @@ impl HigherOrderFunctionsAliasVisitor {
         }))
     }
 
+    #[inline(always)]
     fn make_filter(array: Expression, f: Expression) -> Expression {
         Expression::HigherOrderFunction(HigherOrderFunctionExpr::Filter(FilterExpr {
             array: Box::new(array),
@@ -114,6 +116,7 @@ impl HigherOrderFunctionsAliasVisitor {
         }))
     }
 
+    #[inline(always)]
     fn make_reduce(array: Expression, init_value: Expression, f: Expression) -> Expression {
         Expression::HigherOrderFunction(HigherOrderFunctionExpr::Reduce(ReduceExpr {
             array: Box::new(array),
@@ -123,15 +126,18 @@ impl HigherOrderFunctionsAliasVisitor {
     }
 
     /// Returns the `this` identifier expression used within higher order function bodies.
+    #[inline(always)]
     fn this() -> Expression {
         Expression::Identifier(THIS.to_string())
     }
 
     /// Returns the `value` identifier expression used within higher order function bodies.
+    #[inline(always)]
     fn value() -> Expression {
         Expression::Identifier(VALUE.to_string())
     }
 
+    #[inline(always)]
     fn make_binary(left: Expression, op: BinaryOp, right: Expression) -> Expression {
         Expression::Binary(BinaryExpr {
             left: Box::new(left),
@@ -140,6 +146,7 @@ impl HigherOrderFunctionsAliasVisitor {
         })
     }
 
+    #[inline(always)]
     fn make_size(array: Expression) -> Expression {
         Expression::Function(FunctionExpr {
             function: FunctionName::Size,

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -2,9 +2,10 @@ use crate::ast::{
     self,
     rewrites::{assert_arg_count, ArgCount, Error, Pass, Result},
     visitor::Visitor,
-    AccessExpr, BinaryExpr, BinaryOp, ComparisonOp, Expression, FilterExpr, FunctionArgument,
-    FunctionArguments, FunctionExpr, FunctionName, HigherOrderFunctionExpr, IsExpr, Literal,
-    MapExpr, ReduceExpr, SubpathExpr, TrimExpr, TrimSpec, Type, TypeOrMissing, UnaryExpr, UnaryOp,
+    AccessExpr, ArrayCastExpr, BinaryExpr, BinaryOp, CastExpr, ComparisonOp, Expression,
+    FilterExpr, FunctionArgument, FunctionArguments, FunctionExpr, FunctionName,
+    HigherOrderFunctionExpr, IsExpr, Literal, MapExpr, ReduceExpr, SubpathExpr, TrimExpr, TrimSpec,
+    Type, TypeOrMissing, UnaryExpr, UnaryOp,
 };
 
 const THIS: &str = "this";
@@ -32,13 +33,22 @@ impl Visitor for HigherOrderFunctionsAliasVisitor {
     fn visit_expression(&mut self, node: Expression) -> Expression {
         let node = node.walk(self);
         match node {
+            Expression::ArrayCast(ArrayCastExpr { ref expr, to }) => {
+                let res = Self::rewrite_array_cast(expr, to);
+                match res {
+                    Ok(expr) => expr,
+                    Err(err) => {
+                        self.error = Some(err);
+                        node
+                    }
+                }
+            }
             Expression::Function(FunctionExpr {
                 function,
                 args: FunctionArguments::Args(ref args),
                 set_quantifier: _,
             }) => {
                 let res = match function {
-                    FunctionName::ArrayCast => Self::rewrite_array_cast(args),
                     FunctionName::ArrayExtract => Self::rewrite_array_extract(args),
                     FunctionName::ArrayCompact => Self::rewrite_array_compact(args),
                     FunctionName::ArrayRemove => Self::rewrite_array_remove(args),
@@ -134,9 +144,17 @@ impl HigherOrderFunctionsAliasVisitor {
         })
     }
 
-    fn rewrite_array_cast(args: &[Expression]) -> Result<Expression> {
-        // TODO: need to handle array_cast specially since it takes a Type as an argument
-        todo!()
+    /// Rewrite `ARRAY_CAST(a, to)` into `MAP(a, CAST(this AS to))`.
+    fn rewrite_array_cast(array: &Expression, to: Type) -> Result<Expression> {
+        Ok(Self::make_map(
+            array.clone(),
+            Expression::Cast(CastExpr {
+                expr: Box::new(Self::this()),
+                to,
+                on_null: None,
+                on_error: None,
+            }),
+        ))
     }
 
     /// Rewrite `ARRAY_EXTRACT(a, expr)` into `MAP(a, this.expr)`.

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -65,7 +65,7 @@ impl Visitor for HigherOrderFunctionsAliasVisitor {
                         Literal::Integer(1),
                         BinaryOp::Mul,
                     ),
-                    FunctionName::ArrayAverage => Self::rewrite_array_average(args),
+                    FunctionName::ArrayAvg => Self::rewrite_array_avg(args),
                     FunctionName::ArrayAll => Self::rewrite_single_arg_reduce_alias(
                         function.as_str(),
                         args,
@@ -240,10 +240,10 @@ impl HigherOrderFunctionsAliasVisitor {
         ))
     }
 
-    /// Rewrite `ARRAY_AVERAGE(a)` into `REDUCE(a, 0, this + value) / SIZE(a)`.
-    fn rewrite_array_average(args: &[Expression]) -> Result<Expression> {
+    /// Rewrite `ARRAY_AVG(a)` into `REDUCE(a, 0, this + value) / SIZE(a)`.
+    fn rewrite_array_avg(args: &[Expression]) -> Result<Expression> {
         let rewritten_sum = Self::rewrite_single_arg_reduce_alias(
-            "ARRAY_AVERAGE",
+            "ARRAY_AVG",
             args,
             Literal::Integer(0),
             BinaryOp::Add,

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -1,14 +1,20 @@
 use crate::ast::{
     self,
-    rewrites::{Pass, Result},
+    rewrites::{Error, Pass, Result},
     visitor::Visitor,
+    AccessExpr, BinaryExpr, BinaryOp, ComparisonOp, Expression, FilterExpr, FunctionArgument,
+    FunctionArguments, FunctionExpr, FunctionName, HigherOrderFunctionExpr, IsExpr, Literal,
+    MapExpr, ReduceExpr, SubpathExpr, TrimExpr, TrimSpec, Type, TypeOrMissing, UnaryExpr, UnaryOp,
 };
+
+const THIS: &str = "this";
+const VALUE: &str = "value";
 
 pub struct HigherOrderFunctionsRewritePass;
 
 impl Pass for HigherOrderFunctionsRewritePass {
     fn apply(&self, query: ast::Query) -> Result<ast::Query> {
-        let mut func_alias_visitor = HigherOrderFunctionsAliasVisitor;
+        let mut func_alias_visitor = HigherOrderFunctionsAliasVisitor { error: None };
         let query = query.walk(&mut func_alias_visitor);
 
         let mut func_arg_visitor = FunctionArgumentVisitor;
@@ -18,12 +24,429 @@ impl Pass for HigherOrderFunctionsRewritePass {
     }
 }
 
-struct HigherOrderFunctionsAliasVisitor;
+struct HigherOrderFunctionsAliasVisitor {
+    error: Option<Error>,
+}
 
-// SQL-3297: Implement HigherOrderFunctionsAliasVisitor
-impl Visitor for HigherOrderFunctionsAliasVisitor {}
+impl Visitor for HigherOrderFunctionsAliasVisitor {
+    fn visit_expression(&mut self, node: Expression) -> Expression {
+        let node = node.walk(self);
+        match node {
+            Expression::Function(FunctionExpr {
+                function,
+                args: FunctionArguments::Args(ref args),
+                set_quantifier: _,
+            }) => {
+                let res = match function {
+                    FunctionName::ArrayCast => Self::rewrite_array_cast(args),
+                    FunctionName::ArrayExtract => Self::rewrite_array_extract(args),
+                    FunctionName::ArrayCompact => Self::rewrite_array_compact(args),
+                    FunctionName::ArrayRemove => Self::rewrite_array_remove(args),
+                    FunctionName::ArrayCountIf => Self::rewrite_array_count_if(args),
+                    FunctionName::ArraySum => Self::rewrite_array_sum(args),
+                    FunctionName::ArrayProduct => Self::rewrite_array_product(args),
+                    FunctionName::ArrayAverage => Self::rewrite_array_average(args),
+                    FunctionName::ArrayAll => Self::rewrite_array_all(args),
+                    FunctionName::ArrayAny => Self::rewrite_array_any(args),
+                    FunctionName::ArrayJoin => Self::rewrite_array_join(args),
+                    _ => return node,
+                };
+
+                match res {
+                    Ok(expr) => expr,
+                    Err(err) => {
+                        self.error = Some(err);
+                        node
+                    }
+                }
+            }
+            _ => node,
+        }
+    }
+}
+
+impl HigherOrderFunctionsAliasVisitor {
+    fn make_map(array: Expression, f: Expression) -> Expression {
+        Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+            array: Box::new(array),
+            f: Box::new(FunctionArgument::Expr(f)),
+        }))
+    }
+
+    fn make_filter(array: Expression, f: Expression) -> Expression {
+        Expression::HigherOrderFunction(HigherOrderFunctionExpr::Filter(FilterExpr {
+            array: Box::new(array),
+            f: Box::new(FunctionArgument::Expr(f)),
+        }))
+    }
+
+    fn make_reduce(array: Expression, init_value: Expression, f: Expression) -> Expression {
+        Expression::HigherOrderFunction(HigherOrderFunctionExpr::Reduce(ReduceExpr {
+            array: Box::new(array),
+            init_value: Box::new(init_value),
+            f: Box::new(FunctionArgument::Expr(f)),
+        }))
+    }
+
+    fn rewrite_array_cast(args: &[Expression]) -> Result<Expression> {
+        // TODO: need to handle array_cast specially since it takes a Type as an argument
+        todo!()
+    }
+
+    /// Rewrite `ARRAY_EXTRACT(a, expr)` into `MAP(a, this.expr)`.
+    fn rewrite_array_extract(args: &[Expression]) -> Result<Expression> {
+        if args.len() != 2 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_EXTRACT",
+                required: "2",
+                found: args.len(),
+            });
+        }
+        let array = &args[0];
+        let extract_expr = &args[1];
+
+        // If the second argument is a field-path-like Expression, we should prepend "this" to it.
+        // If it is not, we should wrap it in an AccessExpr with "this" as the base.
+        let f = prepend_parent_to_field_path_expr(THIS, extract_expr).unwrap_or_else(|| {
+            Expression::Access(AccessExpr {
+                expr: Box::new(Expression::Identifier(THIS.to_string())),
+                subfield: Box::new(extract_expr.clone()),
+            })
+        });
+
+        Ok(Self::make_map(array.clone(), f))
+    }
+
+    /// Rewrite `ARRAY_COMPACT(a)` into `FILTER(a, NOT this IS NULL)`.
+    fn rewrite_array_compact(args: &[Expression]) -> Result<Expression> {
+        if args.len() != 1 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_COMPACT",
+                required: "1",
+                found: args.len(),
+            });
+        }
+
+        let array = &args[0];
+        Ok(Self::make_filter(
+            array.clone(),
+            Expression::Unary(UnaryExpr {
+                op: UnaryOp::Not,
+                expr: Box::new(Expression::Is(IsExpr {
+                    expr: Box::new(Expression::Identifier(THIS.to_string())),
+                    target_type: TypeOrMissing::Type(Type::Null),
+                })),
+            }),
+        ))
+    }
+
+    /// Rewrite `ARRAY_REMOVE(a, x)` into `FILTER(a, this <> x)`.
+    fn rewrite_array_remove(args: &[Expression]) -> Result<Expression> {
+        if args.len() != 2 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_REMOVE",
+                required: "2",
+                found: args.len(),
+            });
+        }
+
+        let array = &args[0];
+        let x = &args[1];
+        Ok(Self::make_filter(
+            array.clone(),
+            Expression::Binary(BinaryExpr {
+                left: Box::new(Expression::Identifier(THIS.to_string())),
+                op: BinaryOp::Comparison(ComparisonOp::Neq),
+                right: Box::new(x.clone()),
+            }),
+        ))
+    }
+
+    /// Rewrite `ARRAY_COUNT_IF(a, f)` into `SIZE(FILTER(a, f))`.
+    fn rewrite_array_count_if(args: &[Expression]) -> Result<Expression> {
+        if args.len() != 2 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_COUNT_IF",
+                required: "2",
+                found: args.len(),
+            });
+        }
+
+        let array = &args[0];
+        let f = &args[1];
+        Ok(Expression::Function(FunctionExpr {
+            function: FunctionName::Size,
+            args: FunctionArguments::Args(vec![Self::make_filter(array.clone(), f.clone())]),
+            set_quantifier: None,
+        }))
+    }
+
+    /// Rewrite `ARRAY_SUM(a)` into `REDUCE(a, 0, this + value)`.
+    fn rewrite_array_sum(args: &[Expression]) -> Result<Expression> {
+        if args.len() != 1 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_SUM",
+                required: "1",
+                found: args.len(),
+            });
+        }
+
+        let array = &args[0];
+        Ok(Self::make_reduce(
+            array.clone(),
+            Expression::Literal(Literal::Integer(0)),
+            Expression::Binary(BinaryExpr {
+                left: Box::new(Expression::Identifier(THIS.to_string())),
+                op: BinaryOp::Add,
+                right: Box::new(Expression::Identifier(VALUE.to_string())),
+            }),
+        ))
+    }
+
+    /// Rewrite `ARRAY_PRODUCT(a)` into `REDUCE(a, 1, this * value)`.
+    fn rewrite_array_product(args: &[Expression]) -> Result<Expression> {
+        if args.len() != 1 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_PRODUCT",
+                required: "1",
+                found: args.len(),
+            });
+        }
+
+        let array = &args[0];
+        Ok(Self::make_reduce(
+            array.clone(),
+            Expression::Literal(Literal::Integer(1)),
+            Expression::Binary(BinaryExpr {
+                left: Box::new(Expression::Identifier(THIS.to_string())),
+                op: BinaryOp::Mul,
+                right: Box::new(Expression::Identifier(VALUE.to_string())),
+            }),
+        ))
+    }
+
+    /// Rewrite `ARRAY_AVERAGE(a)` into `REDUCE(a, 0, this + value) / SIZE(a)`.
+    fn rewrite_array_average(args: &[Expression]) -> Result<Expression> {
+        if args.len() != 1 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_AVERAGE",
+                required: "1",
+                found: args.len(),
+            });
+        }
+
+        let rewritten_sum = Self::rewrite_array_sum(args)?;
+        let array = &args[0];
+        Ok(Expression::Binary(BinaryExpr {
+            left: Box::new(rewritten_sum),
+            op: BinaryOp::Div,
+            right: Box::new(Expression::Function(FunctionExpr {
+                function: FunctionName::Size,
+                args: FunctionArguments::Args(vec![array.clone()]),
+                set_quantifier: None,
+            })),
+        }))
+    }
+
+    /// Rewrite `ARRAY_ALL(a)` into `REDUCE(a, true, value AND this)`.
+    fn rewrite_array_all(args: &[Expression]) -> Result<Expression> {
+        if args.len() != 1 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_ALL",
+                required: "1",
+                found: args.len(),
+            });
+        }
+
+        let array = &args[0];
+
+        Ok(Self::make_reduce(
+            array.clone(),
+            Expression::Literal(Literal::Boolean(true)),
+            Expression::Binary(BinaryExpr {
+                left: Box::new(Expression::Identifier(VALUE.to_string())),
+                op: BinaryOp::And,
+                right: Box::new(Expression::Identifier(THIS.to_string())),
+            }),
+        ))
+    }
+
+    /// Rewrite `ARRAY_ANY(a)` into `REDUCE(a, false, value OR this)`.
+    fn rewrite_array_any(args: &[Expression]) -> Result<Expression> {
+        if args.len() != 1 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_ANY",
+                required: "1",
+                found: args.len(),
+            });
+        }
+
+        let array = &args[0];
+
+        Ok(Self::make_reduce(
+            array.clone(),
+            Expression::Literal(Literal::Boolean(false)),
+            Expression::Binary(BinaryExpr {
+                left: Box::new(Expression::Identifier(VALUE.to_string())),
+                op: BinaryOp::Or,
+                right: Box::new(Expression::Identifier(THIS.to_string())),
+            }),
+        ))
+    }
+
+    /// Rewrite `ARRAY_JOIN(a)` or `ARRAY_JOIN(a, '')` into `REDUCE(a, '', value || this)`,
+    /// and rewrite `ARRAY_JOIN(a, sep)` into
+    /// `TRIM(LEADING sep FROM REDUCE(a, '', value || sep || this))`.
+    fn rewrite_array_join(args: &[Expression]) -> Result<Expression> {
+        if args.len() < 1 || args.len() > 2 {
+            return Err(Error::IncorrectArgumentCount {
+                name: "ARRAY_JOIN",
+                required: "1 or 2",
+                found: args.len(),
+            });
+        }
+
+        let array = &args[0];
+        let mut sep = Expression::StringConstructor("".to_string());
+        if args.len() == 2 {
+            sep = args[1].clone();
+        }
+
+        if sep == Expression::StringConstructor("".to_string()) {
+            Ok(Self::make_reduce(
+                array.clone(),
+                Expression::StringConstructor("".to_string()),
+                Expression::Binary(BinaryExpr {
+                    left: Box::new(Expression::Identifier(VALUE.to_string())),
+                    op: BinaryOp::Concat,
+                    right: Box::new(Expression::Identifier(THIS.to_string())),
+                }),
+            ))
+        } else {
+            Ok(Expression::Trim(TrimExpr {
+                trim_spec: TrimSpec::Leading,
+                trim_chars: Box::new(sep.clone()),
+                arg: Box::new(Self::make_reduce(
+                    array.clone(),
+                    Expression::StringConstructor("".to_string()),
+                    Expression::Binary(BinaryExpr {
+                        left: Box::new(Expression::Binary(BinaryExpr {
+                            left: Box::new(Expression::Identifier(VALUE.to_string())),
+                            op: BinaryOp::Concat,
+                            right: Box::new(sep.clone()),
+                        })),
+                        op: BinaryOp::Concat,
+                        right: Box::new(Expression::Identifier(THIS.to_string())),
+                    }),
+                )),
+            }))
+        }
+    }
+}
 
 struct FunctionArgumentVisitor;
 
 // SQL-3296: Implement FunctionArgumentVisitor
 impl Visitor for FunctionArgumentVisitor {}
+
+fn prepend_parent_to_field_path_expr(
+    parent: &str,
+    field_path_expr: &Expression,
+) -> Option<Expression> {
+    match field_path_expr {
+        Expression::Identifier(id) => Some(Expression::Subpath(SubpathExpr {
+            expr: Box::new(Expression::Identifier(parent.to_string())),
+            subpath: id.clone(),
+        })),
+        Expression::Subpath(expr) => Some(Expression::Subpath(SubpathExpr {
+            expr: Box::new(prepend_parent_to_field_path_expr(
+                parent,
+                expr.expr.as_ref(),
+            )?),
+            subpath: expr.subpath.clone(),
+        })),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod prepend_parent_to_field_path_expr_tests {
+    use super::*;
+
+    macro_rules! test_prepend_parent_to_field_path_expr {
+        ($func_name:ident, expected = $expected:expr, input_parent = $input_parent:expr, input_field_path_expr = $input_field_path_expr:expr,) => {
+            #[test]
+            fn $func_name() {
+                let expected = $expected;
+                let input_parent = $input_parent;
+                let input_field_path_expr = $input_field_path_expr;
+
+                let actual =
+                    prepend_parent_to_field_path_expr(input_parent, &input_field_path_expr);
+
+                assert_eq!(expected, actual);
+            }
+        };
+    }
+
+    test_prepend_parent_to_field_path_expr!(
+        identifier,
+        expected = Some(Expression::Subpath(SubpathExpr {
+            expr: Box::new(Expression::Identifier("a".to_string())),
+            subpath: "b".to_string(),
+        })),
+        input_parent = "a",
+        input_field_path_expr = Expression::Identifier("b".to_string()),
+    );
+
+    test_prepend_parent_to_field_path_expr!(
+        subpath,
+        expected = Some(Expression::Subpath(SubpathExpr {
+            expr: Box::new(Expression::Subpath(SubpathExpr {
+                expr: Box::new(Expression::Identifier("a".to_string())),
+                subpath: "b".to_string(),
+            })),
+            subpath: "c".to_string(),
+        })),
+        input_parent = "a",
+        input_field_path_expr = Expression::Subpath(SubpathExpr {
+            expr: Box::new(Expression::Identifier("b".to_string())),
+            subpath: "c".to_string(),
+        }),
+    );
+
+    test_prepend_parent_to_field_path_expr!(
+        deeply_nested_subpath,
+        expected = Some(Expression::Subpath(SubpathExpr {
+            expr: Box::new(Expression::Subpath(SubpathExpr {
+                expr: Box::new(Expression::Subpath(SubpathExpr {
+                    expr: Box::new(Expression::Subpath(SubpathExpr {
+                        expr: Box::new(Expression::Identifier("a".to_string())),
+                        subpath: "b".to_string(),
+                    })),
+                    subpath: "c".to_string(),
+                })),
+                subpath: "d".to_string(),
+            })),
+            subpath: "e".to_string(),
+        })),
+        input_parent = "a",
+        input_field_path_expr = Expression::Subpath(SubpathExpr {
+            expr: Box::new(Expression::Subpath(SubpathExpr {
+                expr: Box::new(Expression::Subpath(SubpathExpr {
+                    expr: Box::new(Expression::Identifier("b".to_string())),
+                    subpath: "c".to_string(),
+                })),
+                subpath: "d".to_string(),
+            })),
+            subpath: "e".to_string(),
+        }),
+    );
+
+    test_prepend_parent_to_field_path_expr!(
+        other,
+        expected = None,
+        input_parent = "a",
+        input_field_path_expr = Expression::Literal(Literal::Integer(1)),
+    );
+}

--- a/mongosql/src/ast/rewrites/mod.rs
+++ b/mongosql/src/ast/rewrites/mod.rs
@@ -57,7 +57,7 @@ pub enum Error {
     #[error("incorrect argument count for {name}: required {required}, found {found}")]
     IncorrectArgumentCount {
         name: &'static str,
-        required: &'static str,
+        required: ArgCount,
         found: usize,
     },
     #[error("invalid date part: {0}")]
@@ -99,4 +99,50 @@ pub fn rewrite_query(query: ast::Query) -> Result<ast::Query> {
         rewritten = pass.apply(rewritten)?;
     }
     Ok(rewritten)
+}
+
+/// Specifies how many arguments a function accepts.
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum ArgCount {
+    /// Exactly this many arguments.
+    Exactly(usize),
+    /// Either of these many arguments.
+    Either(usize, usize),
+}
+
+impl ArgCount {
+    /// Returns whether `n` satisfies this argument count specification.
+    pub(crate) fn contains(&self, n: usize) -> bool {
+        match self {
+            ArgCount::Exactly(count) => n == *count,
+            ArgCount::Either(min, max) => n >= *min && n <= *max,
+        }
+    }
+}
+
+impl std::fmt::Display for ArgCount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArgCount::Exactly(n) => write!(f, "{n}"),
+            ArgCount::Either(min, max) => write!(f, "{min} or {max}"),
+        }
+    }
+}
+
+/// Validates that `args` satisfies `expected`, returning
+/// `Error::IncorrectArgumentCount` otherwise.
+pub(crate) fn assert_arg_count(
+    name: &'static str,
+    args_len: usize,
+    expected: ArgCount,
+) -> Result<()> {
+    if expected.contains(args_len) {
+        Ok(())
+    } else {
+        Err(Error::IncorrectArgumentCount {
+            name,
+            required: expected,
+            found: args_len,
+        })
+    }
 }

--- a/mongosql/src/ast/rewrites/mod.rs
+++ b/mongosql/src/ast/rewrites/mod.rs
@@ -115,7 +115,7 @@ impl ArgCount {
     pub(crate) fn contains(&self, n: usize) -> bool {
         match self {
             ArgCount::Exactly(count) => n == *count,
-            ArgCount::Either(min, max) => n >= *min && n <= *max,
+            ArgCount::Either(a, b) => n == *a || n == *b,
         }
     }
 }
@@ -124,7 +124,7 @@ impl std::fmt::Display for ArgCount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ArgCount::Exactly(n) => write!(f, "{n}"),
-            ArgCount::Either(min, max) => write!(f, "{min} or {max}"),
+            ArgCount::Either(a, b) => write!(f, "{a} or {b}"),
         }
     }
 }

--- a/mongosql/src/ast/rewrites/mod.rs
+++ b/mongosql/src/ast/rewrites/mod.rs
@@ -110,16 +110,6 @@ pub enum ArgCount {
     Either(usize, usize),
 }
 
-impl ArgCount {
-    /// Returns whether `n` satisfies this argument count specification.
-    pub(crate) fn contains(&self, n: usize) -> bool {
-        match self {
-            ArgCount::Exactly(count) => n == *count,
-            ArgCount::Either(a, b) => n == *a || n == *b,
-        }
-    }
-}
-
 impl std::fmt::Display for ArgCount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -129,20 +119,43 @@ impl std::fmt::Display for ArgCount {
     }
 }
 
-/// Validates that `args` satisfies `expected`, returning
-/// `Error::IncorrectArgumentCount` otherwise.
-pub(crate) fn assert_arg_count(
+/// Validates that `args` contains `N` elements, extracting them into as fixed-size array of length
+/// `N` if so. If `args` does not contain exactly `N` elements, an `IncorrectArgumentCount` error is
+/// returned.
+#[inline]
+pub(crate) fn try_exact_args<'a, const N: usize>(
     name: &'static str,
-    args_len: usize,
-    expected: ArgCount,
-) -> Result<()> {
-    if expected.contains(args_len) {
-        Ok(())
-    } else {
-        Err(Error::IncorrectArgumentCount {
+    args: &'a [ast::Expression],
+) -> Result<&'a [ast::Expression; N]> {
+    let Ok(extracted) = args.try_into() else {
+        return Err(Error::IncorrectArgumentCount {
             name,
-            required: expected,
-            found: args_len,
-        })
+            required: ArgCount::Exactly(N),
+            found: args.len(),
+        });
+    };
+    Ok(extracted)
+}
+
+/// Validates that `args` contains either `A` or `B` elements, extracting them into as fixed-size
+/// array of length `A` and a slice of the remaining elements if so. If `args` does not contain
+/// exactly `A` or exactly `B` elements, an `IncorrectArgumentCount` error is returned.
+#[inline]
+pub(crate) fn try_extract_either_args<'a, const A: usize, const B: usize>(
+    name: &'static str,
+    args: &'a [ast::Expression],
+) -> Result<(&'a [ast::Expression; A], &'a [ast::Expression])> {
+    if args.len() != A && args.len() != B {
+        return Err(Error::IncorrectArgumentCount {
+            name,
+            required: ArgCount::Either(A, B),
+            found: args.len(),
+        });
     }
+
+    let (min, rest) = args.split_at(A);
+    let Ok(min) = min.try_into() else {
+        unreachable!();
+    };
+    Ok((min, rest))
 }

--- a/mongosql/src/ast/rewrites/scalar_functions.rs
+++ b/mongosql/src/ast/rewrites/scalar_functions.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     self,
-    rewrites::{Error, Pass, Result},
+    rewrites::{ArgCount, Error, Pass, Result},
     visitor::Visitor,
     *,
 };
@@ -83,7 +83,7 @@ impl Visitor for ScalarFunctionsVisitor {
                     } else {
                         self.error = Some(Error::IncorrectArgumentCount {
                             name: function.as_str(),
-                            required: "1",
+                            required: ArgCount::Exactly(1),
                             found: args.len(),
                         });
                         return node;
@@ -100,7 +100,7 @@ impl Visitor for ScalarFunctionsVisitor {
                     _ => {
                         self.error = Some(Error::IncorrectArgumentCount {
                             name: function.as_str(),
-                            required: "1 or 2",
+                            required: ArgCount::Either(1, 2),
                             found: args.len(),
                         });
                         node
@@ -112,7 +112,7 @@ impl Visitor for ScalarFunctionsVisitor {
                     } else {
                         self.error = Some(Error::IncorrectArgumentCount {
                             name: function.as_str(),
-                            required: "1",
+                            required: ArgCount::Exactly(1),
                             found: args.len(),
                         });
                         node
@@ -135,7 +135,7 @@ impl Visitor for ScalarFunctionsVisitor {
                     } else {
                         self.error = Some(Error::IncorrectArgumentCount {
                             name: function.as_str(),
-                            required: "3",
+                            required: ArgCount::Exactly(3),
                             found: args.len(),
                         });
                         node
@@ -179,7 +179,7 @@ impl Visitor for ScalarFunctionsVisitor {
                     } else {
                         self.error = Some(Error::IncorrectArgumentCount {
                             name: function.as_str(),
-                            required: "3 or 4",
+                            required: ArgCount::Either(3, 4),
                             found: args.len(),
                         });
                         node
@@ -218,7 +218,7 @@ impl Visitor for ScalarFunctionsVisitor {
                     } else {
                         self.error = Some(Error::IncorrectArgumentCount {
                             name: function.as_str(),
-                            required: "2 or 3",
+                            required: ArgCount::Either(2, 3),
                             found: args.len(),
                         });
                         node
@@ -242,7 +242,7 @@ impl Visitor for ScalarFunctionsVisitor {
                     } else {
                         self.error = Some(Error::IncorrectArgumentCount {
                             name: function.as_str(),
-                            required: "1",
+                            required: ArgCount::Exactly(1),
                             found: args.len(),
                         });
                         node

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1475,7 +1475,7 @@ mod higher_order_functions {
         array_averge,
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok("SELECT REDUCE(a, 0, `value` + this) / SIZE(a)"),
-        input = "SELECT ARRAY_AVERAGE(a)",
+        input = "SELECT ARRAY_AVG(a)",
     );
 
     test_rewrite!(

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1548,11 +1548,11 @@ mod higher_order_functions {
         array_average_invalid,
         pass = HigherOrderFunctionsRewritePass,
         expected = Err(Error::IncorrectArgumentCount {
-            name: "ARRAY_AVERAGE",
+            name: "ARRAY_AVG",
             required: ArgCount::Exactly(1),
             found: 0,
         }),
-        input = "SELECT ARRAY_AVERAGE()",
+        input = "SELECT ARRAY_AVG()",
     );
 
     test_rewrite!(

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1437,10 +1437,32 @@ mod higher_order_functions {
     );
 
     test_rewrite!(
+        array_extract_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_EXTRACT",
+            required: ArgCount::Exactly(2),
+            found: 0,
+        }),
+        input = "SELECT ARRAY_EXTRACT()",
+    );
+
+    test_rewrite!(
         array_compact,
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok("SELECT FILTER(a, NOT this IS NULL)"),
         input = "SELECT ARRAY_COMPACT(a)",
+    );
+
+    test_rewrite!(
+        array_compact_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_COMPACT",
+            required: ArgCount::Exactly(1),
+            found: 0,
+        }),
+        input = "SELECT ARRAY_COMPACT()",
     );
 
     test_rewrite!(
@@ -1451,10 +1473,32 @@ mod higher_order_functions {
     );
 
     test_rewrite!(
+        array_remove_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_REMOVE",
+            required: ArgCount::Exactly(2),
+            found: 1,
+        }),
+        input = "SELECT ARRAY_REMOVE(a)",
+    );
+
+    test_rewrite!(
         array_count_if,
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok("SELECT SIZE(FILTER(a, this > y))"),
         input = "SELECT ARRAY_COUNT_IF(a, this > y)",
+    );
+
+    test_rewrite!(
+        array_count_if_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_COUNT_IF",
+            required: ArgCount::Exactly(2),
+            found: 0,
+        }),
+        input = "SELECT ARRAY_COUNT_IF()",
     );
 
     test_rewrite!(
@@ -1465,10 +1509,32 @@ mod higher_order_functions {
     );
 
     test_rewrite!(
+        array_sum_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_SUM",
+            required: ArgCount::Exactly(1),
+            found: 0,
+        }),
+        input = "SELECT ARRAY_SUM()",
+    );
+
+    test_rewrite!(
         array_product,
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok("SELECT REDUCE(a, 1, `value` * this)"),
         input = "SELECT ARRAY_PRODUCT(a)",
+    );
+
+    test_rewrite!(
+        array_product_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_PRODUCT",
+            required: ArgCount::Exactly(1),
+            found: 0,
+        }),
+        input = "SELECT ARRAY_PRODUCT()",
     );
 
     test_rewrite!(
@@ -1479,6 +1545,17 @@ mod higher_order_functions {
     );
 
     test_rewrite!(
+        array_average_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_AVERAGE",
+            required: ArgCount::Exactly(1),
+            found: 0,
+        }),
+        input = "SELECT ARRAY_AVERAGE()",
+    );
+
+    test_rewrite!(
         array_all,
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok("SELECT REDUCE(a, true, `value` AND this)"),
@@ -1486,10 +1563,32 @@ mod higher_order_functions {
     );
 
     test_rewrite!(
+        array_all_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_ALL",
+            required: ArgCount::Exactly(1),
+            found: 0,
+        }),
+        input = "SELECT ARRAY_ALL()",
+    );
+
+    test_rewrite!(
         array_any,
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok("SELECT REDUCE(a, false, `value` OR this)"),
         input = "SELECT ARRAY_ANY(a)",
+    );
+
+    test_rewrite!(
+        array_any_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_ANY",
+            required: ArgCount::Exactly(1),
+            found: 0,
+        }),
+        input = "SELECT ARRAY_ANY()",
     );
 
     test_rewrite!(
@@ -1511,5 +1610,27 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok("SELECT TRIM(LEADING ',' FROM REDUCE(a, '', `value` || ',' || this))"),
         input = "SELECT ARRAY_JOIN(a, ',')",
+    );
+
+    test_rewrite!(
+        array_join_invalid_too_few,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_JOIN",
+            required: ArgCount::Either(1, 2),
+            found: 0,
+        }),
+        input = "SELECT ARRAY_JOIN()",
+    );
+
+    test_rewrite!(
+        array_join_invalid_too_many,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "ARRAY_JOIN",
+            required: ArgCount::Either(1, 2),
+            found: 3,
+        }),
+        input = "SELECT ARRAY_JOIN(a, b, c)",
     );
 }

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1397,3 +1397,98 @@ mod scalar_functions {
         input = "SELECT EXTRACT(YEAR FROM d)",
     );
 }
+
+mod higher_order_functions {
+    use super::*;
+
+    test_rewrite!(
+        array_cast,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT MAP(a, CAST(this AS STRING))"),
+        input = "SELECT ARRAY_CAST(a, STRING)",
+    );
+
+    test_rewrite!(
+        array_extract,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT MAP(a, this.x.y.z)"),
+        input = "SELECT ARRAY_EXTRACT(a, x.y.z)",
+    );
+
+    test_rewrite!(
+        array_compact,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT FILTER(a, this IS NOT NULL)"),
+        input = "SELECT ARRAY_COMPACT(a)",
+    );
+
+    test_rewrite!(
+        array_remove,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT FILTER(a, this <> x)"),
+        input = "SELECT ARRAY_REMOVE(a, x)",
+    );
+
+    test_rewrite!(
+        array_count_if,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT SIZE(FILTER(a, this > y))"),
+        input = "SELECT ARRAY_COUNT_IF(a, this > y)",
+    );
+
+    test_rewrite!(
+        array_sum,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT REDUCE(a, 0, this + value)"),
+        input = "SELECT ARRAY_SUM(a)",
+    );
+
+    test_rewrite!(
+        array_product,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT REDUCE(a, 1, this * value)"),
+        input = "SELECT ARRAY_PRODUCT(a)",
+    );
+
+    test_rewrite!(
+        array_averge,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT REDUCE(a, 0, this + value) / SIZE(a)"),
+        input = "SELECT ARRAY_AVERAGE(a)",
+    );
+
+    test_rewrite!(
+        array_all,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT REDUCE(a, true, value AND this)"),
+        input = "SELECT ARRAY_ALL(a)",
+    );
+
+    test_rewrite!(
+        array_any,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT REDUCE(a, false, value OR this)"),
+        input = "SELECT ARRAY_ANY(a)",
+    );
+
+    test_rewrite!(
+        array_join_without_separator,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT REDUCE(a, '', value || this)"),
+        input = "SELECT ARRAY_JOIN(a)",
+    );
+
+    test_rewrite!(
+        array_join_with_empty_separator,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT REDUCE(a, '', value || this)"),
+        input = "SELECT ARRAY_JOIN(a, '')",
+    );
+
+    test_rewrite!(
+        array_join_with_non_empty_separator,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT TRIM(LEADING ',' FROM REDUCE(`array`, '', value || ',' || this))"),
+        input = "SELECT ARRAY_JOIN(a, ',')",
+    );
+}

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1409,16 +1409,37 @@ mod higher_order_functions {
     );
 
     test_rewrite!(
-        array_extract,
+        array_extract_identifier,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT MAP(a, this.x)"),
+        input = "SELECT ARRAY_EXTRACT(a, x)",
+    );
+
+    test_rewrite!(
+        array_extract_subpath,
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok("SELECT MAP(a, this.x.y.z)"),
         input = "SELECT ARRAY_EXTRACT(a, x.y.z)",
     );
 
     test_rewrite!(
+        array_extract_literal,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT MAP(a, this['field'])"),
+        input = "SELECT ARRAY_EXTRACT(a, 'field')",
+    );
+
+    test_rewrite!(
+        array_extract_other_expr,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT MAP(a, this[field || '_1'])"),
+        input = "SELECT ARRAY_EXTRACT(a, field || '_1')",
+    );
+
+    test_rewrite!(
         array_compact,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT FILTER(a, this IS NOT NULL)"),
+        expected = Ok("SELECT FILTER(a, NOT this IS NULL)"),
         input = "SELECT ARRAY_COMPACT(a)",
     );
 
@@ -1439,56 +1460,56 @@ mod higher_order_functions {
     test_rewrite!(
         array_sum,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, 0, this + value)"),
+        expected = Ok("SELECT REDUCE(a, 0, this + `value`)"),
         input = "SELECT ARRAY_SUM(a)",
     );
 
     test_rewrite!(
         array_product,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, 1, this * value)"),
+        expected = Ok("SELECT REDUCE(a, 1, this * `value`)"),
         input = "SELECT ARRAY_PRODUCT(a)",
     );
 
     test_rewrite!(
         array_averge,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, 0, this + value) / SIZE(a)"),
+        expected = Ok("SELECT REDUCE(a, 0, this + `value`) / SIZE(a)"),
         input = "SELECT ARRAY_AVERAGE(a)",
     );
 
     test_rewrite!(
         array_all,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, true, value AND this)"),
+        expected = Ok("SELECT REDUCE(a, true, `value` AND this)"),
         input = "SELECT ARRAY_ALL(a)",
     );
 
     test_rewrite!(
         array_any,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, false, value OR this)"),
+        expected = Ok("SELECT REDUCE(a, false, `value` OR this)"),
         input = "SELECT ARRAY_ANY(a)",
     );
 
     test_rewrite!(
         array_join_without_separator,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, '', value || this)"),
+        expected = Ok("SELECT REDUCE(a, '', `value` || this)"),
         input = "SELECT ARRAY_JOIN(a)",
     );
 
     test_rewrite!(
         array_join_with_empty_separator,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, '', value || this)"),
+        expected = Ok("SELECT REDUCE(a, '', `value` || this)"),
         input = "SELECT ARRAY_JOIN(a, '')",
     );
 
     test_rewrite!(
         array_join_with_non_empty_separator,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT TRIM(LEADING ',' FROM REDUCE(`array`, '', value || ',' || this))"),
+        expected = Ok("SELECT TRIM(LEADING ',' FROM REDUCE(a, '', `value` || ',' || this))"),
         input = "SELECT ARRAY_JOIN(a, ',')",
     );
 }

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1095,7 +1095,7 @@ mod scalar_functions {
         pass = ScalarFunctionsRewritePass,
         expected = Err(Error::IncorrectArgumentCount {
             name: "LOG",
-            required: "1 or 2",
+            required: ArgCount::Either(1, 2),
             found: 3
         }),
         input = "SELECT { fn LOG(10, 5, 10) }",
@@ -1123,7 +1123,7 @@ mod scalar_functions {
         pass = ScalarFunctionsRewritePass,
         expected = Err(Error::IncorrectArgumentCount {
             name: "LTRIM",
-            required: "1",
+            required: ArgCount::Exactly(1),
             found: 2
         }),
         input = "SELECT LTRIM(' stuff ', 'more stuff')",
@@ -1139,7 +1139,7 @@ mod scalar_functions {
         pass = ScalarFunctionsRewritePass,
         expected = Err(Error::IncorrectArgumentCount {
             name: "RTRIM",
-            required: "1",
+            required: ArgCount::Exactly(1),
             found: 2
         }),
         input = "SELECT RTRIM(' stuff ', 'more stuff')",
@@ -1155,7 +1155,7 @@ mod scalar_functions {
         pass = ScalarFunctionsRewritePass,
         expected = Err(Error::IncorrectArgumentCount {
             name: "DATEADD",
-            required: "3",
+            required: ArgCount::Exactly(3),
             found: 2
         }),
         input = "SELECT DATEADD(YEAR, 2)",
@@ -1177,7 +1177,7 @@ mod scalar_functions {
         pass = ScalarFunctionsRewritePass,
         expected = Err(Error::IncorrectArgumentCount {
             name: "DATEDIFF",
-            required: "3 or 4",
+            required: ArgCount::Either(3, 4),
             found: 2
         }),
         input = "SELECT DATEDIFF(QUARTER, d1)",
@@ -1199,7 +1199,7 @@ mod scalar_functions {
         pass = ScalarFunctionsRewritePass,
         expected = Err(Error::IncorrectArgumentCount {
             name: "DATETRUNC",
-            required: "2 or 3",
+            required: ArgCount::Either(2, 3),
             found: 1
         }),
         input = "SELECT DATETRUNC(YEAR)",
@@ -1460,21 +1460,21 @@ mod higher_order_functions {
     test_rewrite!(
         array_sum,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, 0, this + `value`)"),
+        expected = Ok("SELECT REDUCE(a, 0, `value` + this)"),
         input = "SELECT ARRAY_SUM(a)",
     );
 
     test_rewrite!(
         array_product,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, 1, this * `value`)"),
+        expected = Ok("SELECT REDUCE(a, 1, `value` * this)"),
         input = "SELECT ARRAY_PRODUCT(a)",
     );
 
     test_rewrite!(
         array_averge,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT REDUCE(a, 0, this + `value`) / SIZE(a)"),
+        expected = Ok("SELECT REDUCE(a, 0, `value` + this) / SIZE(a)"),
         input = "SELECT ARRAY_AVERAGE(a)",
     );
 

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -2308,7 +2308,7 @@ impl HigherOrderFunction for MapExpr {
         // be null based on the array argument's nullability.
         Ok(self.propagate_null_arguments_helper(
             array_schema.satisfies(&NULLISH),
-            Schema::Array(Box::new(func_schema)),
+            Schema::Array(Box::new(func_schema.upconvert_missing_to_null())),
         ))
     }
 }
@@ -2453,7 +2453,10 @@ impl HigherOrderFunction for ReduceExpr {
         // The output schema is a union of the initial value schema and the function result schema.
         // It may be null based on the array argument's nullability.
         let output_schema = init_value_schema.union(&func_schema);
-        Ok(self.propagate_null_arguments_helper(array_schema.satisfies(&NULLISH), output_schema))
+        Ok(self.propagate_null_arguments_helper(
+            array_schema.satisfies(&NULLISH),
+            output_schema.upconvert_missing_to_null(),
+        ))
     }
 }
 

--- a/mongosql/src/mir/schema/test/expressions/higher_order_function.rs
+++ b/mongosql/src/mir/schema/test/expressions/higher_order_function.rs
@@ -237,6 +237,24 @@ mod map {
             is_nullable: false,
         })),
     );
+
+    // The output array must not contain missing, since it is upconverted to null.
+    test_schema!(
+        output_array_must_not_contain_missing,
+        expected = Ok(Schema::Array(Box::new(Schema::AnyOf(set![
+            Schema::Atomic(Atomic::String),
+            Schema::Atomic(Atomic::Null)
+        ])))),
+        input = Expression::HigherOrderFunction(HigherOrderFunctionApplication::Map(MapExpr {
+            array: Box::new(Expression::Reference(("foo", 0u16).into())),
+            f: Box::new(Expression::Reference(("possibly_missing", 0u16).into())),
+            is_nullable: false,
+        })),
+        schema_env = map! {
+            ("foo", 0u16).into() => Schema::Array(Box::new(Schema::Atomic(Atomic::Integer))),
+            ("possibly_missing", 0u16).into() => Schema::AnyOf(set![Schema::Atomic(Atomic::String), Schema::Missing]),
+        },
+    );
 }
 
 mod filter {
@@ -1058,5 +1076,29 @@ mod reduce {
                 })),
                 is_nullable: false,
             })),
+    );
+
+    // The output schema must not be possibly missing, as missing should be upconverted to null.
+    test_schema!(
+        output_schema_upconverts_missing_to_null,
+        expected = Ok(Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Integer),
+            Schema::Atomic(Atomic::Null)
+        ])),
+        input =
+            Expression::HigherOrderFunction(HigherOrderFunctionApplication::Reduce(ReduceExpr {
+                array: Box::new(Expression::Array(ArrayExpr {
+                    array: vec![Expression::Reference(("int_or_missing", 0u16).into())]
+                })),
+                init_value: Box::new(Expression::Reference(("int_or_missing", 0u16).into())),
+                f: Box::new(Expression::Reference(("int_or_missing", 0u16).into())),
+                is_nullable: true,
+            })),
+        schema_env = map! {
+            ("int_or_missing", 0u16).into() => Schema::AnyOf(set![
+                Schema::Atomic(Atomic::Integer),
+                Schema::Missing
+            ]),
+        },
     );
 }

--- a/mongosql/src/parser/mongosql.lalrpop
+++ b/mongosql/src/parser/mongosql.lalrpop
@@ -315,6 +315,11 @@ CastExpr: CastExpr = {
             },
 }
 
+ArrayCastExpr: ArrayCastExpr = {
+    ARRAY_CAST LEFT_PAREN <ex:Expression> COMMA <t:Type> RIGHT_PAREN =>
+        ArrayCastExpr {expr: Box::new(ex), to: t},
+}
+
 CurrentTimestamp: FunctionExpr = {
     CURRENT_TIMESTAMP <e:(LEFT_PAREN <Expression> RIGHT_PAREN)?> => match e {
         Some(e) => FunctionExpr {
@@ -556,6 +561,7 @@ Tier14Expr = SubpathTier<Expression, BottomExpr>;
 BottomExpr: Box<Expression> = {
   AccessExpr => Box::new(Expression::Access(<>)),
   ArrayExpr => Box::new(Expression::Array(<>)),
+  ArrayCastExpr => Box::new(Expression::ArrayCast(<>)),
   CaseExpr => Box::new(Expression::Case(<>)),
   CastExpr => Box::new(Expression::Cast(<>)),
   DocumentExpr => Box::new(<>),
@@ -815,6 +821,7 @@ match {
   r"(?i)and" => AND,
   r"(?i)any" => ANY,
   r"(?i)array" => ARRAY,
+  r"(?i)array_cast" => ARRAY_CAST,
   r"(?i)as" => AS,
   r"(?i)asc" => ASC,
   r"(?i)between" => BETWEEN,

--- a/mongosql/src/parser/test.rs
+++ b/mongosql/src/parser/test.rs
@@ -2912,6 +2912,14 @@ mod type_conversion {
     );
 }
 
+mod array_cast {
+    parsable!(
+        array_cast,
+        expected = true,
+        input = "select ARRAY_CAST(v, STRING)"
+    );
+}
+
 mod subquery {
     use crate::ast::*;
     parsable!(

--- a/testdata/spec_tests/query_tests/array_functions.yml
+++ b/testdata/spec_tests/query_tests/array_functions.yml
@@ -9,21 +9,21 @@ dataset:
         - { "_id": 3, "a": [ 1, null, 3 ] }
         - { "_id": 4, "a": null }
         - { "_id": 5 }
-      schema:
-        bsonType: "object"
-        required: [ "_id" ]
-        additionalProperties: false
-        properties:
-          _id:
-            bsonType: "int"
-          a:
-            anyOf:
-              - bsonType: "array"
-                items:
-                  anyOf:
-                    - bsonType: "int"
-                    - bsonType: !!str "null"
-              - bsonType: !!str "null"
+    schema:
+      bsonType: "object"
+      required: [ "_id" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          anyOf:
+            - bsonType: "array"
+              items:
+                anyOf:
+                  - bsonType: "int"
+                  - bsonType: !!str "null"
+            - bsonType: !!str "null"
 
   - db: "spec_query_array_functions"
     collection:
@@ -41,21 +41,21 @@ dataset:
         - { "_id": 9, "a": [ true, null, false ] }
         - { "_id": 10, "a": null }
         - { "_id": 11 }
-      schema:
-        bsonType: "object"
-        required: [ "_id" ]
-        additionalProperties: false
-        properties:
-          _id:
-            bsonType: "int"
-          a:
-            anyOf:
-              - bsonType: "array"
-                items:
-                  anyOf:
-                    - bsonType: "bool"
-                    - bsonType: !!str "null"
-              - bsonType: !!str "null"
+    schema:
+      bsonType: "object"
+      required: [ "_id" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          anyOf:
+            - bsonType: "array"
+              items:
+                anyOf:
+                  - bsonType: "bool"
+                  - bsonType: !!str "null"
+            - bsonType: !!str "null"
 
   - db: "spec_query_array_functions"
     collection:
@@ -68,33 +68,33 @@ dataset:
         - { "_id": 4, "a": [ { "x": { "y": 1 } }, { "x": { "y": null } }, { "x": { } } ] }
         - { "_id": 5, "a": null }
         - { "_id": 6 }
-      schema:
-        bsonType: "object"
-        required: [ "_id" ]
-        additionalProperties: false
-        properties:
-          _id:
-            bsonType: "int"
-          a:
-            anyOf:
-              - bsonType: "array"
-                items:
-                  anyOf:
-                    - bsonType: "object"
-                      required: [ "x" ]
-                      additionalProperties: false
-                      properties:
-                        x:
-                          bsonType: "object"
-                          required: []
-                          additionalProperties: false
-                          properties:
-                            y:
-                              anyOf:
-                                - bsonType: "int"
-                                - bsonType: !!str "null"
-                    - bsonType: !!str "null"
-              - bsonType: !!str "null"
+    schema:
+      bsonType: "object"
+      required: [ "_id" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          anyOf:
+            - bsonType: "array"
+              items:
+                anyOf:
+                  - bsonType: "object"
+                    required: [ "x" ]
+                    additionalProperties: false
+                    properties:
+                      x:
+                        bsonType: "object"
+                        required: []
+                        additionalProperties: false
+                        properties:
+                          y:
+                            anyOf:
+                              - bsonType: "int"
+                              - bsonType: !!str "null"
+                  - bsonType: !!str "null"
+            - bsonType: !!str "null"
 
   - db: "spec_query_array_functions"
     collection:
@@ -111,21 +111,21 @@ dataset:
         - { "_id": 8, "sep": "" }
         - { "_id": 9, "a": [ "a", "b", "c" ], "sep": null }
         - { "_id": 10, "a": [ "a", "b", "c" ] }
-      schema:
-        bsonType: "object"
-        required: [ "_id" ]
-        additionalProperties: false
-        properties:
-          _id:
-            bsonType: "int"
-          a:
-            anyOf:
-              - bsonType: "array"
-                items:
-                  anyOf:
-                    - bsonType: "string"
-                    - bsonType: !!str "null"
-              - bsonType: !!str "null"
+    schema:
+      bsonType: "object"
+      required: [ "_id" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          anyOf:
+            - bsonType: "array"
+              items:
+                anyOf:
+                  - bsonType: "string"
+                  - bsonType: !!str "null"
+            - bsonType: !!str "null"
         sep:
             anyOf:
               - bsonType: "string"

--- a/tests/spec_tests/query_tests/array_functions.yml
+++ b/tests/spec_tests/query_tests/array_functions.yml
@@ -42,7 +42,7 @@ tests:
   - description: ARRAY_REMOVE correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, 1) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
+    skip_reason: "SQL-3387: Implement ARRAY_REMOVE"
     result:
       - { '': { "a": [], "v": [] } }
       - { '': { "a": [1], "v": [] } }
@@ -54,7 +54,7 @@ tests:
   - description: ARRAY_REMOVE remove NULL correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, NULL) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
+    skip_reason: "SQL-3387: Implement ARRAY_REMOVE"
     result:
       - { '': { "a": [], "v": [] } }
       - { '': { "a": [1], "v": [1] } }

--- a/tests/spec_tests/query_tests/array_functions.yml
+++ b/tests/spec_tests/query_tests/array_functions.yml
@@ -3,7 +3,6 @@ tests:
   - description: ARRAY_CAST correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_CAST(a, STRING) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "v": [] } }
       - { '': { "a": [1], "v": ["1"] } }
@@ -16,7 +15,6 @@ tests:
   - description: ARRAY_EXTRACT correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_EXTRACT(a, x.y) } FROM `array_extract` AS `array_extract`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "v": [] } }
       - { '': { "a": [{ "x": { "y": 1 } }], "v": [1] } }
@@ -30,7 +28,6 @@ tests:
   - description: ARRAY_COMPACT correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_COMPACT(a) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "v": [] } }
       - { '': { "a": [1], "v": [1] } }
@@ -70,7 +67,6 @@ tests:
   - description: ARRAY_COUNT_IF correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_COUNT_IF(a, this > 1) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "v": 0 } }
       - { '': { "a": [1], "v": 0 } }
@@ -83,7 +79,6 @@ tests:
   - description: ARRAY_SUM correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_SUM(a) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "v": 0 } }
       - { '': { "a": [1], "v": 1 } }
@@ -96,7 +91,6 @@ tests:
   - description: ARRAY_PRODUCT correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_PRODUCT(a) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "v": 1 } }
       - { '': { "a": [1], "v": 1 } }
@@ -109,7 +103,6 @@ tests:
   - description: ARRAY_AVG correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_AVG(a) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "v": null } }
       - { '': { "a": [1], "v": 1 } }
@@ -122,7 +115,6 @@ tests:
   - description: ARRAY_ALL correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_ALL(a) } FROM `array_default_boolean_data` AS `array_default_boolean_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "v": true } }
       - { '': { "a": [ true ], "v": true } }
@@ -141,7 +133,6 @@ tests:
   - description: ARRAY_ANY correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_ANY(a) } FROM `array_default_boolean_data` AS `array_default_boolean_data`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "v": false } }
       - { '': { "a": [ true ], "v": true } }
@@ -160,7 +151,6 @@ tests:
   - description: ARRAY_JOIN correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'sep': sep, 'v': ARRAY_JOIN(a, sep) } FROM `array_join` AS `array_join`"
-    skip_reason: "SQL-3297: Finish support for array functions"
     result:
       - { '': { "a": [], "sep": "", "v": "" } }
       - { '': { "a": [], "sep": ",", "v": "" } }


### PR DESCRIPTION
This PR implements the `HigherOrderFunctionAliasVisitor` which was previously stubbed out as part of #176 . The design doc describes this visitor [here](https://docs.google.com/document/d/15bcFJ1wH6BcQYem7slPP8eG142BSvmjY3UuTNve8r7I/edit?tab=t.0#heading=h.he6cyip700kh).

This implementation required adding the new array function aliases to the `ast` as `FunctionName` variants. For `ARRAY_CAST`, since the second argument is a `Type`, it could not be added as a normal `FunctionExpr`. Instead, I created an `ArrayCastExpr` which is more akin to `CastExpr`. That was really the only unexpected bump in the road for this one.

I was able to unskip most of the `spec/query/array_functions.yml` tests since we can now parse and rewrite the array function aliases and all the rest of the higher order function work from algebrization onwards is implemented and merged. I was not able to unskip `ARRAY_REMOVE` since we decided to shoot for Snowflake-style semantics on that instead of typical SQL semantics (re: should `ARRAY_REMOVE([1, null, 3], 3)` result in `[1, null]` (like Snowflake) or `[1]` (using SQL 3-value semantics)). I filed a separate ticket to address this.