### PR TITLE
SQL-3296: Implement FunctionArgumentVisitor

### DIFF
--- a/mongosql/src/ast/definitions.rs
+++ b/mongosql/src/ast/definitions.rs
@@ -887,6 +887,17 @@ pub enum UnaryOp {
     Not,
 }
 
+impl UnaryOp {
+    pub fn as_str(&self) -> &'static str {
+        use UnaryOp::*;
+        match self {
+            Pos => "Pos",
+            Neg => "Neg",
+            Not => "Not",
+        }
+    }
+}
+
 #[derive(PartialEq, Eq, Debug, Clone, Copy, VariantCount)]
 pub enum BinaryOp {
     Add,

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -339,7 +339,33 @@ impl FunctionArgumentVisitor {
             FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Sub)) => {
                 FunctionArgument::Expr(Self::rewrite_named_function_to_unary_expr(UnaryOp::Neg))
             }
-            FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op)) => {
+            // Exhaustively match other BinaryOps so in the future if we add new binary operators
+            // with overloaded forms, we will be forced to handle them here.
+            FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op @ BinaryOp::And))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op @ BinaryOp::Concat))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op @ BinaryOp::Div))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op @ BinaryOp::In))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op @ BinaryOp::Mul))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op @ BinaryOp::NotIn))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op @ BinaryOp::Or))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                op @ BinaryOp::Comparison(ComparisonOp::Eq),
+            ))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                op @ BinaryOp::Comparison(ComparisonOp::Gt),
+            ))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                op @ BinaryOp::Comparison(ComparisonOp::Gte),
+            ))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                op @ BinaryOp::Comparison(ComparisonOp::Lt),
+            ))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                op @ BinaryOp::Comparison(ComparisonOp::Lte),
+            ))
+            | FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                op @ BinaryOp::Comparison(ComparisonOp::Neq),
+            )) => {
                 self.error = Some(Error::IncorrectArgumentCount {
                     name: op.as_str(),
                     required: ArgCount::Exactly(2),
@@ -369,7 +395,9 @@ impl FunctionArgumentVisitor {
             FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Neg)) => {
                 FunctionArgument::Expr(Self::rewrite_named_function_to_binary_expr(BinaryOp::Sub))
             }
-            FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op)) => {
+            // Exhaustively match other UnaryOps so in the future if we add new unary operators
+            // with overloaded forms, we will be forced to handle them here.
+            FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op @ UnaryOp::Not)) => {
                 self.error = Some(Error::IncorrectArgumentCount {
                     name: op.as_str(),
                     required: ArgCount::Exactly(1),

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -214,7 +214,7 @@ impl HigherOrderFunctionsAliasVisitor {
     }
 
     /// Rewrite any single-argument reduce-alias function (e.g., `ARRAY_SUM(a)` into
-    /// `REDUCE(a, init_value, value op this)`.
+    /// `REDUCE(a, init_value, value op this)`).
     fn rewrite_single_arg_reduce_alias(
         name: &'static str,
         args: &[Expression],
@@ -230,7 +230,7 @@ impl HigherOrderFunctionsAliasVisitor {
         ))
     }
 
-    /// Rewrite `ARRAY_AVG(a)` into `REDUCE(a, 0, this + value) / SIZE(a)`.
+    /// Rewrite `ARRAY_AVG(a)` into `REDUCE(a, 0, value + this) / SIZE(a)`.
     fn rewrite_array_avg(args: &[Expression]) -> Result<Expression> {
         let rewritten_sum = Self::rewrite_single_arg_reduce_alias(
             "ARRAY_AVG",
@@ -294,174 +294,98 @@ impl Visitor for FunctionArgumentVisitor {
     ) -> HigherOrderFunctionExpr {
         let node = node.walk(self);
         match node {
-            HigherOrderFunctionExpr::Map(MapExpr { array, f }) => match *f {
-                FunctionArgument::Expr(expr) => HigherOrderFunctionExpr::Map(MapExpr {
+            HigherOrderFunctionExpr::Map(MapExpr { array, f }) => {
+                HigherOrderFunctionExpr::Map(MapExpr {
                     array,
-                    f: Box::new(FunctionArgument::Expr(expr)),
-                }),
-                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op)) => {
-                    HigherOrderFunctionExpr::Map(MapExpr {
-                        array,
-                        f: Box::new(FunctionArgument::Expr(
-                            Self::rewrite_named_function_to_unary_expr(op),
-                        )),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Add)) => {
-                    HigherOrderFunctionExpr::Map(MapExpr {
-                        array,
-                        f: Box::new(FunctionArgument::Expr(
-                            Self::rewrite_named_function_to_unary_expr(UnaryOp::Pos),
-                        )),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Sub)) => {
-                    HigherOrderFunctionExpr::Map(MapExpr {
-                        array,
-                        f: Box::new(FunctionArgument::Expr(
-                            Self::rewrite_named_function_to_unary_expr(UnaryOp::Neg),
-                        )),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op)) => {
-                    self.error = Some(Error::IncorrectArgumentCount {
-                        name: op.as_str(),
-                        required: ArgCount::Exactly(2),
-                        found: 1,
-                    });
-                    HigherOrderFunctionExpr::Map(MapExpr {
-                        array,
-                        f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op))),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::Function(op)) => {
-                    HigherOrderFunctionExpr::Map(MapExpr {
-                        array,
-                        f: Box::new(FunctionArgument::Expr(Expression::Function(FunctionExpr {
-                            function: op,
-                            args: FunctionArguments::Args(vec![this()]),
-                            set_quantifier: None,
-                        }))),
-                    })
-                }
-            },
-            HigherOrderFunctionExpr::Filter(FilterExpr { array, f }) => match *f {
-                FunctionArgument::Expr(expr) => HigherOrderFunctionExpr::Filter(FilterExpr {
+                    f: Box::new(self.rewrite_unary_context_arg(*f)),
+                })
+            }
+            HigherOrderFunctionExpr::Filter(FilterExpr { array, f }) => {
+                HigherOrderFunctionExpr::Filter(FilterExpr {
                     array,
-                    f: Box::new(FunctionArgument::Expr(expr)),
-                }),
-                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op)) => {
-                    HigherOrderFunctionExpr::Filter(FilterExpr {
-                        array,
-                        f: Box::new(FunctionArgument::Expr(
-                            Self::rewrite_named_function_to_unary_expr(op),
-                        )),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Add)) => {
-                    HigherOrderFunctionExpr::Filter(FilterExpr {
-                        array,
-                        f: Box::new(FunctionArgument::Expr(
-                            Self::rewrite_named_function_to_unary_expr(UnaryOp::Pos),
-                        )),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Sub)) => {
-                    HigherOrderFunctionExpr::Filter(FilterExpr {
-                        array,
-                        f: Box::new(FunctionArgument::Expr(
-                            Self::rewrite_named_function_to_unary_expr(UnaryOp::Neg),
-                        )),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op)) => {
-                    self.error = Some(Error::IncorrectArgumentCount {
-                        name: op.as_str(),
-                        required: ArgCount::Exactly(2),
-                        found: 1,
-                    });
-                    HigherOrderFunctionExpr::Filter(FilterExpr {
-                        array,
-                        f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op))),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::Function(op)) => {
-                    HigherOrderFunctionExpr::Filter(FilterExpr {
-                        array,
-                        f: Box::new(FunctionArgument::Expr(Expression::Function(FunctionExpr {
-                            function: op,
-                            args: FunctionArguments::Args(vec![this()]),
-                            set_quantifier: None,
-                        }))),
-                    })
-                }
-            },
+                    f: Box::new(self.rewrite_unary_context_arg(*f)),
+                })
+            }
             HigherOrderFunctionExpr::Reduce(ReduceExpr {
                 array,
                 init_value,
                 f,
-            }) => match *f {
-                FunctionArgument::Expr(expr) => HigherOrderFunctionExpr::Reduce(ReduceExpr {
-                    array,
-                    init_value,
-                    f: Box::new(FunctionArgument::Expr(expr)),
-                }),
-                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Pos)) => {
-                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
-                        array,
-                        init_value,
-                        f: Box::new(FunctionArgument::Expr(
-                            Self::rewrite_named_function_to_binary_expr(BinaryOp::Add),
-                        )),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Neg)) => {
-                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
-                        array,
-                        init_value,
-                        f: Box::new(FunctionArgument::Expr(
-                            Self::rewrite_named_function_to_binary_expr(BinaryOp::Sub),
-                        )),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op)) => {
-                    self.error = Some(Error::IncorrectArgumentCount {
-                        name: op.as_str(),
-                        required: ArgCount::Exactly(1),
-                        found: 2,
-                    });
-                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
-                        array,
-                        init_value,
-                        f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op))),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op)) => {
-                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
-                        array,
-                        init_value,
-                        f: Box::new(FunctionArgument::Expr(
-                            Self::rewrite_named_function_to_binary_expr(op),
-                        )),
-                    })
-                }
-                FunctionArgument::NamedFunction(NamedFunction::Function(op)) => {
-                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
-                        array,
-                        init_value,
-                        f: Box::new(FunctionArgument::Expr(Expression::Function(FunctionExpr {
-                            function: op,
-                            args: FunctionArguments::Args(vec![value(), this()]),
-                            set_quantifier: None,
-                        }))),
-                    })
-                }
-            },
+            }) => HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                array,
+                init_value,
+                f: Box::new(self.rewrite_binary_context_arg(*f)),
+            }),
         }
     }
 }
 
 impl FunctionArgumentVisitor {
+    /// Rewrites a `FunctionArgument` appearing in a "unary context", i.e. the body of a `MAP` or
+    /// `FILTER`, where the function is applied to a single argument, `this`.
+    ///
+    /// The overloaded binary operators `+` and `-` are rewritten to their unary counterparts.
+    /// Any other binary operator is an error, since it requires two arguments; in that case the
+    /// argument is returned unchanged (this is because error checking happens after the visitor
+    /// returns).
+    fn rewrite_unary_context_arg(&mut self, f: FunctionArgument) -> FunctionArgument {
+        match f {
+            FunctionArgument::Expr(_) => f,
+            FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op)) => {
+                FunctionArgument::Expr(Self::rewrite_named_function_to_unary_expr(op))
+            }
+            FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Add)) => {
+                FunctionArgument::Expr(Self::rewrite_named_function_to_unary_expr(UnaryOp::Pos))
+            }
+            FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Sub)) => {
+                FunctionArgument::Expr(Self::rewrite_named_function_to_unary_expr(UnaryOp::Neg))
+            }
+            FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op)) => {
+                self.error = Some(Error::IncorrectArgumentCount {
+                    name: op.as_str(),
+                    required: ArgCount::Exactly(2),
+                    found: 1,
+                });
+                f
+            }
+            FunctionArgument::NamedFunction(NamedFunction::Function(op)) => {
+                FunctionArgument::Expr(Self::named_function_to_function_call(op, vec![this()]))
+            }
+        }
+    }
+
+    /// Rewrites a `FunctionArgument` appearing in a "binary context", i.e. the body of a `REDUCE`,
+    /// where the function is applied to two arguments, `value` and `this`.
+    ///
+    /// The overloaded unary operators `+` and `-` are rewritten to their binary counterparts.
+    /// Any other unary operator is an error, since it requires a single argument; in that case the
+    /// argument is returned unchanged (this is because error checking happens after the visitor
+    /// returns).
+    fn rewrite_binary_context_arg(&mut self, f: FunctionArgument) -> FunctionArgument {
+        match f {
+            FunctionArgument::Expr(_) => f,
+            FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Pos)) => {
+                FunctionArgument::Expr(Self::rewrite_named_function_to_binary_expr(BinaryOp::Add))
+            }
+            FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Neg)) => {
+                FunctionArgument::Expr(Self::rewrite_named_function_to_binary_expr(BinaryOp::Sub))
+            }
+            FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op)) => {
+                self.error = Some(Error::IncorrectArgumentCount {
+                    name: op.as_str(),
+                    required: ArgCount::Exactly(1),
+                    found: 2,
+                });
+                f
+            }
+            FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op)) => {
+                FunctionArgument::Expr(Self::rewrite_named_function_to_binary_expr(op))
+            }
+            FunctionArgument::NamedFunction(NamedFunction::Function(op)) => FunctionArgument::Expr(
+                Self::named_function_to_function_call(op, vec![value(), this()]),
+            ),
+        }
+    }
+
     fn rewrite_named_function_to_unary_expr(op: UnaryOp) -> Expression {
         Expression::Unary(UnaryExpr {
             op,
@@ -474,6 +398,14 @@ impl FunctionArgumentVisitor {
             left: Box::new(value()),
             op,
             right: Box::new(this()),
+        })
+    }
+
+    fn named_function_to_function_call(op: FunctionName, args: Vec<Expression>) -> Expression {
+        Expression::Function(FunctionExpr {
+            function: op,
+            args: FunctionArguments::Args(args),
+            set_quantifier: None,
         })
     }
 }

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -1,11 +1,11 @@
 use crate::ast::{
     self,
-    rewrites::{try_exact_args, try_extract_either_args, Error, Pass, Result},
+    rewrites::{try_exact_args, try_extract_either_args, ArgCount, Error, Pass, Result},
     visitor::Visitor,
     AccessExpr, ArrayCastExpr, BinaryExpr, BinaryOp, CastExpr, ComparisonOp, Expression,
     FilterExpr, FunctionArgument, FunctionArguments, FunctionExpr, FunctionName,
-    HigherOrderFunctionExpr, IsExpr, Literal, MapExpr, ReduceExpr, SubpathExpr, TrimExpr, TrimSpec,
-    Type, TypeOrMissing, UnaryExpr, UnaryOp,
+    HigherOrderFunctionExpr, IsExpr, Literal, MapExpr, NamedFunction, ReduceExpr, SubpathExpr,
+    TrimExpr, TrimSpec, Type, TypeOrMissing, UnaryExpr, UnaryOp,
 };
 
 const THIS: &str = "this";
@@ -22,8 +22,12 @@ impl Pass for HigherOrderFunctionsRewritePass {
             return Err(error);
         }
 
-        let mut func_arg_visitor = FunctionArgumentVisitor;
+        let mut func_arg_visitor = FunctionArgumentVisitor { error: None };
         let query = query.walk(&mut func_arg_visitor);
+
+        if let Some(error) = func_arg_visitor.error {
+            return Err(error);
+        }
 
         Ok(query)
     }
@@ -125,18 +129,6 @@ impl HigherOrderFunctionsAliasVisitor {
         }))
     }
 
-    /// Returns the `this` identifier expression used within higher order function bodies.
-    #[inline(always)]
-    fn this() -> Expression {
-        Expression::Identifier(THIS.to_string())
-    }
-
-    /// Returns the `value` identifier expression used within higher order function bodies.
-    #[inline(always)]
-    fn value() -> Expression {
-        Expression::Identifier(VALUE.to_string())
-    }
-
     #[inline(always)]
     fn make_binary(left: Expression, op: BinaryOp, right: Expression) -> Expression {
         Expression::Binary(BinaryExpr {
@@ -160,7 +152,7 @@ impl HigherOrderFunctionsAliasVisitor {
         Ok(Self::make_map(
             array.clone(),
             Expression::Cast(CastExpr {
-                expr: Box::new(Self::this()),
+                expr: Box::new(this()),
                 to,
                 on_null: None,
                 on_error: None,
@@ -176,7 +168,7 @@ impl HigherOrderFunctionsAliasVisitor {
         // If it is not, we should wrap it in an AccessExpr with "this" as the base.
         let f = prepend_parent_to_field_path_expr(THIS, extract_expr).unwrap_or_else(|| {
             Expression::Access(AccessExpr {
-                expr: Box::new(Self::this()),
+                expr: Box::new(this()),
                 subfield: Box::new(extract_expr.clone()),
             })
         });
@@ -193,7 +185,7 @@ impl HigherOrderFunctionsAliasVisitor {
             Expression::Unary(UnaryExpr {
                 op: UnaryOp::Not,
                 expr: Box::new(Expression::Is(IsExpr {
-                    expr: Box::new(Self::this()),
+                    expr: Box::new(this()),
                     target_type: TypeOrMissing::Type(Type::Null),
                 })),
             }),
@@ -207,7 +199,7 @@ impl HigherOrderFunctionsAliasVisitor {
         Ok(Self::make_filter(
             array.clone(),
             Self::make_binary(
-                Self::this(),
+                this(),
                 BinaryOp::Comparison(ComparisonOp::Neq),
                 remove_expr.clone(),
             ),
@@ -234,7 +226,7 @@ impl HigherOrderFunctionsAliasVisitor {
         Ok(Self::make_reduce(
             array.clone(),
             Expression::Literal(init_value),
-            Self::make_binary(Self::value(), op, Self::this()),
+            Self::make_binary(value(), op, this()),
         ))
     }
 
@@ -271,7 +263,7 @@ impl HigherOrderFunctionsAliasVisitor {
             Ok(Self::make_reduce(
                 array.clone(),
                 Expression::StringConstructor("".to_string()),
-                Self::make_binary(Self::value(), BinaryOp::Concat, Self::this()),
+                Self::make_binary(value(), BinaryOp::Concat, this()),
             ))
         } else {
             Ok(Expression::Trim(TrimExpr {
@@ -281,9 +273,9 @@ impl HigherOrderFunctionsAliasVisitor {
                     array.clone(),
                     Expression::StringConstructor("".to_string()),
                     Self::make_binary(
-                        Self::make_binary(Self::value(), BinaryOp::Concat, sep.clone()),
+                        Self::make_binary(value(), BinaryOp::Concat, sep.clone()),
                         BinaryOp::Concat,
-                        Self::this(),
+                        this(),
                     ),
                 )),
             }))
@@ -291,10 +283,215 @@ impl HigherOrderFunctionsAliasVisitor {
     }
 }
 
-struct FunctionArgumentVisitor;
+struct FunctionArgumentVisitor {
+    error: Option<Error>,
+}
 
-// SQL-3296: Implement FunctionArgumentVisitor
-impl Visitor for FunctionArgumentVisitor {}
+impl Visitor for FunctionArgumentVisitor {
+    fn visit_higher_order_function_expr(
+        &mut self,
+        node: HigherOrderFunctionExpr,
+    ) -> HigherOrderFunctionExpr {
+        let node = node.walk(self);
+        match node {
+            HigherOrderFunctionExpr::Map(MapExpr { array, f }) => match *f {
+                FunctionArgument::Expr(expr) => HigherOrderFunctionExpr::Map(MapExpr {
+                    array,
+                    f: Box::new(FunctionArgument::Expr(expr)),
+                }),
+                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op)) => {
+                    HigherOrderFunctionExpr::Map(MapExpr {
+                        array,
+                        f: Box::new(FunctionArgument::Expr(
+                            Self::rewrite_named_function_to_unary_expr(op),
+                        )),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Add)) => {
+                    HigherOrderFunctionExpr::Map(MapExpr {
+                        array,
+                        f: Box::new(FunctionArgument::Expr(
+                            Self::rewrite_named_function_to_unary_expr(UnaryOp::Pos),
+                        )),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Sub)) => {
+                    HigherOrderFunctionExpr::Map(MapExpr {
+                        array,
+                        f: Box::new(FunctionArgument::Expr(
+                            Self::rewrite_named_function_to_unary_expr(UnaryOp::Neg),
+                        )),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op)) => {
+                    self.error = Some(Error::IncorrectArgumentCount {
+                        name: op.as_str(),
+                        required: ArgCount::Exactly(2),
+                        found: 1,
+                    });
+                    HigherOrderFunctionExpr::Map(MapExpr {
+                        array,
+                        f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op))),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::Function(op)) => {
+                    HigherOrderFunctionExpr::Map(MapExpr {
+                        array,
+                        f: Box::new(FunctionArgument::Expr(Expression::Function(FunctionExpr {
+                            function: op,
+                            args: FunctionArguments::Args(vec![this()]),
+                            set_quantifier: None,
+                        }))),
+                    })
+                }
+            },
+            HigherOrderFunctionExpr::Filter(FilterExpr { array, f }) => match *f {
+                FunctionArgument::Expr(expr) => HigherOrderFunctionExpr::Filter(FilterExpr {
+                    array,
+                    f: Box::new(FunctionArgument::Expr(expr)),
+                }),
+                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op)) => {
+                    HigherOrderFunctionExpr::Filter(FilterExpr {
+                        array,
+                        f: Box::new(FunctionArgument::Expr(
+                            Self::rewrite_named_function_to_unary_expr(op),
+                        )),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Add)) => {
+                    HigherOrderFunctionExpr::Filter(FilterExpr {
+                        array,
+                        f: Box::new(FunctionArgument::Expr(
+                            Self::rewrite_named_function_to_unary_expr(UnaryOp::Pos),
+                        )),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(BinaryOp::Sub)) => {
+                    HigherOrderFunctionExpr::Filter(FilterExpr {
+                        array,
+                        f: Box::new(FunctionArgument::Expr(
+                            Self::rewrite_named_function_to_unary_expr(UnaryOp::Neg),
+                        )),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op)) => {
+                    self.error = Some(Error::IncorrectArgumentCount {
+                        name: op.as_str(),
+                        required: ArgCount::Exactly(2),
+                        found: 1,
+                    });
+                    HigherOrderFunctionExpr::Filter(FilterExpr {
+                        array,
+                        f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op))),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::Function(op)) => {
+                    HigherOrderFunctionExpr::Filter(FilterExpr {
+                        array,
+                        f: Box::new(FunctionArgument::Expr(Expression::Function(FunctionExpr {
+                            function: op,
+                            args: FunctionArguments::Args(vec![this()]),
+                            set_quantifier: None,
+                        }))),
+                    })
+                }
+            },
+            HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                array,
+                init_value,
+                f,
+            }) => match *f {
+                FunctionArgument::Expr(expr) => HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                    array,
+                    init_value,
+                    f: Box::new(FunctionArgument::Expr(expr)),
+                }),
+                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Pos)) => {
+                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                        array,
+                        init_value,
+                        f: Box::new(FunctionArgument::Expr(
+                            Self::rewrite_named_function_to_binary_expr(BinaryOp::Add),
+                        )),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Neg)) => {
+                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                        array,
+                        init_value,
+                        f: Box::new(FunctionArgument::Expr(
+                            Self::rewrite_named_function_to_binary_expr(BinaryOp::Sub),
+                        )),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op)) => {
+                    self.error = Some(Error::IncorrectArgumentCount {
+                        name: op.as_str(),
+                        required: ArgCount::Exactly(1),
+                        found: 2,
+                    });
+                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                        array,
+                        init_value,
+                        f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(op))),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::BinaryOp(op)) => {
+                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                        array,
+                        init_value,
+                        f: Box::new(FunctionArgument::Expr(
+                            Self::rewrite_named_function_to_binary_expr(op),
+                        )),
+                    })
+                }
+                FunctionArgument::NamedFunction(NamedFunction::Function(op)) => {
+                    HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                        array,
+                        init_value,
+                        f: Box::new(FunctionArgument::Expr(Expression::Function(FunctionExpr {
+                            function: op,
+                            args: FunctionArguments::Args(vec![value(), this()]),
+                            set_quantifier: None,
+                        }))),
+                    })
+                }
+            },
+        }
+    }
+}
+
+impl FunctionArgumentVisitor {
+    fn rewrite_named_function_to_unary_expr(op: UnaryOp) -> Expression {
+        Expression::Unary(UnaryExpr {
+            op,
+            expr: Box::new(this()),
+        })
+    }
+
+    fn rewrite_named_function_to_binary_expr(op: BinaryOp) -> Expression {
+        Expression::Binary(BinaryExpr {
+            left: Box::new(value()),
+            op,
+            right: Box::new(this()),
+        })
+    }
+}
+
+/***************************************/
+/********** Utility Functions **********/
+/***************************************/
+/// Returns the `this` identifier expression used within higher order function bodies.
+#[inline(always)]
+fn this() -> Expression {
+    Expression::Identifier(THIS.to_string())
+}
+
+/// Returns the `value` identifier expression used within higher order function bodies.
+#[inline(always)]
+fn value() -> Expression {
+    Expression::Identifier(VALUE.to_string())
+}
 
 fn prepend_parent_to_field_path_expr(
     parent: &str,

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1,4 +1,4 @@
-use crate::ast::{pretty_print::PrettyPrint, rewrites::*};
+use crate::ast::{self, pretty_print::PrettyPrint, rewrites::*};
 
 macro_rules! test_rewrite {
     ($func_name:ident, pass = $pass:expr, expected = $expected:expr, input = $input:expr,) => {
@@ -14,6 +14,24 @@ macro_rules! test_rewrite {
             let query = parser::parse_query(input).expect("input query failed to parse");
 
             let actual = pass.apply(query).map(|q| q.pretty_print().unwrap());
+
+            assert_eq!(expected, actual);
+        }
+    };
+}
+
+// For any features that do not yet have parser support but do have `ast` support, use this macro.
+macro_rules! test_rewrite_ast {
+    ($func_name:ident, pass = $pass:expr, expected = $expected:expr, input = $input:expr,) => {
+        #[test]
+        fn $func_name() {
+            use crate::ast::rewrites::Pass;
+
+            let pass = $pass;
+            let input = $input;
+            let expected = $expected;
+
+            let actual = pass.apply(input);
 
             assert_eq!(expected, actual);
         }
@@ -1632,5 +1650,405 @@ mod higher_order_functions {
             found: 3,
         }),
         input = "SELECT ARRAY_JOIN(a, b, c)",
+    );
+
+    fn make_select_query(expr: ast::Expression) -> ast::Query {
+        ast::Query::Select(Box::new(ast::SelectQuery {
+            select_clause: ast::SelectClause {
+                set_quantifier: ast::SetQuantifier::All,
+                body: ast::SelectBody::Standard(vec![ast::SelectExpression::Expression(
+                    ast::OptionallyAliasedExpr::Unaliased(expr),
+                )]),
+            },
+            from_clause: None,
+            where_clause: None,
+            group_by_clause: None,
+            having_clause: None,
+            order_by_clause: None,
+            limit: None,
+            offset: None,
+        }))
+    }
+
+    test_rewrite_ast!(
+        map_unary_op,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
+                    ast::UnaryExpr {
+                        op: ast::UnaryOp::Not,
+                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::UnaryOp(ast::UnaryOp::Not)
+                )),
+            })
+        )),
+    );
+
+    // The parser should always parse a lone `+` or `-` as a unary operator, however the rewriter is
+    // implemented to be tolerant of a change to that default behavior in the future. `+` and `-`
+    // are currently the only overloaded operators in MongoSQL that may be either unary or binary.
+    // In this rewriter, we convert the operator into the correct form (unary or binary) depending
+    // on which higher order function it appears in: MAP and FILTER expect a unary operator, while
+    // REDUCE expects a binary operator.
+    test_rewrite_ast!(
+        map_binary_add_rewritten_to_unary_add,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
+                    ast::UnaryExpr {
+                        op: ast::UnaryOp::Pos,
+                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::BinaryOp(ast::BinaryOp::Add)
+                )),
+            })
+        )),
+    );
+
+    test_rewrite_ast!(
+        map_binary_sub_rewritten_to_unary_sub,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
+                    ast::UnaryExpr {
+                        op: ast::UnaryOp::Neg,
+                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::BinaryOp(ast::BinaryOp::Sub)
+                )),
+            })
+        )),
+    );
+
+    // Mul does not have a unary counterpart, so this is an error.
+    test_rewrite_ast!(
+        map_binary_op_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "Mul",
+            required: ArgCount::Exactly(2),
+            found: 1,
+        }),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::BinaryOp(ast::BinaryOp::Mul)
+                )),
+            })
+        )),
+    );
+
+    // Note that we do not do function arg count checking for ScalarFunctions. We leave this to the
+    // algebrizer. The only reason the rewriter checks arg counts for BinaryOps is because the ast
+    // expr _requires_ two expressions as arguments. `ast::FunctionExpr` can have any number of
+    // arguments.
+    test_rewrite_ast!(
+        map_function,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Function(
+                    ast::FunctionExpr {
+                        function: ast::FunctionName::Upper,
+                        args: ast::FunctionArguments::Args(vec![ast::Expression::Identifier(
+                            "this".to_string()
+                        )]),
+                        set_quantifier: None,
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::Function(ast::FunctionName::Upper)
+                )),
+            })
+        )),
+    );
+
+    test_rewrite_ast!(
+        filter_unary_op,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
+                    ast::UnaryExpr {
+                        op: ast::UnaryOp::Not,
+                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::UnaryOp(ast::UnaryOp::Not)
+                )),
+            })
+        )),
+    );
+
+    // Again, we will rewrite overloaded binary operators to unary operators in the context of Map
+    // and Filter. Of course, `+` and `-` are semantically invalid as the function argument to
+    // Filter. However, the rewriter does not impose semantic checks except in cases where it truly
+    // cannot proceed without performing mild semantic validation (such as ensuring there are
+    // actually 2 arguments for a binary op).
+    test_rewrite_ast!(
+        filter_binary_add_rewritten_to_unary_add,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
+                    ast::UnaryExpr {
+                        op: ast::UnaryOp::Pos,
+                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::BinaryOp(ast::BinaryOp::Add)
+                )),
+            })
+        )),
+    );
+
+    test_rewrite_ast!(
+        filter_binary_sub_rewritten_to_unary_sub,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
+                    ast::UnaryExpr {
+                        op: ast::UnaryOp::Neg,
+                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::BinaryOp(ast::BinaryOp::Sub)
+                )),
+            })
+        )),
+    );
+
+    test_rewrite_ast!(
+        filter_binary_op_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "Eq",
+            required: ArgCount::Exactly(2),
+            found: 1,
+        }),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::BinaryOp(ast::BinaryOp::Comparison(ast::ComparisonOp::Eq))
+                )),
+            })
+        )),
+    );
+
+    test_rewrite_ast!(
+        filter_function,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Function(
+                    ast::FunctionExpr {
+                        function: ast::FunctionName::Coalesce,
+                        args: ast::FunctionArguments::Args(vec![ast::Expression::Identifier(
+                            "this".to_string()
+                        )]),
+                        set_quantifier: None,
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::Function(ast::FunctionName::Coalesce)
+                )),
+            })
+        )),
+    );
+
+    test_rewrite_ast!(
+        reduce_unary_op_invalid,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Err(Error::IncorrectArgumentCount {
+            name: "Not",
+            required: ArgCount::Exactly(1),
+            found: 2,
+        }),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::UnaryOp(ast::UnaryOp::Not)
+                )),
+            })
+        )),
+    );
+
+    // Again, overloaded unary operators (`+` and `-`) are rewritten to their binary counterparts in
+    // the context of a Reduce function since Reduce provides 2 arguments (`this` and `value`).
+    test_rewrite_ast!(
+        reduce_unary_add_rewritten_to_binary_add,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        op: ast::BinaryOp::Add,
+                        left: Box::new(ast::Expression::Identifier("value".to_string())),
+                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::UnaryOp(ast::UnaryOp::Pos)
+                )),
+            })
+        )),
+    );
+
+    test_rewrite_ast!(
+        reduce_unary_sub_rewritten_to_binary_sub,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        op: ast::BinaryOp::Sub,
+                        left: Box::new(ast::Expression::Identifier("value".to_string())),
+                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::UnaryOp(ast::UnaryOp::Neg)
+                )),
+            })
+        )),
+    );
+
+    test_rewrite_ast!(
+        reduce_binary_op,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
+                    ast::BinaryExpr {
+                        op: ast::BinaryOp::Div,
+                        left: Box::new(ast::Expression::Identifier("value".to_string())),
+                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::BinaryOp(ast::BinaryOp::Div)
+                )),
+            })
+        )),
+    );
+
+    test_rewrite_ast!(
+        reduce_function,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
+                f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Function(
+                    ast::FunctionExpr {
+                        function: ast::FunctionName::Pow,
+                        args: ast::FunctionArguments::Args(vec![
+                            ast::Expression::Identifier("value".to_string()),
+                            ast::Expression::Identifier("this".to_string()),
+                        ]),
+                        set_quantifier: None,
+                    }
+                ))),
+            })
+        ))),
+        input = make_select_query(ast::Expression::HigherOrderFunction(
+            ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
+                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
+                f: Box::new(ast::FunctionArgument::NamedFunction(
+                    ast::NamedFunction::Function(ast::FunctionName::Pow)
+                )),
+            })
+        )),
     );
 }


### PR DESCRIPTION
This PR implements the `FunctionArgumentVisitor` which was previously stubbed out as part of #176. ~**Importantly, I rebased this branch on top of #183. When reviewing, I advise omitting the first commit in this PR since it is a squashed version of #183, which is quite large!**~ The design doc describes this visitor [here](https://docs.google.com/document/d/15bcFJ1wH6BcQYem7slPP8eG142BSvmjY3UuTNve8r7I/edit?tab=t.0#heading=h.he6cyip700kh).

This implementation is more self-contained than #183 since it does not involve introducing any new function names or any new parser support.

No spec or end-to-end tests can be skipped as a result of this change. Those are all still waiting on parser support for higher order functions, which will be unblocked once this and #183 are merged.

Edit: #183 has been merged so I rebased on top of that and this is now in much cleaner state to review.