### PR TITLE
SQL-3298: Implement parser support for higher order functions

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -10,21 +10,22 @@ Each error type (schema, parser, and algebrizer) is detailed in separate section
 The following errors occur when something goes wrong while handling the schema of the data source (collection) that the SQL query is querying data from.
 These errors often occur when you use data types in an incorrect or invalid way.
 
-| Error Code | Error Description                                                                                                                                                                 |
-| ---------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Error 1001](#error-1001)  | A function (e.g., Sin, Abs, Round) has the incorrect number of arguments.                                                                                                               |
-| [Error 1002](#error-1002)  | The specified operation (e.g., Sub, And, Substring) has argument(s) of the incorrect type (e.g., string, int).                                                                                |
-| [Error 1003](#error-1003)  | The argument provided to the aggregation is not of a type that is comparable to itself.                                                                                           |                                                                                                                                             |
-| [Error 1005](#error-1005)  | The specified comparison operation (e.g., Lte, Between) could not be done due to incomparable types of their operands (e.g., comparing an int to a string).                                   |
-| [Error 1007](#error-1007)  | Cannot access field, because it cannot be found (and likely doesn't exist).                                                                                                 |
-| [Error 1008](#error-1008)  | The cardinality of a subquery's result set may be greater than 1. The result set MUST have a cardinality of 0 or 1.                                                               |
-| [Error 1010](#error-1010)  | Cannot sort by the specified key because it is of a type that can't be compared against itself.                                                                                   |
-| [Error 1011](#error-1011)  | Cannot group by the specified key because it is of a type that can't be compared against itself.                                                                                  |
-| [Error 1014](#error-1014)  | UNWIND INDEX name conflicts with existing field name.                                                                                                                             |
-| [Error 1016](#error-1016)  | The collection in the specified database could not be found.                                                                                                                      |
-| [Error 1017](#error-1017)  | Extended JSON detected in comparison operation. MongoSQL does not support direct comparisons with extended JSON. Use casting instead (look at "Resolution Steps" for an example). |
-| [Error 1018](#error-1018)  | A field has an unsupported BSON type. |
-| [Error 1019](#error-1019)  | A field of type Binary data has the unsupported subtype of uuid old (subtype 3). |
+| Error Code                | Error Description                                                                                                                                                                 |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Error 1001](#error-1001) | A function (e.g., Sin, Abs, Round) has the incorrect number of arguments.                                                                                                         |
+| [Error 1002](#error-1002) | The specified operation (e.g., Sub, And, Substring) has argument(s) of the incorrect type (e.g., string, int).                                                                    |
+| [Error 1003](#error-1003) | The argument provided to the aggregation is not of a type that is comparable to itself.                                                                                           |                                                                                                                                             |
+| [Error 1005](#error-1005) | The specified comparison operation (e.g., Lte, Between) could not be done due to incomparable types of their operands (e.g., comparing an int to a string).                       |
+| [Error 1007](#error-1007) | Cannot access field, because it cannot be found (and likely doesn't exist).                                                                                                       |
+| [Error 1008](#error-1008) | The cardinality of a subquery's result set may be greater than 1. The result set MUST have a cardinality of 0 or 1.                                                               |
+| [Error 1010](#error-1010) | Cannot sort by the specified key because it is of a type that can't be compared against itself.                                                                                   |
+| [Error 1011](#error-1011) | Cannot group by the specified key because it is of a type that can't be compared against itself.                                                                                  |
+| [Error 1014](#error-1014) | UNWIND INDEX name conflicts with existing field name.                                                                                                                             |
+| [Error 1016](#error-1016) | The collection in the specified database could not be found.                                                                                                                      |
+| [Error 1017](#error-1017) | Extended JSON detected in comparison operation. MongoSQL does not support direct comparisons with extended JSON. Use casting instead (look at "Resolution Steps" for an example). |
+| [Error 1018](#error-1018) | A field has an unsupported BSON type.                                                                                                                                             |
+| [Error 1019](#error-1019) | A field of type Binary data has the unsupported subtype of uuid old (subtype 3).                                                                                                  |
+| [Error 1020](#error-1020) | A schema error occurred in the context of a higher order function (Map, Filter, or Reduce).                                                                                       |
 
 ## Error Codes Beginning With "2" Overview
 
@@ -67,6 +68,7 @@ The following errors occur when something goes wrong while converting the SQL qu
 | [Error 3029](#error-3029) | The UNWIND PATH option is not an identifier. The UNWIND PATH option must be an identifier.                                                                                                                   |
 | [Error 3030](#error-3030) | The target type of the CAST is an invalid type (i.e., it's either an unknown type or a type that MongoSQL does not support casting for).                                                                     |
 | [Error 3034](#error-3034) | A sort key is invalid, because it uses complex expressions (i.e., `ORDER BY {'a': b}.a` is invalid).                                                                                                         |
+| [Error 3035](#error-3035) | An error occured in the context of a higher order function (Map, Filter, or Reduce).                                                                                                         |
 
 ## Error Codes Beginning With "4" Overview
 
@@ -181,7 +183,18 @@ The following errors occur when something goes wrong while using the excludeName
 
 - **Description:** A field of type Binary data has the unsupported subtype of uuid old.
 - **Common Causes:** Historically, different drivers have written Uuids using different byte orders. This may occur for older data written by a driver using the now-unsupported uuid type.
-- **Resolution Steps:** Querying this data is not supported by Atlas SQL. 
+- **Resolution Steps:** Querying this data is not supported by Atlas SQL.
+
+### Error 1020
+
+- **Description:** A schema error occurred in the context of a higher order function (Map, Filter, or Reduce). This error is a wrapper for other schema errors.
+- **Common Causes:** There are several root causes for this error:
+  1. Invalid usage of variable `this`. Recall that usages of the `this` variable must be satisfied by the schema of the elements of the array. For example, `MAP(['a'], this + 1)` is invalid because `this + 1` expects `this` to be a numeric type, but the elements of the array are strings.
+  2. Invalid usage of variable `value` because of the initial value. Recall that usages of the `value` variable must be satisfied by the both the schema of the initial value and the schema of the result of the accumulator function for `REDUCE`. For example, `REDUCE(['a'], 0, value || this)` is invalid because `value || this` expects `value` to be a string, but the initial value is a number.
+  3. Invalid usage of variable `value` because of the result of the accumulator function. Similar to before, except in this case it is the accumulated result that causes the problem. For example, `REDUCE(array_field, 'a', CASE value WHEN 'a' THEN 1 ELSE 1 END)` is invalid because `CASE value WHEN 'a' THEN 1 ELSE 1 END` expects `value` to be a string, but the result of the accumulator function is a number.
+  4. Invalid initial value argument. The initial value must be semantically valid. For example, `REDUCE([1], 'a' + 1, this + value)` is invalid because the initial value is not a valid expression since you cannot add a string and a number.
+  5. Invalid function argument. The function argument must be semantically valid. It must have the correct number of arguments and the arguments must have the correct types. For example, `MAP([1], this + 'a')` is invalid because the function argument is not a valid expression since you cannot add a string and a number.
+- **Resolution Steps:** Resolve the underlying error according to the resolution steps on this page. This error wraps the underlying error and provides its code and error message. One of the root causes above will be identified as part of the wrapper to aid you in identifying which part of the higher order function is at the root of the problem. 
 
 ### Error 2000
 
@@ -364,6 +377,15 @@ The following errors occur when something goes wrong while using the excludeName
     causes this error, because `CAST(d AS DOCUMENT)` is a complex expression.
 - **Resolution Steps:** Make sure you only sort by "pure" field path. A "pure" field path consists only of
     identifiers, such as `foo.d.a` or `a`.
+
+### Error 3035
+
+- **Description:** An error occurred in the context of a higher order function (Map, Filter, or Reduce). This error is a wrapper for other 3000 series errors.
+- **Common Causes:** There are several root causes for this error:
+  1. An invalid array argument. For example, `FILTER(1, this = 1)` is invalid because the first argument must be an array.
+  2. An invalid initial value argument for `REDUCE`. For example, `REDUCE([1], unknown_field, value + this)` would be invalid if `unknown_field` does not exist.
+  3. An invalid function argument. For example, `MAP([1], this * unknown_field)` would be invalid if `unknown_field` does not exist.
+- **Resolution Steps:** Resolve the underlying error according to the resolution steps on this page. This error wraps the underlying error and provides its code and error message. One of the root causes above will be identified as part of the wrapper to aid you in identifying which part of the higher order function is at the root of the problem.
 
 ### Error 4000
 - **Description:** The non-namespaced result set cannot be returned due to field name conflict(s).

--- a/mongosql/src/algebrizer/definitions.rs
+++ b/mongosql/src/algebrizer/definitions.rs
@@ -1535,7 +1535,7 @@ impl<'a> Algebrizer<'a> {
             // If we ever see Identifier in algebrize_expression it must be an unqualified
             // reference, because we do not recurse on the expr field of Subpath if it is an
             // Identifier. It may also be a Variable, which is determined by the ExpressionContext.
-            ast::Expression::Identifier(i) => self.algebrize_unqualified_identifier(i),
+            ast::Expression::Identifier(i) => self.algebrize_unqualified_identifier(i.name),
             ast::Expression::Subpath(s) => self.algebrize_subpath(s),
             ast::Expression::Unary(u) => self.algebrize_unary_expr(u),
             ast::Expression::Binary(b) => self.algebrize_binary_expr(b),
@@ -2556,8 +2556,8 @@ impl<'a> Algebrizer<'a> {
     }
 
     fn algebrize_subpath(&self, p: ast::SubpathExpr) -> Result<mir::Expression> {
-        if let ast::Expression::Identifier(s) = *p.expr {
-            return self.algebrize_possibly_qualified_field_access(s, p.subpath);
+        if let ast::Expression::Identifier(i) = *p.expr {
+            return self.algebrize_possibly_qualified_field_access(i.name, p.subpath);
         }
         // The `expr` of a SubpathExpr is algebrized in an implicit type conversion context since a
         // String is unexpected in this position.

--- a/mongosql/src/algebrizer/test/expressions/between.rs
+++ b/mongosql/src/algebrizer/test/expressions/between.rs
@@ -82,7 +82,7 @@ test_algebrize!(
         min: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"2\"}".to_string()
         )),
-        max: Box::new(ast::Expression::Identifier("a".to_string())),
+        max: Box::new(ast::Expression::Identifier("a".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -126,7 +126,7 @@ test_algebrize!(
         min: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"2\"}".to_string()
         )),
-        max: Box::new(ast::Expression::Identifier("a".to_string())),
+        max: Box::new(ast::Expression::Identifier("a".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -163,7 +163,7 @@ test_algebrize!(
         arg: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
-        min: Box::new(ast::Expression::Identifier("a".to_string())),
+        min: Box::new(ast::Expression::Identifier("a".into())),
         max: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"2\"}".to_string()
         )),
@@ -207,7 +207,7 @@ test_algebrize!(
         arg: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
-        min: Box::new(ast::Expression::Identifier("a".to_string())),
+        min: Box::new(ast::Expression::Identifier("a".into())),
         max: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"2\"}".to_string()
         )),
@@ -244,7 +244,7 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Between(ast::BetweenExpr {
-        arg: Box::new(ast::Expression::Identifier("a".to_string())),
+        arg: Box::new(ast::Expression::Identifier("a".into())),
         min: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
@@ -288,7 +288,7 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Between(ast::BetweenExpr {
-        arg: Box::new(ast::Expression::Identifier("a".to_string())),
+        arg: Box::new(ast::Expression::Identifier("a".into())),
         min: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
@@ -335,8 +335,8 @@ test_algebrize!(
         arg: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
-        min: Box::new(ast::Expression::Identifier("a".to_string())),
-        max: Box::new(ast::Expression::Identifier("b".to_string())),
+        min: Box::new(ast::Expression::Identifier("a".into())),
+        max: Box::new(ast::Expression::Identifier("b".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -378,8 +378,8 @@ test_algebrize!(
         arg: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
-        min: Box::new(ast::Expression::Identifier("a".to_string())),
-        max: Box::new(ast::Expression::Identifier("b".to_string())),
+        min: Box::new(ast::Expression::Identifier("a".into())),
+        max: Box::new(ast::Expression::Identifier("b".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -423,8 +423,8 @@ test_algebrize!(
         arg: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
-        min: Box::new(ast::Expression::Identifier("a".to_string())),
-        max: Box::new(ast::Expression::Identifier("b".to_string())),
+        min: Box::new(ast::Expression::Identifier("a".into())),
+        max: Box::new(ast::Expression::Identifier("b".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -463,11 +463,11 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Between(ast::BetweenExpr {
-        arg: Box::new(ast::Expression::Identifier("a".to_string())),
+        arg: Box::new(ast::Expression::Identifier("a".into())),
         min: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
-        max: Box::new(ast::Expression::Identifier("b".to_string())),
+        max: Box::new(ast::Expression::Identifier("b".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -506,11 +506,11 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Between(ast::BetweenExpr {
-        arg: Box::new(ast::Expression::Identifier("a".to_string())),
+        arg: Box::new(ast::Expression::Identifier("a".into())),
         min: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
-        max: Box::new(ast::Expression::Identifier("b".to_string())),
+        max: Box::new(ast::Expression::Identifier("b".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -551,11 +551,11 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Between(ast::BetweenExpr {
-        arg: Box::new(ast::Expression::Identifier("a".to_string())),
+        arg: Box::new(ast::Expression::Identifier("a".into())),
         min: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
-        max: Box::new(ast::Expression::Identifier("b".to_string())),
+        max: Box::new(ast::Expression::Identifier("b".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -594,8 +594,8 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Between(ast::BetweenExpr {
-        arg: Box::new(ast::Expression::Identifier("a".to_string())),
-        min: Box::new(ast::Expression::Identifier("b".to_string())),
+        arg: Box::new(ast::Expression::Identifier("a".into())),
+        min: Box::new(ast::Expression::Identifier("b".into())),
         max: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
@@ -637,8 +637,8 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Between(ast::BetweenExpr {
-        arg: Box::new(ast::Expression::Identifier("a".to_string())),
-        min: Box::new(ast::Expression::Identifier("b".to_string())),
+        arg: Box::new(ast::Expression::Identifier("a".into())),
+        min: Box::new(ast::Expression::Identifier("b".into())),
         max: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
@@ -682,8 +682,8 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Between(ast::BetweenExpr {
-        arg: Box::new(ast::Expression::Identifier("a".to_string())),
-        min: Box::new(ast::Expression::Identifier("b".to_string())),
+        arg: Box::new(ast::Expression::Identifier("a".into())),
+        min: Box::new(ast::Expression::Identifier("b".into())),
         max: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
         )),

--- a/mongosql/src/algebrizer/test/expressions/binary.rs
+++ b/mongosql/src/algebrizer/test/expressions/binary.rs
@@ -592,7 +592,7 @@ test_algebrize!(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
         op: ast::BinaryOp::Comparison(ast::ComparisonOp::Gt),
-        right: Box::new(ast::Expression::Identifier("a".to_string())),
+        right: Box::new(ast::Expression::Identifier("a".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -631,7 +631,7 @@ test_algebrize!(
             "{\"$numberInt\": \"1\"}".to_string()
         )),
         op: ast::BinaryOp::Comparison(ast::ComparisonOp::Lt),
-        right: Box::new(ast::Expression::Identifier("a".to_string())),
+        right: Box::new(ast::Expression::Identifier("a".into())),
     }),
     env = map! {
         ("foo", 1u16).into() => Schema::Document( Document {
@@ -664,7 +664,7 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Binary(ast::BinaryExpr {
-        left: Box::new(ast::Expression::Identifier("a".to_string())),
+        left: Box::new(ast::Expression::Identifier("a".into())),
         op: ast::BinaryOp::Comparison(ast::ComparisonOp::Gte),
         right: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
@@ -703,7 +703,7 @@ test_algebrize!(
         }
     )),
     input = ast::Expression::Binary(ast::BinaryExpr {
-        left: Box::new(ast::Expression::Identifier("a".to_string())),
+        left: Box::new(ast::Expression::Identifier("a".into())),
         op: ast::BinaryOp::Comparison(ast::ComparisonOp::Lte),
         right: Box::new(ast::Expression::StringConstructor(
             "{\"$numberInt\": \"1\"}".to_string()
@@ -748,7 +748,7 @@ mod in_operator {
             }
         )),
         input = ast::Expression::Binary(ast::BinaryExpr {
-            left: Box::new(ast::Expression::Identifier("a".to_string())),
+            left: Box::new(ast::Expression::Identifier("a".into())),
             op: ast::BinaryOp::In,
             right: Box::new(ast::Expression::Tuple(vec![
                 ast::Expression::Literal(ast::Literal::Integer(1)),
@@ -793,7 +793,7 @@ mod in_operator {
             }
         )),
         input = ast::Expression::Binary(ast::BinaryExpr {
-            left: Box::new(ast::Expression::Identifier("a".to_string())),
+            left: Box::new(ast::Expression::Identifier("a".into())),
             op: ast::BinaryOp::NotIn,
             right: Box::new(ast::Expression::Tuple(vec![
                 ast::Expression::Literal(ast::Literal::Integer(1)),
@@ -834,7 +834,7 @@ mod in_operator {
             }
         )),
         input = ast::Expression::Binary(ast::BinaryExpr {
-            left: Box::new(ast::Expression::Identifier("a".to_string())),
+            left: Box::new(ast::Expression::Identifier("a".into())),
             op: ast::BinaryOp::In,
             right: Box::new(ast::Expression::Tuple(vec![ast::Expression::Literal(
                 ast::Literal::Boolean(true)
@@ -931,7 +931,7 @@ mod in_operator {
             }
         )),
         input = ast::Expression::Binary(ast::BinaryExpr {
-            left: Box::new(ast::Expression::Identifier("d".to_string())),
+            left: Box::new(ast::Expression::Identifier("d".into())),
             op: ast::BinaryOp::In,
             right: Box::new(ast::Expression::Tuple(vec![
                 ast::Expression::StringConstructor(
@@ -980,7 +980,7 @@ mod in_operator {
             }
         )),
         input = ast::Expression::Binary(ast::BinaryExpr {
-            left: Box::new(ast::Expression::Identifier("s".to_string())),
+            left: Box::new(ast::Expression::Identifier("s".into())),
             op: ast::BinaryOp::In,
             right: Box::new(ast::Expression::Tuple(vec![
                 ast::Expression::StringConstructor("hello".to_string()),
@@ -1057,7 +1057,7 @@ mod in_operator {
             }
         )),
         input = ast::Expression::Binary(ast::BinaryExpr {
-            left: Box::new(ast::Expression::Identifier("n".to_string())),
+            left: Box::new(ast::Expression::Identifier("n".into())),
             op: ast::BinaryOp::In,
             right: Box::new(ast::Expression::Tuple(vec![
                 ast::Expression::Literal(ast::Literal::Integer(1)),

--- a/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
+++ b/mongosql/src/algebrizer/test/expressions/higher_order_functions.rs
@@ -47,7 +47,7 @@ mod map {
         input =
             ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
                 array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "a".to_string(),
                 })),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
@@ -88,7 +88,7 @@ mod map {
                     ast::Literal::Integer(1)
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "this".to_string()
+                    "this".into()
                 ))),
             })),
     );
@@ -119,7 +119,7 @@ mod map {
                     ast::Expression::Literal(ast::Literal::Null),
                 ])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "this".to_string()
+                    "this".into()
                 ))),
             })),
     );
@@ -159,9 +159,9 @@ mod map {
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Add,
-                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                        right: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })),
@@ -205,10 +205,10 @@ mod map {
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Add,
                         right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            expr: Box::new(ast::Expression::Identifier("foo".into())),
                             subpath: "this".to_string(),
                         })),
                     }
@@ -243,7 +243,7 @@ mod map {
         input =
             ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
                 array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "a".to_string(),
                 })),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
@@ -273,10 +273,10 @@ mod map {
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Add,
                         right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            expr: Box::new(ast::Expression::Identifier("foo".into())),
                             subpath: "this".to_string(),
                         })),
                     }
@@ -335,7 +335,7 @@ mod filter {
         input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
             ast::FilterExpr {
                 array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "a".to_string(),
                 })),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
@@ -378,7 +378,7 @@ mod filter {
                     ast::Literal::Boolean(true)
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "this".to_string()
+                    "this".into()
                 ))),
             }
         )),
@@ -411,7 +411,7 @@ mod filter {
                     ast::Expression::Literal(ast::Literal::Null),
                 ])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "this".to_string()
+                    "this".into()
                 ))),
             }
         )),
@@ -453,9 +453,9 @@ mod filter {
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Comparison(ast::ComparisonOp::Eq),
-                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                        right: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             }
@@ -501,10 +501,10 @@ mod filter {
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Comparison(ast::ComparisonOp::Eq),
                         right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            expr: Box::new(ast::Expression::Identifier("foo".into())),
                             subpath: "this".to_string(),
                         })),
                     }
@@ -540,7 +540,7 @@ mod filter {
         input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Filter(
             ast::FilterExpr {
                 array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "a".to_string(),
                 })),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
@@ -571,10 +571,10 @@ mod filter {
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Comparison(ast::ComparisonOp::Eq),
                         right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            expr: Box::new(ast::Expression::Identifier("foo".into())),
                             subpath: "this".to_string(),
                         })),
                     }
@@ -637,7 +637,7 @@ mod reduce {
         input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
             ast::ReduceExpr {
                 array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "a".to_string(),
                 })),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
@@ -683,7 +683,7 @@ mod reduce {
                 )])),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "this".to_string()
+                    "this".into()
                 ))),
             }
         )),
@@ -718,7 +718,7 @@ mod reduce {
                 ])),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "this".to_string()
+                    "this".into()
                 ))),
             }
         )),
@@ -749,7 +749,7 @@ mod reduce {
                 )])),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "value".to_string()
+                    "value".into()
                 ))),
             }
         )),
@@ -780,7 +780,7 @@ mod reduce {
                 ),])),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Null)),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "value".to_string()
+                    "value".into()
                 ))),
             }
         )),
@@ -821,7 +821,7 @@ mod reduce {
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("value".to_string())),
+                        left: Box::new(ast::Expression::Identifier("value".into())),
                         op: ast::BinaryOp::Add,
                         right: Box::new(ast::Expression::Literal(ast::Literal::Null)),
                     }
@@ -894,20 +894,20 @@ mod reduce {
                     ast::Literal::Integer(1)
                 )])),
                 init_value: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "field".to_string(),
                 })),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Add,
                         right: Box::new(ast::Expression::Binary(ast::BinaryExpr {
-                            left: Box::new(ast::Expression::Identifier("value".to_string())),
+                            left: Box::new(ast::Expression::Identifier("value".into())),
                             op: ast::BinaryOp::Add,
                             right: Box::new(ast::Expression::Binary(ast::BinaryExpr {
-                                left: Box::new(ast::Expression::Identifier("this".to_string())),
+                                left: Box::new(ast::Expression::Identifier("this".into())),
                                 op: ast::BinaryOp::Add,
-                                right: Box::new(ast::Expression::Identifier("value".to_string())),
+                                right: Box::new(ast::Expression::Identifier("value".into())),
                             })),
                         })),
                     }
@@ -996,19 +996,19 @@ mod reduce {
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Add,
                         right: Box::new(ast::Expression::Binary(ast::BinaryExpr {
                             left: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                                expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                                expr: Box::new(ast::Expression::Identifier("foo".into())),
                                 subpath: "this".to_string(),
                             })),
                             op: ast::BinaryOp::Add,
                             right: Box::new(ast::Expression::Binary(ast::BinaryExpr {
-                                left: Box::new(ast::Expression::Identifier("value".to_string())),
+                                left: Box::new(ast::Expression::Identifier("value".into())),
                                 op: ast::BinaryOp::Add,
                                 right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                                     subpath: "value".to_string(),
                                 })),
                             })),
@@ -1047,7 +1047,7 @@ mod reduce {
         input = ast::Expression::HigherOrderFunction(ast::HigherOrderFunctionExpr::Reduce(
             ast::ReduceExpr {
                 array: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "a".to_string(),
                 })),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
@@ -1078,7 +1078,7 @@ mod reduce {
                     ast::Literal::Integer(1)
                 )])),
                 init_value: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "a".to_string(),
                 })),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Literal(
@@ -1110,10 +1110,10 @@ mod reduce {
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Add,
                         right: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                            expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                            expr: Box::new(ast::Expression::Identifier("foo".into())),
                             subpath: "this".to_string(),
                         })),
                     }
@@ -1152,7 +1152,7 @@ mod shadowing_variables {
                     ast::Literal::Null
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "this".to_string()
+                    "this".into()
                 ))),
             })),
     );
@@ -1184,7 +1184,7 @@ mod shadowing_variables {
                     ast::Literal::Boolean(true)
                 )])),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Identifier(
-                    "this".to_string()
+                    "this".into()
                 ))),
             }
         )),
@@ -1232,9 +1232,9 @@ mod shadowing_variables {
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(1))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
-                        left: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier("this".into())),
                         op: ast::BinaryOp::Add,
-                        right: Box::new(ast::Expression::Identifier("value".to_string())),
+                        right: Box::new(ast::Expression::Identifier("value".into())),
                     }
                 ))),
             }
@@ -1472,7 +1472,7 @@ mod shadowing_variables {
                                                             expr: Box::new(ast::Expression::Binary(
                                                                 ast::BinaryExpr {
                                                                     left: Box::new(ast::Expression::Identifier(
-                                                                        "this".to_string(),
+                                                                        "this".into(),
                                                                     )),
                                                                     op: ast::BinaryOp::Concat,
                                                                     right: Box::new(
@@ -1492,7 +1492,7 @@ mod shadowing_variables {
                                                         })),
                                                         op: ast::BinaryOp::Add,
                                                         right: Box::new(ast::Expression::Identifier(
-                                                            "value".to_string()
+                                                            "value".into()
                                                         )),
                                                     })),
                                                     op: ast::BinaryOp::Add,
@@ -1508,12 +1508,12 @@ mod shadowing_variables {
                                                                         f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                                                                             ast::BinaryExpr {
                                                                                 left: Box::new(ast::Expression::Identifier(
-                                                                                    "this".to_string()
+                                                                                    "this".into()
                                                                                 )),
                                                                                 op: ast::BinaryOp::Or,
                                                                                 right: Box::new(ast::Expression::Cast(ast::CastExpr {
                                                                                     expr: Box::new(ast::Expression::Identifier(
-                                                                                        "value".to_string()
+                                                                                        "value".into()
                                                                                     )),
                                                                                     to: ast::Type::Boolean,
                                                                                     on_null: Some(ast::Expression::Literal(
@@ -1535,10 +1535,10 @@ mod shadowing_variables {
                                     set_quantifier: None,
                                 })),
                                 op: ast::BinaryOp::Add,
-                                right: Box::new(ast::Expression::Identifier("this".to_string())),
+                                right: Box::new(ast::Expression::Identifier("this".into())),
                             })),
                             op: ast::BinaryOp::Add,
-                            right: Box::new(ast::Expression::Identifier("value".to_string()))
+                            right: Box::new(ast::Expression::Identifier("value".into()))
                         }
                     )),
                     op: ast::BinaryOp::Add,
@@ -1553,7 +1553,7 @@ mod shadowing_variables {
                                     expr: Box::new(ast::Expression::Binary(
                                         ast::BinaryExpr {
                                             left: Box::new(ast::Expression::Cast(ast::CastExpr {
-                                                expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                                                expr: Box::new(ast::Expression::Identifier("this".into())),
                                                 to: ast::Type::Int32,
                                                 on_null: Some(ast::Expression::Literal(
                                                     ast::Literal::Integer(0)
@@ -1565,7 +1565,7 @@ mod shadowing_variables {
                                             op: ast::BinaryOp::Add,
                                             right: Box::new(ast::Expression::Cast(ast::CastExpr {
                                                 expr: Box::new(ast::Expression::Identifier(
-                                                    "value".to_string()
+                                                    "value".into()
                                                 )),
                                                 to: ast::Type::Int32,
                                                 on_null: Some(ast::Expression::Literal(

--- a/mongosql/src/algebrizer/test/from_clause/mod.rs
+++ b/mongosql/src/algebrizer/test/from_clause/mod.rs
@@ -801,9 +801,9 @@ test_algebrize!(
             alias: "bar".into(),
         })),
         condition: Some(ast::Expression::Binary(ast::BinaryExpr {
-            left: Box::new(ast::Expression::Identifier("a".to_string())),
+            left: Box::new(ast::Expression::Identifier("a".into())),
             op: ast::BinaryOp::Comparison(ast::ComparisonOp::Eq),
-            right: Box::new(ast::Expression::Identifier("b".to_string())),
+            right: Box::new(ast::Expression::Identifier("b".into())),
         }))
     })),
 );

--- a/mongosql/src/algebrizer/test/group_by_clause/mod.rs
+++ b/mongosql/src/algebrizer/test/group_by_clause/mod.rs
@@ -84,7 +84,7 @@ lazy_static! {
     // GROUP BY KEYS
     static ref AST_SUBPATH: ast::OptionallyAliasedExpr = ast::OptionallyAliasedExpr::Aliased(ast::AliasedExpr {
         expr: ast::Expression::Subpath(ast::SubpathExpr {
-            expr: Box::new(ast::Expression::Identifier("arr".to_string())),
+            expr: Box::new(ast::Expression::Identifier("arr".into())),
             subpath: "a".to_string()
         }),
         alias: "key".to_string(),
@@ -100,7 +100,7 @@ lazy_static! {
     static ref AST_SUBPATH_COMPLEX_EXPR: ast::OptionallyAliasedExpr = ast::OptionallyAliasedExpr::Aliased(ast::AliasedExpr {
         expr: ast::Expression::Binary(ast::BinaryExpr {
             left: Box::new(ast::Expression::Subpath(ast::SubpathExpr {
-                expr: Box::new(ast::Expression::Identifier("arr".to_string())),
+                expr: Box::new(ast::Expression::Identifier("arr".into())),
                 subpath: "a".to_string()
             })),
             op: ast::BinaryOp::Add,
@@ -117,7 +117,7 @@ lazy_static! {
             function: ast::FunctionName::Avg,
             args: ast::FunctionArguments::Args(vec![
                 ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("arr".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("arr".into())),
                     subpath: "a".to_string()
                 })
             ]),

--- a/mongosql/src/algebrizer/test/order_by_clause/mod.rs
+++ b/mongosql/src/algebrizer/test/order_by_clause/mod.rs
@@ -37,14 +37,14 @@ test_algebrize!(
         sort_specs: vec![
             ast::SortSpec {
                 key: ast::SortKey::Simple(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "a".to_string()
                 })),
                 direction: ast::SortDirection::Asc
             },
             ast::SortSpec {
                 key: ast::SortKey::Simple(ast::Expression::Subpath(ast::SubpathExpr {
-                    expr: Box::new(ast::Expression::Identifier("foo".to_string())),
+                    expr: Box::new(ast::Expression::Identifier("foo".into())),
                     subpath: "b".to_string()
                 })),
                 direction: ast::SortDirection::Desc
@@ -90,7 +90,7 @@ test_algebrize!(
     input = Some(ast::OrderByClause {
         sort_specs: vec![ast::SortSpec {
             key: ast::SortKey::Simple(ast::Expression::Subpath(ast::SubpathExpr {
-                expr: Box::new(ast::Expression::Identifier("arr".to_string())),
+                expr: Box::new(ast::Expression::Identifier("arr".into())),
                 subpath: "a".to_string()
             })),
             direction: ast::SortDirection::Asc

--- a/mongosql/src/ast/definitions.rs
+++ b/mongosql/src/ast/definitions.rs
@@ -296,7 +296,7 @@ pub enum Expression {
     Document(Vec<DocumentPair>),
     Access(AccessExpr),
     Subpath(SubpathExpr),
-    Identifier(String),
+    Identifier(IdentifierExpr),
     Is(IsExpr),
     Like(LikeExpr),
     Literal(Literal),
@@ -309,7 +309,7 @@ pub enum Expression {
 impl Expression {
     pub fn into_date_part(self) -> Option<DatePart> {
         match self {
-            Expression::Identifier(i) => i.as_str().try_into().ok(),
+            Expression::Identifier(IdentifierExpr { name: i, .. }) => i.as_str().try_into().ok(),
             _ => None
         }
     }
@@ -845,6 +845,48 @@ pub struct AccessExpr {
 pub struct SubpathExpr {
     pub expr: Box<Expression>,
     pub subpath: String,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct IdentifierExpr {
+    pub name: String,
+    pub is_delimited: bool,
+}
+
+impl From<&str> for IdentifierExpr {
+    fn from(name: &str) -> Self {
+        IdentifierExpr {
+            name: name.to_string(),
+            is_delimited: false,
+        }
+    }
+}
+
+impl From<(&str, bool)> for IdentifierExpr {
+    fn from((name, is_delimited): (&str, bool)) -> Self {
+        IdentifierExpr {
+            name: name.to_string(),
+            is_delimited,
+        }
+    }
+}
+
+impl From<String> for IdentifierExpr {
+    fn from(name: String) -> Self {
+        IdentifierExpr {
+            name: name.clone(),
+            is_delimited: false,
+        }
+    }
+}
+
+impl From<(String, bool)> for IdentifierExpr {
+    fn from((name, is_delimited): (String, bool)) -> Self {
+        IdentifierExpr {
+            name: name.clone(),
+            is_delimited,
+        }
+    }
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/mongosql/src/ast/pretty_print.rs
+++ b/mongosql/src/ast/pretty_print.rs
@@ -115,7 +115,11 @@ lazy_static! {
 }
 
 fn identifier_to_string(s: &str) -> String {
-    if ident_needs_delimiters(s) {
+    identifier_to_string_with_delimiter_info(s, false)
+}
+
+fn identifier_to_string_with_delimiter_info(s: &str, is_delimited: bool) -> String {
+    if is_delimited || ident_needs_delimiters(s) {
         format!("`{}`", s.replace('`', "``"))
     } else {
         s.to_string()
@@ -785,7 +789,7 @@ impl PrettyPrint for Expression {
     fn pretty_print(&self) -> Result<String> {
         use Expression::*;
         match self {
-            Identifier(s) => Ok(identifier_to_string(s)),
+            Identifier(i) => i.pretty_print(),
             Is(i) => i.pretty_print(),
             Like(l) => l.pretty_print(),
             TypeAssertion(t) => t.pretty_print(),
@@ -833,6 +837,15 @@ impl PrettyPrint for Expression {
             HigherOrderFunction(hof) => hof.pretty_print(),
             ArrayCast(ac) => ac.pretty_print(),
         }
+    }
+}
+
+impl PrettyPrint for IdentifierExpr {
+    fn pretty_print(&self) -> Result<String> {
+        Ok(identifier_to_string_with_delimiter_info(
+            self.name.as_str(),
+            self.is_delimited,
+        ))
     }
 }
 
@@ -1140,7 +1153,7 @@ impl PrettyPrint for WhenBranch {
     }
 }
 
-fn ident_needs_delimiters(s: &str) -> bool {
+pub(crate) fn ident_needs_delimiters(s: &str) -> bool {
     if s.is_empty() {
         return true;
     }

--- a/mongosql/src/ast/pretty_print.rs
+++ b/mongosql/src/ast/pretty_print.rs
@@ -1346,7 +1346,9 @@ impl PrettyPrint for FunctionArgument {
     fn pretty_print(&self) -> Result<String> {
         Ok(match self {
             FunctionArgument::Expr(e) => e.pretty_print()?,
-            FunctionArgument::NamedFunction(NamedFunction::UnaryOp(u)) => u.pretty_print()?,
+            FunctionArgument::NamedFunction(NamedFunction::UnaryOp(u)) => {
+                u.pretty_print()?.trim().to_string()
+            }
             FunctionArgument::NamedFunction(NamedFunction::BinaryOp(b)) => b.pretty_print()?,
             FunctionArgument::NamedFunction(NamedFunction::Function(f)) => f.pretty_print()?,
         })

--- a/mongosql/src/ast/pretty_print_fuzz_test.rs
+++ b/mongosql/src/ast/pretty_print_fuzz_test.rs
@@ -1282,7 +1282,29 @@ mod arbitrary {
             let rng = &(0..Self::VARIANT_COUNT).collect::<Vec<_>>();
             match g.choose(rng).unwrap() {
                 0 => Self::UnaryOp(UnaryOp::arbitrary(g)),
-                1 => Self::BinaryOp(BinaryOp::arbitrary(g)),
+                1 => {
+                    let op = BinaryOp::arbitrary(g);
+                    match op {
+                        // `+` and `-` are always parsed as the UnaryOp versions, so we cannot
+                        // create a BinaryOp version of them here or else the reparsed tree would
+                        // differ.
+                        BinaryOp::Add => Self::UnaryOp(UnaryOp::Pos),
+                        BinaryOp::Sub => Self::UnaryOp(UnaryOp::Neg),
+                        BinaryOp::And
+                        | BinaryOp::Concat
+                        | BinaryOp::Div
+                        | BinaryOp::In
+                        | BinaryOp::Mul
+                        | BinaryOp::NotIn
+                        | BinaryOp::Or
+                        | BinaryOp::Comparison(ComparisonOp::Eq)
+                        | BinaryOp::Comparison(ComparisonOp::Gt)
+                        | BinaryOp::Comparison(ComparisonOp::Gte)
+                        | BinaryOp::Comparison(ComparisonOp::Lt)
+                        | BinaryOp::Comparison(ComparisonOp::Lte)
+                        | BinaryOp::Comparison(ComparisonOp::Neq) => Self::BinaryOp(op),
+                    }
+                }
                 2 => Self::Function(FunctionName::arbitrary(g)),
                 _ => panic!("missing NamedFunction variant(s)"),
             }

--- a/mongosql/src/ast/pretty_print_fuzz_test.rs
+++ b/mongosql/src/ast/pretty_print_fuzz_test.rs
@@ -3,7 +3,7 @@ mod fuzz_test {
     use crate::{
         ast::{
             definitions::*,
-            pretty_print::PrettyPrint,
+            pretty_print::{ident_needs_delimiters, PrettyPrint},
             rewrites::{Pass, SingleTupleRewritePass},
         },
         parser,
@@ -72,6 +72,7 @@ Reparsed AST:
 
 mod arbitrary {
     use crate::ast::definitions::*;
+    use crate::ast::pretty_print::ident_needs_delimiters;
     use quickcheck::{Arbitrary, Gen};
     use rand::{rng, RngExt as _};
 
@@ -127,6 +128,10 @@ mod arbitrary {
     /// it just uses arbitrary_string, but this allows us to fine tune
     /// easily if we decide to use different rules for identifiers from
     /// strings.
+    /// Note that this is useful for contexts where you need an "identifier"
+    /// with a lowercase "i" -- as in, not an actual IdentifierExpr. For
+    /// example, a collection name in a CollectionSource. Only IdentifierExprs
+    /// retain delimiter information.
     fn arbitrary_identifier(g: &mut Gen) -> String {
         arbitrary_string(g)
     }
@@ -140,7 +145,7 @@ mod arbitrary {
         if bool::arbitrary(g) {
             Expression::Literal(Literal::arbitrary(g))
         } else {
-            Expression::Identifier(arbitrary_identifier(g))
+            Expression::Identifier(IdentifierExpr::arbitrary(g))
         }
     }
 
@@ -636,7 +641,7 @@ mod arbitrary {
                 ),
                 14 => Self::Access(AccessExpr::arbitrary(nested_g)),
                 15 => Self::Subpath(SubpathExpr::arbitrary(nested_g)),
-                16 => Self::Identifier(arbitrary_identifier(g)),
+                16 => Self::Identifier(IdentifierExpr::arbitrary(g)),
                 17 => Self::Is(IsExpr::arbitrary(nested_g)),
                 18 => Self::Like(LikeExpr::arbitrary(nested_g)),
                 19 => Self::Literal(Literal::arbitrary(nested_g)),
@@ -1008,9 +1013,17 @@ mod arbitrary {
         //     the parser rejecting expressions like 1.a, for example
         fn arbitrary(g: &mut Gen) -> Self {
             Self {
-                expr: Box::new(Expression::Identifier(arbitrary_identifier(g))),
+                expr: Box::new(Expression::Identifier(IdentifierExpr::arbitrary(g))),
                 subpath: arbitrary_identifier(g),
             }
+        }
+    }
+
+    impl Arbitrary for IdentifierExpr {
+        fn arbitrary(g: &mut Gen) -> Self {
+            let name = arbitrary_identifier(g);
+            let is_delimited = ident_needs_delimiters(name.as_str()) || bool::arbitrary(g);
+            Self { name, is_delimited }
         }
     }
 
@@ -1152,7 +1165,7 @@ mod arbitrary {
                 1 => {
                     let rng = &(0..2).collect::<Vec<i32>>();
                     Self::Simple(match g.choose(rng).unwrap() {
-                        0 => Expression::Identifier(arbitrary_identifier(g)),
+                        0 => Expression::Identifier(IdentifierExpr::arbitrary(g)),
                         1 => Expression::Subpath(SubpathExpr::arbitrary(g)),
                         _ => panic!(),
                     })

--- a/mongosql/src/ast/pretty_print_fuzz_test.rs
+++ b/mongosql/src/ast/pretty_print_fuzz_test.rs
@@ -3,7 +3,7 @@ mod fuzz_test {
     use crate::{
         ast::{
             definitions::*,
-            pretty_print::{ident_needs_delimiters, PrettyPrint},
+            pretty_print::PrettyPrint,
             rewrites::{Pass, SingleTupleRewritePass},
         },
         parser,
@@ -648,9 +648,7 @@ mod arbitrary {
                 20 => Self::StringConstructor(arbitrary_string(g)),
                 21 => Self::Tuple((1..4).map(|_| Self::arbitrary(nested_g)).collect()),
                 22 => Self::TypeAssertion(TypeAssertionExpr::arbitrary(nested_g)),
-                // TODO: SQL-3298: Replace `23 => TypeAssertion` with `23 => HigherOrderFunction`
-                23 => Self::TypeAssertion(TypeAssertionExpr::arbitrary(nested_g)),
-                // 23 => Self::HigherOrderFunction(HigherOrderFunctionExpr::arbitrary(nested_g)),
+                23 => Self::HigherOrderFunction(HigherOrderFunctionExpr::arbitrary(nested_g)),
                 24 => Self::ArrayCast(ArrayCastExpr::arbitrary(nested_g)),
                 _ => panic!("missing Expression variant(s)"),
             }

--- a/mongosql/src/ast/pretty_print_test.rs
+++ b/mongosql/src/ast/pretty_print_test.rs
@@ -1287,7 +1287,7 @@ mod higher_order_function {
 
     expression_printer_test!(
         filter_with_named_function_arg,
-        expected = "FILTER(a, NOT )", // we intentionally print a space after unary ops
+        expected = "FILTER(a, NOT)",
         input = "FILTER(a, NOT)"
     );
 

--- a/mongosql/src/ast/pretty_print_test.rs
+++ b/mongosql/src/ast/pretty_print_test.rs
@@ -537,7 +537,11 @@ mod identifier {
         input = "`fo.o` - (bar / `$car`)"
     );
     expression_printer_test!(starts_with_number, expected = "`1foo`", input = "`1foo`");
-    expression_printer_test!(starts_with_underscore, expected = "_foo", input = "`_foo`");
+    expression_printer_test!(
+        starts_with_underscore,
+        expected = "`_foo`",
+        input = "`_foo`"
+    );
     expression_printer_test!(
         regular_identifier_containing_number,
         expected = "foo1",
@@ -545,6 +549,11 @@ mod identifier {
     );
     expression_printer_test!(empty, expected = "``", input = "``");
     expression_printer_test!(is_keyword, expected = "`is`", input = "`is`");
+    expression_printer_test!(
+        delimited_non_keyword_retains_delimiters,
+        expected = "`foo`",
+        input = "`foo`"
+    );
 }
 
 mod is {

--- a/mongosql/src/ast/pretty_print_test.rs
+++ b/mongosql/src/ast/pretty_print_test.rs
@@ -1264,43 +1264,42 @@ mod precedence_tests {
     }
 }
 
-// TODO: unskip as part of SQL-3298
-// mod higher_order_function {
-//     use super::*;
-//
-//     expression_printer_test!(
-//         map_with_expr_arg,
-//         expected = "MAP(a, this + 1)",
-//         input = "MAP(a, this+1)"
-//     );
-//
-//     expression_printer_test!(
-//         map_with_named_function_arg,
-//         expected = "MAP(a, LOWER)",
-//         input = "MAP(a, LOWER)"
-//     );
-//
-//     expression_printer_test!(
-//         filter_with_expr_arg,
-//         expected = "FILTER(a, this = 1)",
-//         input = "FILTER(a, this=1)"
-//     );
-//
-//     expression_printer_test!(
-//         filter_with_named_function_arg,
-//         expected = "FILTER(a, NOT)",
-//         input = "FILTER(a, NOT)"
-//     );
-//
-//     expression_printer_test!(
-//         reduce_with_expr_arg,
-//         expected = "REDUCE(a, 0, this + value)",
-//         input = "REDUCE(a, 0, this+value)"
-//     );
-//
-//     expression_printer_test!(
-//         reduce_with_named_function_arg,
-//         expected = "REDUCE(a, 1, *)",
-//         input = "REDUCE(a, 1, *)"
-//     );
-// }
+mod higher_order_function {
+    use super::*;
+
+    expression_printer_test!(
+        map_with_expr_arg,
+        expected = "MAP(a, this + 1)",
+        input = "MAP(a, this+1)"
+    );
+
+    expression_printer_test!(
+        map_with_named_function_arg,
+        expected = "MAP(a, LOWER)",
+        input = "MAP(a, LOWER)"
+    );
+
+    expression_printer_test!(
+        filter_with_expr_arg,
+        expected = "FILTER(a, this = 1)",
+        input = "FILTER(a, this=1)"
+    );
+
+    expression_printer_test!(
+        filter_with_named_function_arg,
+        expected = "FILTER(a, NOT )", // we intentionally print a space after unary ops
+        input = "FILTER(a, NOT)"
+    );
+
+    expression_printer_test!(
+        reduce_with_expr_arg,
+        expected = "REDUCE(a, 0, this + `value`)",
+        input = "REDUCE(a, 0, this+`value`)"
+    );
+
+    expression_printer_test!(
+        reduce_with_named_function_arg,
+        expected = "REDUCE(a, 1, *)",
+        input = "REDUCE(a, 1, *)"
+    );
+}

--- a/mongosql/src/ast/rewrites/aggregate.rs
+++ b/mongosql/src/ast/rewrites/aggregate.rs
@@ -302,7 +302,7 @@ impl Visitor for AggregateAliasingVisitor {
                 match self.agg_funcs.get(&func_key) {
                     // We can safely unwrap the alias here because any value retrieved
                     // from `agg_funcs` would have been previously inserted with an alias.
-                    Some(x) => Expression::Identifier(x.alias.clone()),
+                    Some(x) => Expression::Identifier(x.alias.clone().into()),
                     None => {
                         let new_agg_alias = format!("_agg{}", self.next_agg_id);
                         self.next_agg_id += 1;
@@ -313,7 +313,7 @@ impl Visitor for AggregateAliasingVisitor {
                                 alias: new_agg_alias.clone(),
                             },
                         );
-                        Expression::Identifier(new_agg_alias)
+                        Expression::Identifier(new_agg_alias.into())
                     }
                 }
             }

--- a/mongosql/src/ast/rewrites/alias.rs
+++ b/mongosql/src/ast/rewrites/alias.rs
@@ -36,7 +36,7 @@ impl AddAliasRewriteVisitor {
                 expr: _,
                 ref subpath,
             }) => subpath.to_string(),
-            Expression::Identifier(ref id) => id.to_string(),
+            Expression::Identifier(IdentifierExpr { name: ref id, .. }) => id.to_string(),
             _ => format!("_{}", self.counter),
         };
         OptionallyAliasedExpr::Aliased(AliasedExpr {

--- a/mongosql/src/ast/rewrites/extended_unwind_rewrite.rs
+++ b/mongosql/src/ast/rewrites/extended_unwind_rewrite.rs
@@ -101,9 +101,9 @@ impl Visitor for ExtendedUnwindRewriteVisitor {
 // Vec, we can not worry about parts that contain `.` in them.
 fn path_vec_to_path(mut path: Vec<String>) -> Expression {
     if path.len() == 1 {
-        return Expression::Identifier(path.remove(0));
+        return Expression::Identifier(path.remove(0).into());
     }
-    let mut ret = Expression::Identifier(path.remove(0));
+    let mut ret = Expression::Identifier(path.remove(0).into());
     for p in path.into_iter() {
         ret = Expression::Subpath(SubpathExpr {
             expr: Box::new(ret),

--- a/mongosql/src/ast/rewrites/group_by_select_alias.rs
+++ b/mongosql/src/ast/rewrites/group_by_select_alias.rs
@@ -90,7 +90,7 @@ impl Visitor for MatchingAliasFinder {
         for expr in group_by.keys.iter() {
             if let ast::OptionallyAliasedExpr::Unaliased(ast::Expression::Identifier(ident)) = expr
             {
-                self.group_key_identifiers.push(ident.clone());
+                self.group_key_identifiers.push(ident.name.clone());
             }
         }
         group_by
@@ -121,7 +121,7 @@ impl Visitor for Rewriter {
                 ast::AliasedExpr { alias, .. },
             )) if self.select_exprs_by_group_key_ident.contains_key(&alias) => {
                 ast::SelectExpression::Expression(ast::OptionallyAliasedExpr::Unaliased(
-                    ast::Expression::Identifier(alias),
+                    ast::Expression::Identifier(alias.into()),
                 ))
             }
             _ => select_expr,
@@ -138,7 +138,7 @@ impl Visitor for Rewriter {
             .into_iter()
             .map(|expr| match expr {
                 ast::OptionallyAliasedExpr::Unaliased(ast::Expression::Identifier(ref ident)) => {
-                    if let Some(ae) = self.select_exprs_by_group_key_ident.get(ident) {
+                    if let Some(ae) = self.select_exprs_by_group_key_ident.get(&ident.name) {
                         ast::OptionallyAliasedExpr::Aliased(ae.clone())
                     } else {
                         expr

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -444,13 +444,14 @@ impl FunctionArgumentVisitor {
 /// Returns the `this` identifier expression used within higher order function bodies.
 #[inline(always)]
 fn this() -> Expression {
-    Expression::Identifier(THIS.to_string())
+    Expression::Identifier(THIS.into())
 }
 
 /// Returns the `value` identifier expression used within higher order function bodies.
+/// Note that "value" is a reserved keyword in SQL, so we need indicate that it is delimited.
 #[inline(always)]
 fn value() -> Expression {
-    Expression::Identifier(VALUE.to_string())
+    Expression::Identifier((VALUE, true).into())
 }
 
 fn prepend_parent_to_field_path_expr(
@@ -459,8 +460,8 @@ fn prepend_parent_to_field_path_expr(
 ) -> Option<Expression> {
     match field_path_expr {
         Expression::Identifier(id) => Some(Expression::Subpath(SubpathExpr {
-            expr: Box::new(Expression::Identifier(parent.to_string())),
-            subpath: id.clone(),
+            expr: Box::new(Expression::Identifier(parent.into())),
+            subpath: id.name.clone(),
         })),
         Expression::Subpath(expr) => Some(Expression::Subpath(SubpathExpr {
             expr: Box::new(prepend_parent_to_field_path_expr(
@@ -496,25 +497,25 @@ mod prepend_parent_to_field_path_expr_tests {
     test_prepend_parent_to_field_path_expr!(
         identifier,
         expected = Some(Expression::Subpath(SubpathExpr {
-            expr: Box::new(Expression::Identifier("a".to_string())),
+            expr: Box::new(Expression::Identifier("a".into())),
             subpath: "b".to_string(),
         })),
         input_parent = "a",
-        input_field_path_expr = Expression::Identifier("b".to_string()),
+        input_field_path_expr = Expression::Identifier("b".into()),
     );
 
     test_prepend_parent_to_field_path_expr!(
         subpath,
         expected = Some(Expression::Subpath(SubpathExpr {
             expr: Box::new(Expression::Subpath(SubpathExpr {
-                expr: Box::new(Expression::Identifier("a".to_string())),
+                expr: Box::new(Expression::Identifier("a".into())),
                 subpath: "b".to_string(),
             })),
             subpath: "c".to_string(),
         })),
         input_parent = "a",
         input_field_path_expr = Expression::Subpath(SubpathExpr {
-            expr: Box::new(Expression::Identifier("b".to_string())),
+            expr: Box::new(Expression::Identifier("b".into())),
             subpath: "c".to_string(),
         }),
     );
@@ -525,7 +526,7 @@ mod prepend_parent_to_field_path_expr_tests {
             expr: Box::new(Expression::Subpath(SubpathExpr {
                 expr: Box::new(Expression::Subpath(SubpathExpr {
                     expr: Box::new(Expression::Subpath(SubpathExpr {
-                        expr: Box::new(Expression::Identifier("a".to_string())),
+                        expr: Box::new(Expression::Identifier("a".into())),
                         subpath: "b".to_string(),
                     })),
                     subpath: "c".to_string(),
@@ -538,7 +539,7 @@ mod prepend_parent_to_field_path_expr_tests {
         input_field_path_expr = Expression::Subpath(SubpathExpr {
             expr: Box::new(Expression::Subpath(SubpathExpr {
                 expr: Box::new(Expression::Subpath(SubpathExpr {
-                    expr: Box::new(Expression::Identifier("b".to_string())),
+                    expr: Box::new(Expression::Identifier("b".into())),
                     subpath: "c".to_string(),
                 })),
                 subpath: "d".to_string(),

--- a/mongosql/src/ast/rewrites/order_by.rs
+++ b/mongosql/src/ast/rewrites/order_by.rs
@@ -62,7 +62,7 @@ impl PositionalSortKeyRewriteVisitor {
             Some(_) => Err(Error::NoAliasForSortKeyAtPosition(position)),
         };
         match alias {
-            Ok(alias) => SortKey::Simple(Expression::Identifier(alias.clone())),
+            Ok(alias) => SortKey::Simple(Expression::Identifier(alias.clone().into())),
             Err(err) => {
                 self.error = Some(err);
                 key

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1675,18 +1675,18 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
                     ast::UnaryExpr {
                         op: ast::UnaryOp::Not,
-                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                        expr: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::UnaryOp(ast::UnaryOp::Not)
                 )),
@@ -1705,18 +1705,18 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
                     ast::UnaryExpr {
                         op: ast::UnaryOp::Pos,
-                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                        expr: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::BinaryOp(ast::BinaryOp::Add)
                 )),
@@ -1729,18 +1729,18 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
                     ast::UnaryExpr {
                         op: ast::UnaryOp::Neg,
-                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                        expr: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::BinaryOp(ast::BinaryOp::Sub)
                 )),
@@ -1759,7 +1759,7 @@ mod higher_order_functions {
         }),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::BinaryOp(ast::BinaryOp::Mul)
                 )),
@@ -1776,12 +1776,12 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Function(
                     ast::FunctionExpr {
                         function: ast::FunctionName::Upper,
                         args: ast::FunctionArguments::Args(vec![ast::Expression::Identifier(
-                            "this".to_string()
+                            "this".into()
                         )]),
                         set_quantifier: None,
                     }
@@ -1790,7 +1790,7 @@ mod higher_order_functions {
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Map(ast::MapExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::Function(ast::FunctionName::Upper)
                 )),
@@ -1803,18 +1803,18 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
                     ast::UnaryExpr {
                         op: ast::UnaryOp::Not,
-                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                        expr: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::UnaryOp(ast::UnaryOp::Not)
                 )),
@@ -1832,18 +1832,18 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
                     ast::UnaryExpr {
                         op: ast::UnaryOp::Pos,
-                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                        expr: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::BinaryOp(ast::BinaryOp::Add)
                 )),
@@ -1856,18 +1856,18 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Unary(
                     ast::UnaryExpr {
                         op: ast::UnaryOp::Neg,
-                        expr: Box::new(ast::Expression::Identifier("this".to_string())),
+                        expr: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::BinaryOp(ast::BinaryOp::Sub)
                 )),
@@ -1885,7 +1885,7 @@ mod higher_order_functions {
         }),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::BinaryOp(ast::BinaryOp::Comparison(ast::ComparisonOp::Eq))
                 )),
@@ -1898,12 +1898,12 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Function(
                     ast::FunctionExpr {
                         function: ast::FunctionName::Coalesce,
                         args: ast::FunctionArguments::Args(vec![ast::Expression::Identifier(
-                            "this".to_string()
+                            "this".into()
                         )]),
                         set_quantifier: None,
                     }
@@ -1912,7 +1912,7 @@ mod higher_order_functions {
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Filter(ast::FilterExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::Function(ast::FunctionName::Coalesce)
                 )),
@@ -1930,7 +1930,7 @@ mod higher_order_functions {
         }),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::UnaryOp(ast::UnaryOp::Not)
@@ -1946,20 +1946,20 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
                         op: ast::BinaryOp::Add,
-                        left: Box::new(ast::Expression::Identifier("value".to_string())),
-                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier(("value", true).into())),
+                        right: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::UnaryOp(ast::UnaryOp::Pos)
@@ -1973,20 +1973,20 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
                         op: ast::BinaryOp::Sub,
-                        left: Box::new(ast::Expression::Identifier("value".to_string())),
-                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier(("value", true).into())),
+                        right: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::UnaryOp(ast::UnaryOp::Neg)
@@ -2000,20 +2000,20 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Binary(
                     ast::BinaryExpr {
                         op: ast::BinaryOp::Div,
-                        left: Box::new(ast::Expression::Identifier("value".to_string())),
-                        right: Box::new(ast::Expression::Identifier("this".to_string())),
+                        left: Box::new(ast::Expression::Identifier(("value", true).into())),
+                        right: Box::new(ast::Expression::Identifier("this".into())),
                     }
                 ))),
             })
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::BinaryOp(ast::BinaryOp::Div)
@@ -2027,14 +2027,14 @@ mod higher_order_functions {
         pass = HigherOrderFunctionsRewritePass,
         expected = Ok(make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
                 f: Box::new(ast::FunctionArgument::Expr(ast::Expression::Function(
                     ast::FunctionExpr {
                         function: ast::FunctionName::Pow,
                         args: ast::FunctionArguments::Args(vec![
-                            ast::Expression::Identifier("value".to_string()),
-                            ast::Expression::Identifier("this".to_string()),
+                            ast::Expression::Identifier(("value", true).into()),
+                            ast::Expression::Identifier("this".into()),
                         ]),
                         set_quantifier: None,
                     }
@@ -2043,7 +2043,7 @@ mod higher_order_functions {
         ))),
         input = make_select_query(ast::Expression::HigherOrderFunction(
             ast::HigherOrderFunctionExpr::Reduce(ast::ReduceExpr {
-                array: Box::new(ast::Expression::Identifier("a".to_string())),
+                array: Box::new(ast::Expression::Identifier("a".into())),
                 init_value: Box::new(ast::Expression::Literal(ast::Literal::Integer(0))),
                 f: Box::new(ast::FunctionArgument::NamedFunction(
                     ast::NamedFunction::Function(ast::FunctionName::Pow)

--- a/mongosql/src/ast/visitors/subpath_fields.rs
+++ b/mongosql/src/ast/visitors/subpath_fields.rs
@@ -23,7 +23,7 @@ impl SubpathFieldVisitor {
                 self.collect_subpath_entries(&subpath_expr.expr, entries);
                 entries.push(subpath_expr.subpath.clone());
             }
-            Expression::Identifier(ident) => {
+            Expression::Identifier(IdentifierExpr { name: ident, .. }) => {
                 entries.push(ident.clone());
             }
             _ => (),

--- a/mongosql/src/ast/visitors/test.rs
+++ b/mongosql/src/ast/visitors/test.rs
@@ -156,7 +156,7 @@ mod subpath_field_tests {
         expected = vec![vec!["a", "b"]],
         input = build_select_query!(SelectBody::Standard(vec![SelectExpression::Expression(
             OptionallyAliasedExpr::Unaliased(Subpath(SubpathExpr {
-                expr: Box::new(Identifier("a".to_string(),)),
+                expr: Box::new(Identifier("a".into(),)),
                 subpath: "b".to_string(),
             },),),
         ),])),
@@ -168,7 +168,7 @@ mod subpath_field_tests {
         input = build_select_query!(SelectBody::Standard(vec![SelectExpression::Expression(
             OptionallyAliasedExpr::Unaliased(Subpath(SubpathExpr {
                 expr: Box::new(Subpath(SubpathExpr {
-                    expr: Box::new(Identifier("a".to_string(),)),
+                    expr: Box::new(Identifier("a".into(),)),
                     subpath: "b".to_string(),
                 },)),
                 subpath: "c".to_string(),
@@ -184,7 +184,7 @@ mod subpath_field_tests {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
                     OptionallyAliasedExpr::Unaliased(Subpath(SubpathExpr {
-                        expr: Box::new(Identifier("a".to_string(),)),
+                        expr: Box::new(Identifier("a".into(),)),
                         subpath: "b".to_string(),
                     },),),
                 ),]),
@@ -203,12 +203,12 @@ mod subpath_field_tests {
                 },)),
                 condition: Some(Binary(BinaryExpr {
                     left: Box::from(Subpath(SubpathExpr {
-                        expr: Box::new(Identifier("c".to_string(),)),
+                        expr: Box::new(Identifier("c".into(),)),
                         subpath: "d".to_string(),
                     },)),
                     op: BinaryOp::Comparison(ComparisonOp::Eq,),
                     right: Box::from(Subpath(SubpathExpr {
-                        expr: Box::new(Identifier("e".to_string(),)),
+                        expr: Box::new(Identifier("e".into(),)),
                         subpath: "f".to_string(),
                     },)),
                 },),),

--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -2263,6 +2263,37 @@ trait HigherOrderFunction: SqlFunction {
             error: Box::new(error),
         }
     }
+
+    /// Validate that the given array expression satisfies ANY_ARRAY_OR_NULLISH. Return the array
+    /// schema and return its item schema.
+    fn validate_array_and_get_item_schema(
+        &self,
+        state: &SchemaInferenceState,
+        array: &Expression,
+    ) -> Result<(Schema, Schema), Error> {
+        // The first argument must satisfy ANY_ARRAY_OR_NULLISH.
+        let array_schema = array.schema(state)?;
+        if !state.check_satisfies(&array_schema, &ANY_ARRAY_OR_NULLISH) {
+            return Err(Error::SchemaChecking {
+                name: self.as_str(),
+                required: ANY_ARRAY_OR_NULLISH.clone().into(),
+                found: array_schema.into(),
+                var_cause: array.as_var_cause(),
+            });
+        }
+
+        // At this point, we know the schema satisfies ANY_ARRAY_OR_NULLISH. In STRICT mode, that
+        // means the schema must be exactly NULLISH if there is no array item schema. In RELAXED
+        // mode, technically there may be other non-array/non-nullish schemas, but those will cause
+        // runtime errors (which users tolerate in RELAXED mode). Therefore, we use Missing as the
+        // default schema for "this" if the array item schema is None since we know the `array` arg
+        // is never an array.
+        let array_item_schema = array_schema
+            .get_array_item_schema()
+            .unwrap_or(Schema::Missing);
+
+        Ok((array_schema, array_item_schema))
+    }
 }
 
 impl HigherOrderFunctionApplication {
@@ -2283,26 +2314,8 @@ impl SqlFunction for MapExpr {
 
 impl HigherOrderFunction for MapExpr {
     fn schema(&self, state: &SchemaInferenceState) -> Result<Schema, Error> {
-        // The first argument must satisfy ANY_ARRAY_OR_NULLISH.
-        let array_schema = self.array.schema(state)?;
-        if !state.check_satisfies(&array_schema, &ANY_ARRAY_OR_NULLISH) {
-            return Err(Error::SchemaChecking {
-                name: self.as_str(),
-                required: ANY_ARRAY_OR_NULLISH.clone().into(),
-                found: array_schema.into(),
-                var_cause: self.array.as_var_cause(),
-            });
-        }
-
-        let Some(array_item_schema) = array_schema.get_array_item_schema() else {
-            // At this point, we know the schema satisfies ANY_ARRAY_OR_NULLISH. In STRICT
-            // mode, that means the schema must be exactly NULLISH if there is no array item
-            // schema. In RELAXED mode, technically there may be other non-array/non-nullish
-            // schemas, but those would cause runtime errors. Therefore, we can just return
-            // Null as the expression schema at this point since we know the `array` arg is
-            // never an array.
-            return Ok(Schema::Atomic(Atomic::Null));
-        };
+        let (array_schema, array_item_schema) =
+            self.validate_array_and_get_item_schema(state, self.array.as_ref())?;
 
         // Add the array item schema to the SchemaInferenceState as a variable using the
         // name `this`.
@@ -2334,26 +2347,8 @@ impl SqlFunction for FilterExpr {
 
 impl HigherOrderFunction for FilterExpr {
     fn schema(&self, state: &SchemaInferenceState) -> Result<Schema, Error> {
-        // The first argument must satisfy ANY_ARRAY_OR_NULLISH.
-        let array_schema = self.array.schema(state)?;
-        if !state.check_satisfies(&array_schema, &ANY_ARRAY_OR_NULLISH) {
-            return Err(Error::SchemaChecking {
-                name: self.as_str(),
-                required: ANY_ARRAY_OR_NULLISH.clone().into(),
-                found: array_schema.into(),
-                var_cause: self.array.as_var_cause(),
-            });
-        }
-
-        let Some(array_item_schema) = array_schema.get_array_item_schema() else {
-            // At this point, we know the schema satisfies ANY_ARRAY_OR_NULLISH. In STRICT
-            // mode, that means the schema must be exactly NULLISH if there is no array item
-            // schema. In RELAXED mode, technically there may be other non-array/non-nullish
-            // schemas, but those would cause runtime errors. Therefore, we can just return
-            // Null as the expression schema at this point since we know the `array` arg is
-            // never an array.
-            return Ok(Schema::Atomic(Atomic::Null));
-        };
+        let (array_schema, array_item_schema) =
+            self.validate_array_and_get_item_schema(state, self.array.as_ref())?;
 
         // Add the array item schema to the SchemaInferenceState as a variable using the
         // name `this`.
@@ -2391,26 +2386,8 @@ impl SqlFunction for ReduceExpr {
 
 impl HigherOrderFunction for ReduceExpr {
     fn schema(&self, state: &SchemaInferenceState) -> Result<Schema, Error> {
-        // The first argument must satisfy ANY_ARRAY_OR_NULLISH.
-        let array_schema = self.array.schema(state)?;
-        if !state.check_satisfies(&array_schema, &ANY_ARRAY_OR_NULLISH) {
-            return Err(Error::SchemaChecking {
-                name: self.as_str(),
-                required: ANY_ARRAY_OR_NULLISH.clone().into(),
-                found: array_schema.into(),
-                var_cause: self.array.as_var_cause(),
-            });
-        }
-
-        let Some(array_item_schema) = array_schema.get_array_item_schema() else {
-            // At this point, we know the schema satisfies ANY_ARRAY_OR_NULLISH. In STRICT
-            // mode, that means the schema must be exactly NULLISH if there is no array item
-            // schema. In RELAXED mode, technically there may be other non-array/non-nullish
-            // schemas, but those would cause runtime errors. Therefore, we can just return
-            // Null as the expression schema at this point since we know the `array` arg is
-            // never an array.
-            return Ok(Schema::Atomic(Atomic::Null));
-        };
+        let (array_schema, array_item_schema) =
+            self.validate_array_and_get_item_schema(state, self.array.as_ref())?;
 
         // Get the initial value schema. If it is invalid, indicate that an invalid initial value
         // expression was provided.

--- a/mongosql/src/parser/mongosql.lalrpop
+++ b/mongosql/src/parser/mongosql.lalrpop
@@ -27,7 +27,7 @@ WithQuery: Query = {
 
 NamedQuery: NamedQuery = {
   <i:Identifier> AS LEFT_PAREN <q:SimpleQuery> RIGHT_PAREN => NamedQuery {
-    name: i,
+    name: i.name,
     query: q,
   }
 }
@@ -113,24 +113,24 @@ UnwindDatasource: Datasource = {
 UnwindOption: ExtendedUnwindOption = {
   PATH ARROW <p:PeriodPlus<UnwindPathPart>> => ExtendedUnwindOption::Paths(vec![p]),
   PATH ARROW LEFT_PAREN <p:CommaPlus<PeriodPlus<UnwindPathPart>>> RIGHT_PAREN => ExtendedUnwindOption::Paths(p),
-  INDEX ARROW <i:Identifier> => ExtendedUnwindOption::Index(i),
+  INDEX ARROW <i:Identifier> => ExtendedUnwindOption::Index(i.name),
   OUTER ARROW <o:Boolean> => ExtendedUnwindOption::Outer(o)
 }
 
 // Only INDEX and OUTER are allowed on a PATH part. Putting a PATH in a PATH part
 // would be confusing
 UnwindPathPartOption: UnwindPathPartOption = {
-  INDEX ARROW <i:Identifier> => UnwindPathPartOption::Index(i),
+  INDEX ARROW <i:Identifier> => UnwindPathPartOption::Index(i.name),
   OUTER ARROW <o:Boolean> => UnwindPathPartOption::Outer(o)
 }
 
 UnwindPathPart: UnwindPathPart = {
     <i:Identifier> => UnwindPathPart {
-        field: i, 
+        field: i.name,
         options: Vec::default(),
     },
     <i:Identifier> <o:BracketList<CommaStar<UnwindPathPartOption>>> => UnwindPathPart {
-        field: i, 
+        field: i.name,
         options: o,
     }
 }
@@ -224,18 +224,18 @@ SelectExpression: SelectExpression = {
 OptionallyAliasedExpr: OptionallyAliasedExpr = {
   <e:Expression> <a:(AS? <Identifier>)?> => {
         match a {
-            Some(alias) => OptionallyAliasedExpr::Aliased(AliasedExpr{expr:e, alias}),
+            Some(alias) => OptionallyAliasedExpr::Aliased(AliasedExpr{expr:e, alias: alias.name}),
             None => OptionallyAliasedExpr::Unaliased(e),
         }
   }
 }
 
 AliasedExpr: AliasedExpr = {
-  <e:Expression> <a:(AS? <Identifier>)> => AliasedExpr{expr:e, alias:a}
+  <e:Expression> <a:(AS? <Identifier>)> => AliasedExpr{expr:e, alias:a.name}
 };
 
 SubstarExpr: SubstarExpr = {
-  <i:Identifier> DOT_STAR => SubstarExpr{datasource: i}
+  <i:Identifier> DOT_STAR => SubstarExpr{datasource: i.name}
 };
 
 pub Expression: Expression = {
@@ -427,7 +427,7 @@ FunctionArgument: FunctionArgument = {
     <e:Expression> => {
         // Check if this is a bare identifier that could be a function name
         match &e {
-            Expression::Identifier(id) => {
+            Expression::Identifier(IdentifierExpr { name: id, is_delimited: false }) => {
                 match FunctionName::try_from(id.as_str()) {
                     Ok(f) => FunctionArgument::NamedFunction(NamedFunction::Function(f)),
                     Err(_) => FunctionArgument::Expr(e),
@@ -483,10 +483,10 @@ AccessExpr: AccessExpr = {
   <e:Tier13Expr> LEFT_BRACKET <s:Expression> RIGHT_BRACKET => AccessExpr{expr:e, subfield:Box::new(s)},
 }
 
-Identifier: String = {
-  ID => <>.to_string(),
-  DELIMITED_IDENT_QUOTE => process_delimited_ident(<>),
-  DELIMITED_IDENT_BACKTICK => process_delimited_ident(<>),
+Identifier: IdentifierExpr = {
+  ID => (<>.to_string(), false).into(),
+  DELIMITED_IDENT_QUOTE => (process_delimited_ident(<>), true).into(),
+  DELIMITED_IDENT_BACKTICK => (process_delimited_ident(<>), true).into(),
 };
 
 // A tuple is a grouping of >= 1 elements, like (A), (A,B), (A,B,C), etc.
@@ -558,7 +558,7 @@ BetweenTier<Expr, NextTier>: Box<Expression> = {
 }
 
 SubpathTier<Expr, NextTier>: Box<Expression> = {
-  <expr:SubpathTier<Expr, NextTier>> DOT <subpath:Identifier> => Box::new(Expression::Subpath(SubpathExpr{<>})),
+  <expr:SubpathTier<Expr, NextTier>> DOT <subpath:Identifier> => Box::new(Expression::Subpath(SubpathExpr{expr, subpath: subpath.name})),
   NextTier
 };
 

--- a/mongosql/src/parser/mongosql.lalrpop
+++ b/mongosql/src/parser/mongosql.lalrpop
@@ -403,11 +403,24 @@ Substring: FunctionExpr = {
 }
 
 HigherOrderFunctionExpr: HigherOrderFunctionExpr = {
-    MAP LEFT_PAREN <e1:Expression> COMMA <e2:FunctionArgument> RIGHT_PAREN =>? {
-        Ok(HigherOrderFunctionExpr::Map(MapExpr {
+    MAP LEFT_PAREN <e1:Expression> COMMA <e2:FunctionArgument> RIGHT_PAREN => {
+        HigherOrderFunctionExpr::Map(MapExpr {
             array: Box::new(e1),
             f: Box::new(e2),
-        }))
+        })
+    },
+    FILTER LEFT_PAREN <e1:Expression> COMMA <e2:FunctionArgument> RIGHT_PAREN => {
+        HigherOrderFunctionExpr::Filter(FilterExpr {
+            array: Box::new(e1),
+            f: Box::new(e2),
+        })
+    },
+    REDUCE LEFT_PAREN <e1:Expression> COMMA <e2:Expression> COMMA <e3:FunctionArgument> RIGHT_PAREN => {
+        HigherOrderFunctionExpr::Reduce(ReduceExpr {
+            array: Box::new(e1),
+            init_value: Box::new(e2),
+            f: Box::new(e3),
+        })
     },
 }
 
@@ -902,6 +915,7 @@ match {
   r"(?i)extract" => EXTRACT,
   r"(?i)false" => FALSE,
   r"(?i)fetch\s+(first|next)" => FETCH_FIRST,
+  r"(?i)filter" => FILTER,
   r"(?i)flatten" => FLATTEN,
   r"(?i)float" => FLOAT,
   r"(?i)for" => FOR,
@@ -943,6 +957,7 @@ match {
   r"(?i)position" => POSITION,
   r"(?i)precision" => PRECISION,
   r"(?i)real" => REAL,
+  r"(?i)reduce" => REDUCE,
   r"(?i)regex" => REGEX,
   r"(?i)right" => RIGHT,
   r"(?i)rows?\s+only" => ROWS_ONLY,

--- a/mongosql/src/parser/mongosql.lalrpop
+++ b/mongosql/src/parser/mongosql.lalrpop
@@ -402,6 +402,42 @@ Substring: FunctionExpr = {
     }
 }
 
+HigherOrderFunctionExpr: HigherOrderFunctionExpr = {
+    MAP LEFT_PAREN <e1:Expression> COMMA <e2:FunctionArgument> RIGHT_PAREN =>? {
+        Ok(HigherOrderFunctionExpr::Map(MapExpr {
+            array: Box::new(e1),
+            f: Box::new(e2),
+        }))
+    },
+}
+
+FunctionArgument: FunctionArgument = {
+    ADD => {
+        FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Pos))
+    },
+    SUB => {
+        FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Neg))
+    },
+    NOT => {
+        FunctionArgument::NamedFunction(NamedFunction::UnaryOp(UnaryOp::Not))
+    },
+    <b:NonOverloadedBinaryOp> => {
+        FunctionArgument::NamedFunction(NamedFunction::BinaryOp(b))
+    },
+    <e:Expression> => {
+        // Check if this is a bare identifier that could be a function name
+        match &e {
+            Expression::Identifier(id) => {
+                match FunctionName::try_from(id.as_str()) {
+                    Ok(f) => FunctionArgument::NamedFunction(NamedFunction::Function(f)),
+                    Err(_) => FunctionArgument::Expr(e),
+                }
+            },
+            _ => FunctionArgument::Expr(e),
+        }
+    },
+}
+
 TrimSpec: TrimSpec = {
   LEADING => TrimSpec::Leading,
   TRAILING => TrimSpec::Trailing,
@@ -569,6 +605,7 @@ BottomExpr: Box<Expression> = {
   Trim => Box::new(Expression::Trim(<>)),
   Extract => Box::new(Expression::Extract(<>)),
   FunctionExpr => Box::new(Expression::Function(<>)),
+  HigherOrderFunctionExpr => Box::new(Expression::HigherOrderFunction(<>)),
   Identifier => Box::new(Expression::Identifier(<>)),
   Literal => Box::new(Expression::Literal(<>)),
   StringConstructor => Box::new(Expression::StringConstructor(<>)),
@@ -619,6 +656,13 @@ MulOp: BinaryOp = {
   STAR => BinaryOp::Mul,
   DIV => BinaryOp::Div,
 };
+
+NonOverloadedBinaryOp: BinaryOp = {
+  InOp,
+  BoolOp,
+  ConcatOp,
+  MulOp,
+}
 
 NotOp: UnaryOp = {
   NOT => UnaryOp::Not
@@ -878,6 +922,7 @@ match {
   r"(?i)left" => LEFT,
   r"(?i)limit" => LIMIT,
   r"(?i)long" => LONG,
+  r"(?i)map" => MAP,
   r"(?i)maxkey" => MAXKEY,
   r"(?i)minkey" => MINKEY,
   r"(?i)missing" => MISSING,

--- a/mongosql/src/parser/test.rs
+++ b/mongosql/src/parser/test.rs
@@ -3660,106 +3660,108 @@ mod unrecognized_token_suggestion {
 }
 
 mod higher_order_functions {
-    use crate::ast::*;
+    mod map {
+        use crate::ast::*;
 
-    parsable!(
-        map_with_expr_function_arg,
-        expected = true,
-        input = "SELECT MAP([1, 2, 3], this + 1)"
-    );
+        parsable!(
+            with_expr_function_arg,
+            expected = true,
+            input = "SELECT MAP([1, 2, 3], this + 1)"
+        );
 
-    parsable!(
-        map_with_named_function_unary_op_arg,
-        expected = true,
-        input = "SELECT MAP(a, not)"
-    );
+        parsable!(
+            with_named_function_unary_op_arg,
+            expected = true,
+            input = "SELECT MAP(a, not)"
+        );
 
-    parsable!(
-        map_with_named_function_binray_op_arg,
-        expected = true,
-        input = "SELECT MAP(a, *)"
-    );
+        parsable!(
+            with_named_function_binray_op_arg,
+            expected = true,
+            input = "SELECT MAP(a, *)"
+        );
 
-    parsable!(
-        map_with_named_function_function_arg,
-        expected = true,
-        input = "SELECT MAP(a, LOWER)"
-    );
+        parsable!(
+            with_named_function_function_arg,
+            expected = true,
+            input = "SELECT MAP(a, LOWER)"
+        );
 
-    validate_ast!(
-        map_with_expr_function_arg_ast,
-        method = parse_expression,
-        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".into())),
-            f: Box::new(FunctionArgument::Expr(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("this".into())),
-                op: BinaryOp::Mul,
-                right: Box::new(Expression::Identifier("this".into())),
-            }))),
-        })),
-        input = "map(a, this * this)",
-    );
+        validate_ast!(
+            with_expr_function_arg_ast,
+            method = parse_expression,
+            expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+                array: Box::new(Expression::Identifier("a".into())),
+                f: Box::new(FunctionArgument::Expr(Expression::Binary(BinaryExpr {
+                    left: Box::new(Expression::Identifier("this".into())),
+                    op: BinaryOp::Mul,
+                    right: Box::new(Expression::Identifier("this".into())),
+                }))),
+            })),
+            input = "map(a, this * this)",
+        );
 
-    // Note that the parser defaults to UnaryOp::Pos for `+`.
-    validate_ast!(
-        map_with_named_function_pos_unary_op_arg_ast,
-        method = parse_expression,
-        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".into())),
-            f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
-                UnaryOp::Pos
-            ))),
-        })),
-        input = "map(a, +)",
-    );
+        // Note that the parser defaults to UnaryOp::Pos for `+`.
+        validate_ast!(
+            with_named_function_pos_unary_op_arg_ast,
+            method = parse_expression,
+            expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+                array: Box::new(Expression::Identifier("a".into())),
+                f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
+                    UnaryOp::Pos
+                ))),
+            })),
+            input = "map(a, +)",
+        );
 
-    // Note that the parser defaults to UnaryOp::Neg for `-`.
-    validate_ast!(
-        map_with_named_function_neg_unary_op_arg_ast,
-        method = parse_expression,
-        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".into())),
-            f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
-                UnaryOp::Neg
-            ))),
-        })),
-        input = "map(a, -)",
-    );
+        // Note that the parser defaults to UnaryOp::Neg for `-`.
+        validate_ast!(
+            with_named_function_neg_unary_op_arg_ast,
+            method = parse_expression,
+            expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+                array: Box::new(Expression::Identifier("a".into())),
+                f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
+                    UnaryOp::Neg
+                ))),
+            })),
+            input = "map(a, -)",
+        );
 
-    validate_ast!(
-        map_with_named_function_binary_op_arg_ast,
-        method = parse_expression,
-        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".into())),
-            f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
-                BinaryOp::Div
-            ))),
-        })),
-        input = "map(a, /)",
-    );
+        validate_ast!(
+            with_named_function_binary_op_arg_ast,
+            method = parse_expression,
+            expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+                array: Box::new(Expression::Identifier("a".into())),
+                f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                    BinaryOp::Div
+                ))),
+            })),
+            input = "map(a, /)",
+        );
 
-    validate_ast!(
-        map_with_named_function_function_arg_ast,
-        method = parse_expression,
-        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".into())),
-            f: Box::new(FunctionArgument::NamedFunction(NamedFunction::Function(
-                FunctionName::Log10
-            ))),
-        })),
-        input = "map(a, LOG10)",
-    );
+        validate_ast!(
+            with_named_function_function_arg_ast,
+            method = parse_expression,
+            expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+                array: Box::new(Expression::Identifier("a".into())),
+                f: Box::new(FunctionArgument::NamedFunction(NamedFunction::Function(
+                    FunctionName::Log10
+                ))),
+            })),
+            input = "map(a, LOG10)",
+        );
 
-    // Note that if a function name is delimited, it is parsed as an Identifier.
-    validate_ast!(
-        map_with_delimited_named_function_function_arg_ast,
-        method = parse_expression,
-        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".into())),
-            f: Box::new(FunctionArgument::Expr(Expression::Identifier(
-                ("LOG", true).into()
-            ))),
-        })),
-        input = "map(a, `LOG`)",
-    );
+        // Note that if a function name is delimited, it is parsed as an Identifier.
+        validate_ast!(
+            with_delimited_named_function_function_arg_ast,
+            method = parse_expression,
+            expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+                array: Box::new(Expression::Identifier("a".into())),
+                f: Box::new(FunctionArgument::Expr(Expression::Identifier(
+                    ("LOG", true).into()
+                ))),
+            })),
+            input = "map(a, `LOG`)",
+        );
+    }
 }

--- a/mongosql/src/parser/test.rs
+++ b/mongosql/src/parser/test.rs
@@ -3660,8 +3660,10 @@ mod unrecognized_token_suggestion {
 }
 
 mod higher_order_functions {
+    use crate::ast::*;
+
     mod map {
-        use crate::ast::*;
+        use super::*;
 
         parsable!(
             with_expr_function_arg,
@@ -3762,6 +3764,239 @@ mod higher_order_functions {
                 ))),
             })),
             input = "map(a, `LOG`)",
+        );
+    }
+
+    mod filter {
+        use super::*;
+
+        parsable!(
+            with_expr_function_arg,
+            expected = true,
+            input = "SELECT FILTER([1, 2, 3], this > 1)"
+        );
+
+        parsable!(
+            with_named_function_unary_op_arg,
+            expected = true,
+            input = "SELECT FILTER(a, not)"
+        );
+
+        parsable!(
+            with_named_function_binray_op_arg,
+            expected = true,
+            input = "SELECT FILTER(a, =)"
+        );
+
+        parsable!(
+            with_named_function_function_arg,
+            expected = true,
+            input = "SELECT FILTER(a, COALESCE)"
+        );
+
+        validate_ast!(
+            with_expr_function_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Filter(FilterExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    f: Box::new(FunctionArgument::Expr(Expression::Binary(BinaryExpr {
+                        left: Box::new(Expression::Identifier("this".into())),
+                        op: BinaryOp::Comparison(ComparisonOp::Eq),
+                        right: Box::new(Expression::Identifier("this".into())),
+                    }))),
+                })),
+            input = "filter(a, this = this)",
+        );
+
+        // Note that the parser defaults to UnaryOp::Pos for `+`.
+        // This test is semantically invalid since Filter expects a (nullable) boolean value, but
+        // we still want to ensure it parses as expected since it is syntactically valid.
+        validate_ast!(
+            with_named_function_pos_unary_op_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Filter(FilterExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
+                        UnaryOp::Pos
+                    ))),
+                })),
+            input = "filter(a, +)",
+        );
+
+        // Note that the parser defaults to UnaryOp::Neg for `-`.
+        validate_ast!(
+            with_named_function_neg_unary_op_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Filter(FilterExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
+                        UnaryOp::Neg
+                    ))),
+                })),
+            input = "Filter(a, -)",
+        );
+
+        validate_ast!(
+            with_named_function_binary_op_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Filter(FilterExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                        BinaryOp::Div
+                    ))),
+                })),
+            input = "filter(a, /)",
+        );
+
+        validate_ast!(
+            with_named_function_function_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Filter(FilterExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    f: Box::new(FunctionArgument::NamedFunction(NamedFunction::Function(
+                        FunctionName::Round
+                    ))),
+                })),
+            input = "Filter(a, Round)",
+        );
+
+        // Note that if a function name is delimited, it is parsed as an Identifier.
+        validate_ast!(
+            with_delimited_named_function_function_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Filter(FilterExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    f: Box::new(FunctionArgument::Expr(Expression::Identifier(
+                        ("POW", true).into()
+                    ))),
+                })),
+            input = "filter(a, `POW`)",
+        );
+    }
+
+    mod reduce {
+        use super::*;
+
+        parsable!(
+            with_expr_function_arg,
+            expected = true,
+            input = "SELECT REDUCE([1, 2, 3], 0, this + `value`)"
+        );
+
+        parsable!(
+            with_named_function_unary_op_arg,
+            expected = true,
+            input = "SELECT REDUCE(a, b, not)"
+        );
+
+        parsable!(
+            with_named_function_binray_op_arg,
+            expected = true,
+            input = "SELECT REDUCE(a, b + 1, *)"
+        );
+
+        parsable!(
+            with_named_function_function_arg,
+            expected = true,
+            input = "SELECT REDUCE(a, 1, POW)"
+        );
+
+        validate_ast!(
+            with_expr_function_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    init_value: Box::new(Expression::Identifier("b".into())),
+                    f: Box::new(FunctionArgument::Expr(Expression::Binary(BinaryExpr {
+                        // Note that value is a keyword, so it is delimited in the input and
+                        // therefore delimiting is expected in the ast.
+                        left: Box::new(Expression::Identifier(("value", true).into())),
+                        op: BinaryOp::Div,
+                        right: Box::new(Expression::Identifier("this".into())),
+                    }))),
+                })),
+            input = "Reduce(a, b, `value` / this)",
+        );
+
+        // Note that the parser defaults to UnaryOp::Pos for `+`. At rewrite time, this is changed
+        // to BinaryOp::Add.
+        validate_ast!(
+            with_named_function_pos_unary_op_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    init_value: Box::new(Expression::Identifier("b".into())),
+                    f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
+                        UnaryOp::Pos
+                    ))),
+                })),
+            input = "reduce(a, b, +)",
+        );
+
+        // Note that the parser defaults to UnaryOp::Neg for `-`.
+        validate_ast!(
+            with_named_function_neg_unary_op_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    init_value: Box::new(Expression::Literal(Literal::Integer(0))),
+                    f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
+                        UnaryOp::Neg
+                    ))),
+                })),
+            input = "Reduce(a, 0, -)",
+        );
+
+        validate_ast!(
+            with_named_function_binary_op_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    init_value: Box::new(Expression::Literal(Literal::Integer(1))),
+                    f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                        BinaryOp::Mul
+                    ))),
+                })),
+            input = "reduce(a, 1, *)",
+        );
+
+        validate_ast!(
+            with_named_function_function_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    init_value: Box::new(Expression::Literal(Literal::Integer(1))),
+                    f: Box::new(FunctionArgument::NamedFunction(NamedFunction::Function(
+                        FunctionName::Log
+                    ))),
+                })),
+            input = "reduce(a, 1, LOG)",
+        );
+
+        // Note that if a function name is delimited, it is parsed as an Identifier.
+        validate_ast!(
+            with_delimited_named_function_function_arg_ast,
+            method = parse_expression,
+            expected =
+                Expression::HigherOrderFunction(HigherOrderFunctionExpr::Reduce(ReduceExpr {
+                    array: Box::new(Expression::Identifier("a".into())),
+                    init_value: Box::new(Expression::Identifier("b".into())),
+                    f: Box::new(FunctionArgument::Expr(Expression::Identifier(
+                        ("FLOOR", true).into()
+                    ))),
+                })),
+            input = "reduce(a, b, `FLOOR`)",
         );
     }
 }

--- a/mongosql/src/parser/test.rs
+++ b/mongosql/src/parser/test.rs
@@ -198,7 +198,7 @@ mod select {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".to_string()))
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".into()))
                 )])
             },
             from_clause: None,
@@ -218,7 +218,7 @@ mod select {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier(("foo", true).into()),)
                 )])
             },
             from_clause: None,
@@ -238,7 +238,7 @@ mod select {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier(("foo", true).into()),)
                 )])
             },
             from_clause: None,
@@ -258,7 +258,9 @@ mod select {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("1 + 2".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier(
+                        ("1 + 2", true).into()
+                    ),)
                 )])
             },
             from_clause: None,
@@ -278,7 +280,9 @@ mod select {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("fo`o``".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier(
+                        ("fo`o``", true).into()
+                    ),)
                 )])
             },
             from_clause: None,
@@ -299,7 +303,7 @@ mod select {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
                     OptionallyAliasedExpr::Unaliased(Expression::Identifier(
-                        r#"fo"o"""#.to_string()
+                        (r#"fo"o"""#, true).into()
                     ),)
                 )])
             },
@@ -321,7 +325,7 @@ mod select {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
                     OptionallyAliasedExpr::Unaliased(Expression::Identifier(
-                        r#"fo""o"#.to_string()
+                        (r#"fo""o"#, true).into()
                     ),)
                 )])
             },
@@ -342,7 +346,9 @@ mod select {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("fo``o".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier(
+                        ("fo``o", true).into()
+                    ))
                 )])
             },
             from_clause: None,
@@ -399,9 +405,7 @@ mod query {
                     select_clause: SelectClause {
                         set_quantifier: SetQuantifier::All,
                         body: SelectBody::Standard(vec![SelectExpression::Expression(
-                            OptionallyAliasedExpr::Unaliased(Expression::Identifier(
-                                "a".to_string()
-                            ),)
+                            OptionallyAliasedExpr::Unaliased(Expression::Identifier("a".into()))
                         )])
                     },
                     from_clause: None,
@@ -417,9 +421,7 @@ mod query {
                     select_clause: SelectClause {
                         set_quantifier: SetQuantifier::All,
                         body: SelectBody::Standard(vec![SelectExpression::Expression(
-                            OptionallyAliasedExpr::Unaliased(Expression::Identifier(
-                                "b".to_string()
-                            ),)
+                            OptionallyAliasedExpr::Unaliased(Expression::Identifier("b".into()))
                         )])
                     },
                     from_clause: None,
@@ -436,7 +438,7 @@ mod query {
                 select_clause: SelectClause {
                     set_quantifier: SetQuantifier::All,
                     body: SelectBody::Standard(vec![SelectExpression::Expression(
-                        OptionallyAliasedExpr::Unaliased(Expression::Identifier("c".to_string()),)
+                        OptionallyAliasedExpr::Unaliased(Expression::Identifier("c".into()))
                     )])
                 },
                 from_clause: None,
@@ -604,7 +606,7 @@ mod operator {
         is_missing_ast,
         method = parse_expression,
         expected = Expression::Is(IsExpr {
-            expr: Box::new(Expression::Identifier("a".to_string())),
+            expr: Box::new(Expression::Identifier("a".into())),
             target_type: TypeOrMissing::Missing,
         }),
         input = "a IS MISSING",
@@ -650,9 +652,9 @@ mod operator {
         between_ast,
         method = parse_expression,
         expected = Expression::Between(BetweenExpr {
-            arg: Box::new(Expression::Identifier("a".to_string())),
-            min: Box::new(Expression::Identifier("b".to_string())),
-            max: Box::new(Expression::Identifier("c".to_string())),
+            arg: Box::new(Expression::Identifier("a".into())),
+            min: Box::new(Expression::Identifier("b".into())),
+            max: Box::new(Expression::Identifier("c".into())),
         }),
         input = "a between b and c",
     );
@@ -663,9 +665,9 @@ mod operator {
         expected = Expression::Unary(UnaryExpr {
             op: UnaryOp::Not,
             expr: Box::new(Expression::Between(BetweenExpr {
-                arg: Box::new(Expression::Identifier("a".to_string())),
-                min: Box::new(Expression::Identifier("b".to_string())),
-                max: Box::new(Expression::Identifier("c".to_string())),
+                arg: Box::new(Expression::Identifier("a".into())),
+                min: Box::new(Expression::Identifier("b".into())),
+                max: Box::new(Expression::Identifier("c".into())),
             }))
         }),
         input = "a not between b and c",
@@ -679,22 +681,22 @@ mod operator {
             when_branch: vec![
                 WhenBranch {
                     when: Box::new(Expression::Binary(BinaryExpr {
-                        left: Box::new(Expression::Identifier("a".to_string())),
+                        left: Box::new(Expression::Identifier("a".into())),
                         op: BinaryOp::Comparison(ComparisonOp::Eq),
-                        right: Box::new(Expression::Identifier("b".to_string()))
+                        right: Box::new(Expression::Identifier("b".into()))
                     })),
-                    then: Box::new(Expression::Identifier("a".to_string()))
+                    then: Box::new(Expression::Identifier("a".into()))
                 },
                 WhenBranch {
                     when: Box::new(Expression::Binary(BinaryExpr {
-                        left: Box::new(Expression::Identifier("c".to_string())),
+                        left: Box::new(Expression::Identifier("c".into())),
                         op: BinaryOp::Comparison(ComparisonOp::Eq),
-                        right: Box::new(Expression::Identifier("d".to_string()))
+                        right: Box::new(Expression::Identifier("d".into()))
                     })),
-                    then: Box::new(Expression::Identifier("c".to_string()))
+                    then: Box::new(Expression::Identifier("c".into()))
                 }
             ],
-            else_branch: Some(Box::new(Expression::Identifier("e".to_string())))
+            else_branch: Some(Box::new(Expression::Identifier("e".into())))
         }),
         input = "case when a=b then a when c=d then c else e end",
     );
@@ -703,16 +705,16 @@ mod operator {
         case_multiple_exprs_ast,
         method = parse_expression,
         expected = Expression::Case(CaseExpr {
-            expr: Some(Box::new(Expression::Identifier("a".to_string()))),
+            expr: Some(Box::new(Expression::Identifier("a".into()))),
             when_branch: vec![WhenBranch {
                 when: Box::new(Expression::Binary(BinaryExpr {
-                    left: Box::new(Expression::Identifier("a".to_string())),
+                    left: Box::new(Expression::Identifier("a".into())),
                     op: BinaryOp::Comparison(ComparisonOp::Eq),
-                    right: Box::new(Expression::Identifier("b".to_string()))
+                    right: Box::new(Expression::Identifier("b".into()))
                 })),
-                then: Box::new(Expression::Identifier("a".to_string()))
+                then: Box::new(Expression::Identifier("a".into()))
             }],
-            else_branch: Some(Box::new(Expression::Identifier("c".to_string())))
+            else_branch: Some(Box::new(Expression::Identifier("c".into())))
         }),
         input = "case a when a=b then a else c end",
     );
@@ -726,12 +728,12 @@ mod operator_precedence {
         method = parse_expression,
         expected = Expression::Between(BetweenExpr {
             arg: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("a".to_string())),
+                left: Box::new(Expression::Identifier("a".into())),
                 op: BinaryOp::Comparison(ComparisonOp::Eq),
-                right: Box::new(Expression::Identifier("b".to_string()))
+                right: Box::new(Expression::Identifier("b".into()))
             })),
-            min: Box::new(Expression::Identifier("c".to_string())),
-            max: Box::new(Expression::Identifier("d".to_string()))
+            min: Box::new(Expression::Identifier("c".into())),
+            max: Box::new(Expression::Identifier("d".into()))
         }),
         input = "a = b BETWEEN c AND d",
     );
@@ -741,14 +743,14 @@ mod operator_precedence {
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
             left: Box::new(Expression::Between(BetweenExpr {
-                arg: Box::new(Expression::Identifier("a".to_string())),
-                min: Box::new(Expression::Identifier("b".to_string())),
-                max: Box::new(Expression::Identifier("c".to_string()))
+                arg: Box::new(Expression::Identifier("a".into())),
+                min: Box::new(Expression::Identifier("b".into())),
+                max: Box::new(Expression::Identifier("c".into()))
             })),
             op: BinaryOp::In,
             right: Box::new(Expression::Tuple(vec![
-                Expression::Identifier("x".to_string()),
-                Expression::Identifier("y".to_string())
+                Expression::Identifier("x".into()),
+                Expression::Identifier("y".into())
             ]))
         }),
         input = "a BETWEEN b AND c IN (x, y)",
@@ -758,13 +760,13 @@ mod operator_precedence {
         in_binds_more_tightly_than_like,
         method = parse_expression,
         expected = Expression::Like(LikeExpr {
-            expr: Box::new(Expression::Identifier("a".to_string())),
+            expr: Box::new(Expression::Identifier("a".into())),
             pattern: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("x".to_string())),
+                left: Box::new(Expression::Identifier("x".into())),
                 op: BinaryOp::In,
                 right: Box::new(Expression::Tuple(vec![
-                    Expression::Identifier("y".to_string()),
-                    Expression::Identifier("z".to_string()),
+                    Expression::Identifier("y".into()),
+                    Expression::Identifier("z".into()),
                 ]))
             })),
             escape: None
@@ -777,8 +779,8 @@ mod operator_precedence {
         method = parse_expression,
         expected = Expression::Is(IsExpr {
             expr: Box::new(Expression::Like(LikeExpr {
-                expr: Box::new(Expression::Identifier("a".to_string())),
-                pattern: Box::new(Expression::Identifier("b".to_string())),
+                expr: Box::new(Expression::Identifier("a".into())),
+                pattern: Box::new(Expression::Identifier("b".into())),
                 escape: None,
             })),
             target_type: TypeOrMissing::Type(Type::Null)
@@ -792,7 +794,7 @@ mod operator_precedence {
         expected = Expression::Unary(UnaryExpr {
             op: UnaryOp::Not,
             expr: Box::new(Expression::Is(IsExpr {
-                expr: Box::new(Expression::Identifier("a".to_string())),
+                expr: Box::new(Expression::Identifier("a".into())),
                 target_type: TypeOrMissing::Type(Type::Null)
             }))
         }),
@@ -805,10 +807,10 @@ mod operator_precedence {
         expected = Expression::Binary(BinaryExpr {
             left: Box::new(Expression::Unary(UnaryExpr {
                 op: UnaryOp::Not,
-                expr: Box::new(Expression::Identifier("a".to_string())),
+                expr: Box::new(Expression::Identifier("a".into())),
             })),
             op: BinaryOp::And,
-            right: Box::new(Expression::Identifier("b".to_string()))
+            right: Box::new(Expression::Identifier("b".into()))
         }),
         input = "NOT a AND b",
     );
@@ -818,12 +820,12 @@ mod operator_precedence {
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
             left: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("a".to_string())),
+                left: Box::new(Expression::Identifier("a".into())),
                 op: BinaryOp::And,
-                right: Box::new(Expression::Identifier("b".to_string()))
+                right: Box::new(Expression::Identifier("b".into()))
             })),
             op: BinaryOp::Or,
-            right: Box::new(Expression::Identifier("c".to_string()))
+            right: Box::new(Expression::Identifier("c".into()))
         }),
         input = "a AND b OR c",
     );
@@ -834,9 +836,9 @@ mod operator_precedence {
         expected = Expression::Unary(UnaryExpr {
             op: UnaryOp::Not,
             expr: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("a".to_string())),
+                left: Box::new(Expression::Identifier("a".into())),
                 op: BinaryOp::Mul,
-                right: Box::new(Expression::Identifier("b".to_string()))
+                right: Box::new(Expression::Identifier("b".into()))
             }))
         }),
         input = "NOT a * b",
@@ -846,11 +848,11 @@ mod operator_precedence {
         unary_binds_more_tightly_than_binary_sub,
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
-            left: Box::new(Expression::Identifier("b".to_string())),
+            left: Box::new(Expression::Identifier("b".into())),
             op: BinaryOp::Sub,
             right: Box::new(Expression::Unary(UnaryExpr {
                 op: UnaryOp::Neg,
-                expr: Box::new(Expression::Identifier("a".to_string()))
+                expr: Box::new(Expression::Identifier("a".into()))
             }))
         }),
         input = "b- -a",
@@ -862,10 +864,10 @@ mod operator_precedence {
         expected = Expression::Binary(BinaryExpr {
             left: Box::new(Expression::Unary(UnaryExpr {
                 op: UnaryOp::Neg,
-                expr: Box::new(Expression::Identifier("a".to_string()))
+                expr: Box::new(Expression::Identifier("a".into()))
             })),
             op: BinaryOp::Div,
-            right: Box::new(Expression::Identifier("b".to_string()))
+            right: Box::new(Expression::Identifier("b".into()))
         }),
         input = "-a/b",
     );
@@ -875,15 +877,15 @@ mod operator_precedence {
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
             left: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("a".to_string())),
+                left: Box::new(Expression::Identifier("a".into())),
                 op: BinaryOp::Mul,
-                right: Box::new(Expression::Identifier("b".to_string()))
+                right: Box::new(Expression::Identifier("b".into()))
             })),
             op: BinaryOp::Add,
             right: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("x".to_string())),
+                left: Box::new(Expression::Identifier("x".into())),
                 op: BinaryOp::Mul,
-                right: Box::new(Expression::Identifier("y".to_string()))
+                right: Box::new(Expression::Identifier("y".into()))
             }))
         }),
         input = "a*b+x*y",
@@ -894,15 +896,15 @@ mod operator_precedence {
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
             left: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("a".to_string())),
+                left: Box::new(Expression::Identifier("a".into())),
                 op: BinaryOp::Div,
-                right: Box::new(Expression::Identifier("b".to_string()))
+                right: Box::new(Expression::Identifier("b".into()))
             })),
             op: BinaryOp::Sub,
             right: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("x".to_string())),
+                left: Box::new(Expression::Identifier("x".into())),
                 op: BinaryOp::Div,
-                right: Box::new(Expression::Identifier("y".to_string()))
+                right: Box::new(Expression::Identifier("y".into()))
             }))
         }),
         input = "a/b-x/y",
@@ -913,12 +915,12 @@ mod operator_precedence {
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
             left: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("a".to_string())),
+                left: Box::new(Expression::Identifier("a".into())),
                 op: BinaryOp::Add,
-                right: Box::new(Expression::Identifier("b".to_string()))
+                right: Box::new(Expression::Identifier("b".into()))
             })),
             op: BinaryOp::Concat,
-            right: Box::new(Expression::Identifier("c".to_string()))
+            right: Box::new(Expression::Identifier("c".into()))
         }),
         input = "a+b||c",
     );
@@ -927,12 +929,12 @@ mod operator_precedence {
         binary_concat_compare_ast,
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
-            left: Box::new(Expression::Identifier("c".to_string())),
+            left: Box::new(Expression::Identifier("c".into())),
             op: BinaryOp::Comparison(ComparisonOp::Gt),
             right: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("a".to_string())),
+                left: Box::new(Expression::Identifier("a".into())),
                 op: BinaryOp::Concat,
-                right: Box::new(Expression::Identifier("b".to_string()))
+                right: Box::new(Expression::Identifier("b".into()))
             }))
         }),
         input = "c>a||b",
@@ -943,12 +945,12 @@ mod operator_precedence {
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
             left: Box::new(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("a".to_string())),
+                left: Box::new(Expression::Identifier("a".into())),
                 op: BinaryOp::Comparison(ComparisonOp::Lt),
-                right: Box::new(Expression::Identifier("b".to_string()))
+                right: Box::new(Expression::Identifier("b".into()))
             })),
             op: BinaryOp::And,
-            right: Box::new(Expression::Identifier("c".to_string()))
+            right: Box::new(Expression::Identifier("c".into()))
         }),
         input = "a<b AND c",
     );
@@ -957,10 +959,10 @@ mod operator_precedence {
         cast_precedence_binary,
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
-            left: Box::new(Expression::Identifier("a".to_string())),
+            left: Box::new(Expression::Identifier("a".into())),
             op: BinaryOp::Mul,
             right: Box::new(Expression::Cast(CastExpr {
-                expr: Box::new(Expression::Identifier("b".to_string())),
+                expr: Box::new(Expression::Identifier("b".into())),
                 to: Type::Int32,
                 on_null: None,
                 on_error: None,
@@ -974,7 +976,7 @@ mod operator_precedence {
         expected = Expression::Unary(UnaryExpr {
             op: UnaryOp::Not,
             expr: Box::new(Expression::Cast(CastExpr {
-                expr: Box::new(Expression::Identifier("a".to_string())),
+                expr: Box::new(Expression::Identifier("a".into())),
                 to: Type::Boolean,
                 on_null: None,
                 on_error: None,
@@ -1053,15 +1055,13 @@ mod group_by {
             where_clause: None,
             group_by_clause: Some(GroupByClause {
                 keys: vec![
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("a".to_string())),
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("b".to_string()))
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("a".into())),
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("b".into()))
                 ],
                 aggregations: vec![AliasedExpr {
                     expr: Expression::Function(FunctionExpr {
                         function: FunctionName::Sum,
-                        args: FunctionArguments::Args(vec![Expression::Identifier(
-                            "b".to_string()
-                        )]),
+                        args: FunctionArguments::Args(vec![Expression::Identifier("b".into())]),
                         set_quantifier: Some(SetQuantifier::Distinct),
                     }),
                     alias: "c".to_string(),
@@ -1103,14 +1103,14 @@ mod having {
             where_clause: None,
             group_by_clause: Some(GroupByClause {
                 keys: vec![OptionallyAliasedExpr::Unaliased(Expression::Identifier(
-                    "a".to_string()
+                    "a".into()
                 ),)],
                 aggregations: vec![]
             }),
             having_clause: Some(Expression::Binary(BinaryExpr {
                 left: Box::new(Expression::Function(FunctionExpr {
                     function: FunctionName::Sum,
-                    args: FunctionArguments::Args(vec![Expression::Identifier("a".to_string())]),
+                    args: FunctionArguments::Args(vec![Expression::Identifier("a".into())]),
                     set_quantifier: Some(SetQuantifier::Distinct),
                 })),
                 op: BinaryOp::Comparison(ComparisonOp::Gt),
@@ -1170,7 +1170,7 @@ mod order_by {
             having_clause: None,
             order_by_clause: Some(OrderByClause {
                 sort_specs: vec![SortSpec {
-                    key: SortKey::Simple(Expression::Identifier("a".to_string())),
+                    key: SortKey::Simple(Expression::Identifier("a".into())),
                     direction: SortDirection::Asc
                 }]
             }),
@@ -1839,15 +1839,15 @@ mod scalar_function {
             function: FunctionName::Position,
             args: FunctionArguments::Args(vec![
                 Expression::Tuple(vec![Expression::Binary(BinaryExpr {
-                    left: Box::new(Expression::Identifier("a".to_string())),
+                    left: Box::new(Expression::Identifier("a".into())),
                     op: BinaryOp::Add,
                     right: Box::new(Expression::Binary(BinaryExpr {
-                        left: Box::new(Expression::Identifier("b".to_string())),
+                        left: Box::new(Expression::Identifier("b".into())),
                         op: BinaryOp::Mul,
-                        right: Box::new(Expression::Identifier("c".to_string()))
+                        right: Box::new(Expression::Identifier("c".into()))
                     }))
                 })]),
-                Expression::Identifier("d".to_string()),
+                Expression::Identifier("d".into()),
             ]),
             set_quantifier: None,
         }),
@@ -1858,7 +1858,7 @@ mod scalar_function {
         method = parse_expression,
         expected = Expression::Extract(ExtractExpr {
             extract_spec: DatePart::Year,
-            arg: Box::new(Expression::Identifier("a".to_string()))
+            arg: Box::new(Expression::Identifier("a".into()))
         }),
         input = "extract(year from a)",
     );
@@ -1868,9 +1868,9 @@ mod scalar_function {
         expected = Expression::Function(FunctionExpr {
             function: FunctionName::DateAdd,
             args: FunctionArguments::Args(vec![
-                Expression::Identifier("year".to_string()),
+                Expression::Identifier("year".into()),
                 Expression::Literal(Literal::Integer(5)),
-                Expression::Identifier("a".to_string())
+                Expression::Identifier("a".into())
             ]),
             set_quantifier: None,
         }),
@@ -1882,9 +1882,9 @@ mod scalar_function {
         expected = Expression::Function(FunctionExpr {
             function: FunctionName::DateDiff,
             args: FunctionArguments::Args(vec![
-                Expression::Identifier("year".to_string()),
-                Expression::Identifier("a".to_string()),
-                Expression::Identifier("b".to_string()),
+                Expression::Identifier("year".into()),
+                Expression::Identifier("a".into()),
+                Expression::Identifier("b".into()),
             ]),
             set_quantifier: None,
         }),
@@ -1896,10 +1896,10 @@ mod scalar_function {
         expected = Expression::Function(FunctionExpr {
             function: FunctionName::DateDiff,
             args: FunctionArguments::Args(vec![
-                Expression::Identifier("year".to_string()),
-                Expression::Identifier("a".to_string()),
-                Expression::Identifier("b".to_string()),
-                Expression::Identifier("wednesday".to_string())
+                Expression::Identifier("year".into()),
+                Expression::Identifier("a".into()),
+                Expression::Identifier("b".into()),
+                Expression::Identifier("wednesday".into())
             ]),
             set_quantifier: None,
         }),
@@ -1911,8 +1911,8 @@ mod scalar_function {
         expected = Expression::Function(FunctionExpr {
             function: FunctionName::DateTrunc,
             args: FunctionArguments::Args(vec![
-                Expression::Identifier("year".to_string()),
-                Expression::Identifier("a".to_string()),
+                Expression::Identifier("year".into()),
+                Expression::Identifier("a".into()),
             ]),
             set_quantifier: None,
         }),
@@ -1924,9 +1924,9 @@ mod scalar_function {
         expected = Expression::Function(FunctionExpr {
             function: FunctionName::DateTrunc,
             args: FunctionArguments::Args(vec![
-                Expression::Identifier("year".to_string()),
-                Expression::Identifier("a".to_string()),
-                Expression::Identifier("wednesday".to_string())
+                Expression::Identifier("year".into()),
+                Expression::Identifier("a".into()),
+                Expression::Identifier("wednesday".into())
             ]),
             set_quantifier: None,
         }),
@@ -1938,7 +1938,7 @@ mod scalar_function {
         expected = Expression::Trim(TrimExpr {
             trim_spec: TrimSpec::Both,
             trim_chars: Box::new(Expression::Identifier("substr".into())),
-            arg: Box::new(Expression::Identifier("str".to_string())),
+            arg: Box::new(Expression::Identifier("str".into())),
         }),
         input = "trim(substr FROM str)",
     );
@@ -1948,7 +1948,7 @@ mod scalar_function {
         expected = Expression::Trim(TrimExpr {
             trim_spec: TrimSpec::Leading,
             trim_chars: Box::new(Expression::StringConstructor(" ".into())),
-            arg: Box::new(Expression::Identifier("str".to_string())),
+            arg: Box::new(Expression::Identifier("str".into())),
         }),
         input = "trim(leading FROM str)",
     );
@@ -1958,7 +1958,7 @@ mod scalar_function {
         expected = Expression::Trim(TrimExpr {
             trim_spec: TrimSpec::Both,
             trim_chars: Box::new(Expression::StringConstructor(" ".into())),
-            arg: Box::new(Expression::Identifier("str".to_string())),
+            arg: Box::new(Expression::Identifier("str".into())),
         }),
         input = "trim(str)",
     );
@@ -1967,7 +1967,7 @@ mod scalar_function {
         method = parse_expression,
         expected = Expression::Function(FunctionExpr {
             function: FunctionName::Upper,
-            args: FunctionArguments::Args(vec![Expression::Identifier("a".to_string())]),
+            args: FunctionArguments::Args(vec![Expression::Identifier("a".into())]),
             set_quantifier: None,
         }),
         input = "upper(a)",
@@ -2461,7 +2461,7 @@ mod where_test {
             },
             from_clause: None,
             where_clause: Some(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("a".to_string())),
+                left: Box::new(Expression::Identifier("a".into())),
                 op: BinaryOp::Comparison(ComparisonOp::Gte),
                 right: Box::new(Expression::Literal(Literal::Integer(2)))
             })),
@@ -2903,7 +2903,7 @@ mod type_conversion {
         cast_to_decimal_ast,
         method = parse_expression,
         expected = Expression::Cast(CastExpr {
-            expr: Box::new(Expression::Identifier("v".to_string())),
+            expr: Box::new(Expression::Identifier("v".into())),
             to: Type::Decimal128,
             on_null: Some(Box::new(Expression::StringConstructor("null".to_string()))),
             on_error: Some(Box::new(Expression::StringConstructor("error".to_string()))),
@@ -2976,14 +2976,14 @@ mod subquery {
         some_subquery,
         method = parse_expression,
         expected = Expression::SubqueryComparison(SubqueryComparisonExpr {
-            expr: Box::new(Expression::Identifier("x".to_string())),
+            expr: Box::new(Expression::Identifier("x".into())),
             op: ComparisonOp::Neq,
             quantifier: SubqueryQuantifier::Any,
             subquery: Box::new(Query::Select(Box::new(SelectQuery {
                 select_clause: SelectClause {
                     set_quantifier: SetQuantifier::All,
                     body: SelectBody::Standard(vec![SelectExpression::Expression(
-                        OptionallyAliasedExpr::Unaliased(Expression::Identifier("a".to_string()),)
+                        OptionallyAliasedExpr::Unaliased(Expression::Identifier("a".into()),)
                     )])
                 },
                 from_clause: None,
@@ -3002,16 +3002,14 @@ mod subquery {
         in_subquery,
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
-            left: Box::new(Expression::Identifier("x".to_string())),
+            left: Box::new(Expression::Identifier("x".into())),
             op: BinaryOp::In,
             right: Box::new(Expression::Subquery(Box::new(Query::Select(Box::new(
                 SelectQuery {
                     select_clause: SelectClause {
                         set_quantifier: SetQuantifier::All,
                         body: SelectBody::Standard(vec![SelectExpression::Expression(
-                            OptionallyAliasedExpr::Unaliased(Expression::Identifier(
-                                "a".to_string()
-                            ),)
+                            OptionallyAliasedExpr::Unaliased(Expression::Identifier("a".into()),)
                         )])
                     },
                     from_clause: None,
@@ -3031,16 +3029,14 @@ mod subquery {
         not_in_subquery,
         method = parse_expression,
         expected = Expression::Binary(BinaryExpr {
-            left: Box::new(Expression::Identifier("x".to_string())),
+            left: Box::new(Expression::Identifier("x".into())),
             op: BinaryOp::NotIn,
             right: Box::new(Expression::Subquery(Box::new(Query::Select(Box::new(
                 SelectQuery {
                     select_clause: SelectClause {
                         set_quantifier: SetQuantifier::All,
                         body: SelectBody::Standard(vec![SelectExpression::Expression(
-                            OptionallyAliasedExpr::Unaliased(Expression::Identifier(
-                                "a".to_string()
-                            ),)
+                            OptionallyAliasedExpr::Unaliased(Expression::Identifier("a".into()),)
                         )])
                     },
                     from_clause: None,
@@ -3151,7 +3147,7 @@ mod document {
         expected = Expression::Subpath(SubpathExpr {
             expr: Box::new(Expression::Access(AccessExpr {
                 expr: Box::new(Expression::Subpath(SubpathExpr {
-                    expr: Box::new(Expression::Identifier("a".to_string())),
+                    expr: Box::new(Expression::Identifier("a".into())),
                     subpath: "b".to_string()
                 })),
                 subfield: Box::new(Expression::StringConstructor("c".to_string())),
@@ -3214,7 +3210,7 @@ mod comments {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".into()),)
                 )])
             },
             from_clause: None,
@@ -3235,7 +3231,7 @@ mod comments {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".into()),)
                 )])
             },
             from_clause: None,
@@ -3257,7 +3253,7 @@ mod comments {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".into()),)
                 )])
             },
             from_clause: None,
@@ -3278,7 +3274,7 @@ mod comments {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".into()),)
                 )])
             },
             from_clause: None,
@@ -3301,7 +3297,7 @@ mod comments {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".into()),)
                 )])
             },
             from_clause: None,
@@ -3323,7 +3319,7 @@ mod comments {
             select_clause: SelectClause {
                 set_quantifier: SetQuantifier::All,
                 body: SelectBody::Standard(vec![SelectExpression::Expression(
-                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".to_string()),)
+                    OptionallyAliasedExpr::Unaliased(Expression::Identifier("foo".into()),)
                 )])
             },
             from_clause: None,
@@ -3694,11 +3690,11 @@ mod higher_order_functions {
         map_with_expr_function_arg_ast,
         method = parse_expression,
         expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".to_string())),
+            array: Box::new(Expression::Identifier("a".into())),
             f: Box::new(FunctionArgument::Expr(Expression::Binary(BinaryExpr {
-                left: Box::new(Expression::Identifier("this".to_string())),
+                left: Box::new(Expression::Identifier("this".into())),
                 op: BinaryOp::Mul,
-                right: Box::new(Expression::Identifier("this".to_string())),
+                right: Box::new(Expression::Identifier("this".into())),
             }))),
         })),
         input = "map(a, this * this)",
@@ -3709,7 +3705,7 @@ mod higher_order_functions {
         map_with_named_function_pos_unary_op_arg_ast,
         method = parse_expression,
         expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".to_string())),
+            array: Box::new(Expression::Identifier("a".into())),
             f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
                 UnaryOp::Pos
             ))),
@@ -3722,7 +3718,7 @@ mod higher_order_functions {
         map_with_named_function_neg_unary_op_arg_ast,
         method = parse_expression,
         expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".to_string())),
+            array: Box::new(Expression::Identifier("a".into())),
             f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
                 UnaryOp::Neg
             ))),
@@ -3734,7 +3730,7 @@ mod higher_order_functions {
         map_with_named_function_binary_op_arg_ast,
         method = parse_expression,
         expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".to_string())),
+            array: Box::new(Expression::Identifier("a".into())),
             f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
                 BinaryOp::Div
             ))),
@@ -3746,11 +3742,24 @@ mod higher_order_functions {
         map_with_named_function_function_arg_ast,
         method = parse_expression,
         expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
-            array: Box::new(Expression::Identifier("a".to_string())),
+            array: Box::new(Expression::Identifier("a".into())),
             f: Box::new(FunctionArgument::NamedFunction(NamedFunction::Function(
                 FunctionName::Log10
             ))),
         })),
         input = "map(a, LOG10)",
+    );
+
+    // Note that if a function name is delimited, it is parsed as an Identifier.
+    validate_ast!(
+        map_with_delimited_named_function_function_arg_ast,
+        method = parse_expression,
+        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+            array: Box::new(Expression::Identifier("a".into())),
+            f: Box::new(FunctionArgument::Expr(Expression::Identifier(
+                ("LOG", true).into()
+            ))),
+        })),
+        input = "map(a, `LOG`)",
     );
 }

--- a/mongosql/src/parser/test.rs
+++ b/mongosql/src/parser/test.rs
@@ -1592,7 +1592,7 @@ mod array {
     parsable!(indexing, expected = true, input = "select [1, 2, 3][0]");
 }
 
-mod parenthized_expression {
+mod parenthesized_expression {
     parsable!(
         multiple_binary_ops,
         expected = true,
@@ -3660,5 +3660,97 @@ mod unrecognized_token_suggestion {
         expected = false,
         expected_error_user_msg = "Unrecognized token `notavalidquery`, expected: `SELECT`, `WITH`",
         input = "notavalidquery"
+    );
+}
+
+mod higher_order_functions {
+    use crate::ast::*;
+
+    parsable!(
+        map_with_expr_function_arg,
+        expected = true,
+        input = "SELECT MAP([1, 2, 3], this + 1)"
+    );
+
+    parsable!(
+        map_with_named_function_unary_op_arg,
+        expected = true,
+        input = "SELECT MAP(a, not)"
+    );
+
+    parsable!(
+        map_with_named_function_binray_op_arg,
+        expected = true,
+        input = "SELECT MAP(a, *)"
+    );
+
+    parsable!(
+        map_with_named_function_function_arg,
+        expected = true,
+        input = "SELECT MAP(a, LOWER)"
+    );
+
+    validate_ast!(
+        map_with_expr_function_arg_ast,
+        method = parse_expression,
+        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+            array: Box::new(Expression::Identifier("a".to_string())),
+            f: Box::new(FunctionArgument::Expr(Expression::Binary(BinaryExpr {
+                left: Box::new(Expression::Identifier("this".to_string())),
+                op: BinaryOp::Mul,
+                right: Box::new(Expression::Identifier("this".to_string())),
+            }))),
+        })),
+        input = "map(a, this * this)",
+    );
+
+    // Note that the parser defaults to UnaryOp::Pos for `+`.
+    validate_ast!(
+        map_with_named_function_pos_unary_op_arg_ast,
+        method = parse_expression,
+        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+            array: Box::new(Expression::Identifier("a".to_string())),
+            f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
+                UnaryOp::Pos
+            ))),
+        })),
+        input = "map(a, +)",
+    );
+
+    // Note that the parser defaults to UnaryOp::Neg for `-`.
+    validate_ast!(
+        map_with_named_function_neg_unary_op_arg_ast,
+        method = parse_expression,
+        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+            array: Box::new(Expression::Identifier("a".to_string())),
+            f: Box::new(FunctionArgument::NamedFunction(NamedFunction::UnaryOp(
+                UnaryOp::Neg
+            ))),
+        })),
+        input = "map(a, -)",
+    );
+
+    validate_ast!(
+        map_with_named_function_binary_op_arg_ast,
+        method = parse_expression,
+        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+            array: Box::new(Expression::Identifier("a".to_string())),
+            f: Box::new(FunctionArgument::NamedFunction(NamedFunction::BinaryOp(
+                BinaryOp::Div
+            ))),
+        })),
+        input = "map(a, /)",
+    );
+
+    validate_ast!(
+        map_with_named_function_function_arg_ast,
+        method = parse_expression,
+        expected = Expression::HigherOrderFunction(HigherOrderFunctionExpr::Map(MapExpr {
+            array: Box::new(Expression::Identifier("a".to_string())),
+            f: Box::new(FunctionArgument::NamedFunction(NamedFunction::Function(
+                FunctionName::Log10
+            ))),
+        })),
+        input = "map(a, LOG10)",
     );
 }

--- a/mongosql/src/parser/util.rs
+++ b/mongosql/src/parser/util.rs
@@ -63,7 +63,9 @@ pub fn parse_simple_datasource(
 ) -> Result<Datasource, LalrpopError<'static>> {
     let (expr, alias) = ae.take_fields();
     match expr {
-        Expression::Identifier(collection) => Ok(Datasource::Collection(CollectionSource {
+        Expression::Identifier(IdentifierExpr {
+            name: collection, ..
+        }) => Ok(Datasource::Collection(CollectionSource {
             database: None,
             collection,
             alias,
@@ -106,7 +108,7 @@ impl Expression {
 
     pub fn take_identifier_name(self) -> Option<String> {
         match self {
-            Expression::Identifier(s) => Some(s),
+            Expression::Identifier(IdentifierExpr { name: s, .. }) => Some(s),
             _ => None,
         }
     }

--- a/testdata/spec_tests/query_tests/higher_order_functions.yml
+++ b/testdata/spec_tests/query_tests/higher_order_functions.yml
@@ -9,21 +9,21 @@ dataset:
         - { "_id": 3, "a": [ 1, null, 3 ] }
         - { "_id": 4, "a": null }
         - { "_id": 5 }
-      schema:
-        bsonType: "object"
-        required: [ "_id" ]
-        additionalProperties: false
-        properties:
-          _id:
-            bsonType: "int"
-          a:
-            anyOf:
-              - bsonType: "array"
-                items:
-                  anyOf:
-                    - bsonType: "int"
-                    - bsonType: !!str "null"
-              - bsonType: !!str "null"
+    schema:
+      bsonType: "object"
+      required: [ "_id" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          anyOf:
+            - bsonType: "array"
+              items:
+                anyOf:
+                  - bsonType: "int"
+                  - bsonType: !!str "null"
+            - bsonType: !!str "null"
 
   - db: "spec_query_higher_order_functions"
     collection:
@@ -35,21 +35,21 @@ dataset:
         - { "_id": 3, "a": [ 1, null, 3 ] }
         - { "_id": 4, "a": null }
         - { "_id": 5 }
-      schema:
-        bsonType: "object"
-        required: [ "_id" ]
-        additionalProperties: false
-        properties:
-          _id:
-            bsonType: "int"
-          a:
-            anyOf:
-              - bsonType: "array"
-                items:
-                  anyOf:
-                    - bsonType: "int"
-                    - bsonType: !!str "null"
-              - bsonType: !!str "null"
+    schema:
+      bsonType: "object"
+      required: [ "_id" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          anyOf:
+            - bsonType: "array"
+              items:
+                anyOf:
+                  - bsonType: "int"
+                  - bsonType: !!str "null"
+            - bsonType: !!str "null"
 
   - db: "spec_query_higher_order_functions"
     collection:
@@ -64,25 +64,25 @@ dataset:
         - { "_id": 6, "i": 0 }
         - { "_id": 7, "a": [ 1, 2, 3 ], "i": null }
         - { "_id": 8, "a": [ 1, 2, 3 ] }
-      schema:
-        bsonType: "object"
-        required: [ "_id" ]
-        additionalProperties: false
-        properties:
-          _id:
-            bsonType: "int"
-          a:
-            anyOf:
-              - bsonType: "array"
-                items:
-                  anyOf:
-                    - bsonType: "int"
-                    - bsonType: !!str "null"
-              - bsonType: !!str "null"
-          i:
-            anyOf:
-              - bsonType: "int"
-              - bsonType: !!str "null"
+    schema:
+      bsonType: "object"
+      required: [ "_id" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          anyOf:
+            - bsonType: "array"
+              items:
+                anyOf:
+                  - bsonType: "int"
+                  - bsonType: !!str "null"
+            - bsonType: !!str "null"
+        i:
+          anyOf:
+            - bsonType: "int"
+            - bsonType: !!str "null"
 
   - db: "spec_query_higher_order_functions"
     collection:
@@ -95,24 +95,24 @@ dataset:
         - { "_id": 4, "a": [ 1, 2, 3 ], "value": 1000 }
         - { "_id": 5, "a": [ 1, 2, 3 ], "this": 100, "value": null }
         - { "_id": 6, "a": [ 1, 2, 3 ], "this": 100 }
-      schema:
-        bsonType: "object"
-        required: [ "_id", "a" ]
-        additionalProperties: false
-        properties:
-          _id:
-            bsonType: "int"
-          a:
-            bsonType: "array"
-            items:
-              anyOf:
-                - bsonType: "int"
-                - bsonType: !!str "null"
-          this:
+    schema:
+      bsonType: "object"
+      required: [ "_id", "a" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          bsonType: "array"
+          items:
             anyOf:
               - bsonType: "int"
               - bsonType: !!str "null"
-          value:
-            anyOf:
-              - bsonType: "int"
-              - bsonType: !!str "null"
+        this:
+          anyOf:
+            - bsonType: "int"
+            - bsonType: !!str "null"
+        value:
+          anyOf:
+            - bsonType: "int"
+            - bsonType: !!str "null"

--- a/tests/errors/algebrizer.yml
+++ b/tests/errors/algebrizer.yml
@@ -145,6 +145,12 @@ tests:
     should_compile: false
     algebrize_error: "Error 3030: invalid CAST target type 'Date'"
 
+  - description: Error 3035 HigherOrderFunctionWrapper
+    query: "SELECT REDUCE(aa, 0, value + this) FROM foo"
+    current_db: errors_algebrizer
+    should_compile: false
+    algebrize_error: "Error 3035: Invalid array argument for `Reduce`: The first argument must be semantically valid, and must evaluate to either an Array, Null, or Missing. Sub-Error Code 3008: Field `aa` not found. Did you mean: a, b, c, d"
+
   - description: Error 4000 FieldConflictInNonNamespacedResult
     query: "SELECT foo.*, bar.a FROM foo, bar"
     current_db: errors_algebrizer

--- a/tests/errors/rewriter.yml
+++ b/tests/errors/rewriter.yml
@@ -1,0 +1,6 @@
+tests:
+  - description: IncorrectArgumentCount with Minimum requirement in Higher Order Function
+    query: "SELECT MAP(a, *) FROM foo"
+    current_db: test
+    should_compile: false
+    rewriter_error: 'rewrite error: incorrect argument count for Mul: required 2, found 1'

--- a/tests/errors/schema.yml
+++ b/tests/errors/schema.yml
@@ -5,13 +5,6 @@ tests:
     should_compile: false
     algebrize_error: 'Error 1001: incorrect argument count for Round: required exactly 2, found 3'
 
-  - description: Error 1001 IncorrectArgumentCount with Minimum requirement
-    query: "SELECT MAP(a, +) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    current_db: errors_schema
-    should_compile: false
-    algebrize_error: 'Error 1001: incorrect argument count for Add: required at least 2, found 1'
-
   - description: Error 1002 SchemaChecking
     query: "SELECT ROUND(c,5) FROM foo"
     current_db: errors_schema

--- a/tests/errors/schema.yml
+++ b/tests/errors/schema.yml
@@ -5,6 +5,12 @@ tests:
     should_compile: false
     algebrize_error: 'Error 1001: incorrect argument count for Round: required exactly 2, found 3'
 
+  - description: Error 1001 IncorrectArgumentCount with Minimum requirement
+    query: "SELECT COALESCE() FROM foo"
+    current_db: errors_schema
+    should_compile: false
+    algebrize_error: 'Error 1001: incorrect argument count for Coalesce: required at least 1, found 0'
+
   - description: Error 1002 SchemaChecking
     query: "SELECT ROUND(c,5) FROM foo"
     current_db: errors_schema
@@ -89,3 +95,8 @@ tests:
     should_compile: false
     algebrize_error: "Error 1016: unknown collection 'baz' in database 'errors_schema'"
 
+  - description: Error 1020 HigherOrderFunctionWrapper
+    query: "SELECT MAP(['a'], this + 1) FROM foo"
+    current_db: errors_schema
+    should_compile: false
+    algebrize_error: "Error 1020: Invalid function argument for `Map`: Invalid usage of variable `this`. Recall that usages of the `this` variable must be satisfied by the schema of the elements of the array. Sub-Error Code 1002: Incorrect argument type for `Add`. Required: nullable numeric type. Found: string."

--- a/tests/spec_tests/query_tests/higher_order_functions.yml
+++ b/tests/spec_tests/query_tests/higher_order_functions.yml
@@ -2,7 +2,6 @@ tests:
   - description: MAP correctness test
     current_db: spec_query_higher_order_functions
     query: "SELECT VALUE { 'a': a, 'v': MAP(a, this + 1) } FROM `map` AS `map`"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     result:
       - { '': { "a": [], "v": [] } }
       - { '': { "a": [1], "v": [2] } }
@@ -14,7 +13,6 @@ tests:
   - description: FILTER correctness test
     current_db: spec_query_higher_order_functions
     query: "SELECT VALUE { 'a': a, 'v': FILTER(a, this > 0) } FROM `filter` AS `filter`"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     result:
       - { '': { "a": [], "v": [] } }
       - { '': { "a": [1], "v": [1] } }
@@ -25,8 +23,7 @@ tests:
 
   - description: REDUCE correctness test
     current_db: spec_query_higher_order_functions
-    query: "SELECT VALUE { 'a': a, 'i': i, 'v': REDUCE(a, i, this + value) } FROM `reduce` AS `reduce`"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
+    query: "SELECT VALUE { 'a': a, 'i': i, 'v': REDUCE(a, i, this + `value`) } FROM `reduce` AS `reduce`"
     result:
       - { '': { "a": [], "i": 0, "v": 0 } }
       - { '': { "a": [1], "i": 0, "v": 1 } }
@@ -43,7 +40,6 @@ tests:
   - description: There is no ambiguity between higher order function variable this and field references called this (MAP)
     current_db: spec_query_higher_order_functions
     query: "SELECT VALUE { 'a': a, 'this': this, 'with_local_this': MAP(a, this + this), 'with_field_ref_this': MAP(a, this + unambiguous.this)} FROM `unambiguous` AS `unambiguous`"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     result:
       - { '': { 'a': [], 'this': 100, 'with_local_this': [], 'with_field_ref_this': [] } }
       - { '': { 'a': [1], 'this': 100, 'with_local_this': [2], 'with_field_ref_this': [101] } }
@@ -58,8 +54,7 @@ tests:
   # references to this in the context of a higher order function are resolved to the variable this.
   - description: There is no ambiguity between higher order function variable this and field references called this (FILTER)
     current_db: spec_query_higher_order_functions
-    query: "SELECT VALUE { 'a': a, 'this': this, 'with_local_this': FILTER(a, this = this), 'with_field_ref_this': MAP(a, this = unambiguous.this)} FROM `unambiguous` AS `unambiguous`"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
+    query: "SELECT VALUE { 'a': a, 'this': this, 'with_local_this': FILTER(a, this = this), 'with_field_ref_this': FILTER(a, this = unambiguous.this)} FROM `unambiguous` AS `unambiguous`"
     result:
       - { '': { 'a': [], 'this': 100, 'with_local_this': [], 'with_field_ref_this': [] } }
       - { '': { 'a': [1], 'this': 100, 'with_local_this': [1], 'with_field_ref_this': [] } }
@@ -75,13 +70,12 @@ tests:
   # variables this or value.
   - description: There is no ambiguity between higher order function variable this and field references called this (REDUCE)
     current_db: spec_query_higher_order_functions
-    query: "SELECT VALUE { 'a': a, 'this': this, 'value': value, 'with_local_vars': REDUCE(a, 0, this + value), 'with_field_ref_this': REDUCE(a, 0, unambiguous.this + value), 'with_field_ref_value': REDUCE(a, 0, this + unambiguous.value) } FROM `unambiguous` AS `unambiguous`"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
+    query: "SELECT VALUE { 'a': a, 'this': this, 'value': `value`, 'with_local_vars': REDUCE(a, 0, this + `value`), 'with_field_ref_this': REDUCE(a, 0, unambiguous.this + `value`), 'with_field_ref_value': REDUCE(a, 0, this + unambiguous.`value`) } FROM `unambiguous` AS `unambiguous`"
     result:
       - { '': { 'a': [], 'this': 100, 'value': 1000, 'with_local_vars': 0, 'with_field_ref_this': 0, 'with_field_ref_value': 0 } }
-      - { '': { 'a': [1], 'this': 100, 'value': 1000, 'with_local_this': 1, 'with_field_ref_this': 100, 'with_field_ref_value': 1001 } }
-      - { '': { 'a': [1, 2, 3], 'this': 100, 'value': 1000, 'with_local_this': 6, 'with_field_ref_this': 300, 'with_field_ref_value': 1003 } }
-      - { '': { 'a': [1, 2, 3], 'this': null, 'value': 1000, 'with_local_this': 6, 'with_field_ref_this': null, 'with_field_ref_value': 1003 } }
-      - { '': { 'a': [1, 2, 3], 'value': 1000, 'with_local_this': 6, 'with_field_ref_this': null, 'with_field_ref_value': 1003 } }
-      - { '': { 'a': [1, 2, 3], 'this': 100, 'value': null, 'with_local_this': 6, 'with_field_ref_this': 300, 'with_field_ref_value': null } }
-      - { '': { 'a': [1, 2, 3], 'this': 100, 'with_local_this': 6, 'with_field_ref_this': 300, 'with_field_ref_value': null } }
+      - { '': { 'a': [1], 'this': 100, 'value': 1000, 'with_local_vars': 1, 'with_field_ref_this': 100, 'with_field_ref_value': 1001 } }
+      - { '': { 'a': [1, 2, 3], 'this': 100, 'value': 1000, 'with_local_vars': 6, 'with_field_ref_this': 300, 'with_field_ref_value': 1003 } }
+      - { '': { 'a': [1, 2, 3], 'this': null, 'value': 1000, 'with_local_vars': 6, 'with_field_ref_this': null, 'with_field_ref_value': 1003 } }
+      - { '': { 'a': [1, 2, 3], 'value': 1000, 'with_local_vars': 6, 'with_field_ref_this': null, 'with_field_ref_value': 1003 } }
+      - { '': { 'a': [1, 2, 3], 'this': 100, 'value': null, 'with_local_vars': 6, 'with_field_ref_this': 300, 'with_field_ref_value': null } }
+      - { '': { 'a': [1, 2, 3], 'this': 100, 'with_local_vars': 6, 'with_field_ref_this': 300, 'with_field_ref_value': null } }

--- a/tests/spec_tests/rewrite_tests/array_functions.yml
+++ b/tests/spec_tests/rewrite_tests/array_functions.yml
@@ -4,12 +4,10 @@ tests:
   #################################
   - description: Rewrite ARRAY_CAST to MAP
     query: "SELECT ARRAY_CAST(`array`, STRING) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     result: "SELECT VALUE {'_1': MAP(`array`, CAST(this AS STRING))} FROM foo AS foo"
 
   - description: Rewrite ARRAY_EXTRACT to MAP
     query: "SELECT ARRAY_EXTRACT(`array`, a.b.c) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     result: "SELECT VALUE {'_1': MAP(`array`, this.a.b.c)} FROM foo AS foo"
 
   #################################
@@ -17,17 +15,14 @@ tests:
   #################################
   - description: Rewrite ARRAY_COMPACT to FILTER
     query: "SELECT ARRAY_COMPACT(`array`) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': FILTER(`array`, this IS NOT NULL)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': FILTER(`array`, NOT this IS NULL)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_REMOVE to FILTER
     query: "SELECT ARRAY_REMOVE(`array`, x) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     result: "SELECT VALUE {'_1': FILTER(`array`, this <> x)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_COUNT_IF to FILTER
     query: "SELECT ARRAY_COUNT_IF(`array`, this > y) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     result: "SELECT VALUE {'_1': SIZE(FILTER(`array`, this > y))} FROM foo AS foo"
 
   #################################
@@ -35,40 +30,32 @@ tests:
   #################################
   - description: Rewrite ARRAY_SUM to REDUCE
     query: "SELECT ARRAY_SUM(`array`) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': REDUCE(`array`, 0, this + value)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': REDUCE(`array`, 0, `value` + this)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_PRODUCT to REDUCE
     query: "SELECT ARRAY_PRODUCT(`array`) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': REDUCE(`array`, 1, this * value)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': REDUCE(`array`, 1, `value` * this)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_AVG to REDUCE
     query: "SELECT ARRAY_AVG(`array`) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': REDUCE(`array`, 0, this + value) / SIZE(`array`)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': REDUCE(`array`, 0, `value` + this) / SIZE(`array`)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_ALL to REDUCE
     query: "SELECT ARRAY_ALL(`array`) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': REDUCE(`array`, TRUE, value AND this)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': REDUCE(`array`, true, `value` AND this)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_ANY to REDUCE
     query: "SELECT ARRAY_ANY(`array`) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': REDUCE(`array`, FALSE, value OR this)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': REDUCE(`array`, false, `value` OR this)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_JOIN without separator to REDUCE
     query: "SELECT ARRAY_JOIN(`array`) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': REDUCE(`array`, '', value || this)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': REDUCE(`array`, '', `value` || this)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_JOIN with empty separator to REDUCE
     query: "SELECT ARRAY_JOIN(`array`, '') FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': REDUCE(`array`, '', value || this)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': REDUCE(`array`, '', `value` || this)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_JOIN with non-empty separator to REDUCE
     query: "SELECT ARRAY_JOIN(`array`, ',') FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': TRIM(LEADING ',' FROM REDUCE(`array`, '', value || ',' || this))} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': TRIM(LEADING ',' FROM REDUCE(`array`, '', `value` || ',' || this))} FROM foo AS foo"

--- a/tests/spec_tests/rewrite_tests/higher_order_functions.yml
+++ b/tests/spec_tests/rewrite_tests/higher_order_functions.yml
@@ -1,15 +1,12 @@
 tests:
   - description: Rewrite MAP named function argument to use this
     query: "SELECT MAP(`array`, LOWER) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     result: "SELECT VALUE {'_1': MAP(`array`, LOWER(this))} FROM foo AS foo"
 
   - description: Rewrite FILTER named function argument to use this
     query: "SELECT FILTER(`array`, NOT) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     result: "SELECT VALUE {'_1': FILTER(`array`, NOT this)} FROM foo AS foo"
 
   - description: Rewrite REDUCE named function argument to use this and value
     query: "SELECT REDUCE(`array`, 0, +) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
-    result: "SELECT VALUE {'_1': REDUCE(`array`, 0, this + value)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': REDUCE(`array`, 0, `value` + this)} FROM foo AS foo"

--- a/tests/spec_tests/type_constraint_tests/higher_order_functions.yml
+++ b/tests/spec_tests/type_constraint_tests/higher_order_functions.yml
@@ -8,7 +8,6 @@ tests:
   # array schema of the first argument.
   - description: MAP operand type constraints
     query: "SELECT MAP(arg1, arg2) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     valid_types:
       - { "arg1": ["ARRAY", "NULL"], "arg2": *any }
 
@@ -18,7 +17,6 @@ tests:
   # the inner type of the array schema of the first argument.
   - description: FILTER operand type constraints
     query: "SELECT FILTER(arg1, arg2) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     valid_types:
       - { "arg1": ["ARRAY", "NULL"], "arg2": ["BOOL", "NULL"] }
 
@@ -32,6 +30,5 @@ tests:
   # result in "value" violating any schema constraints of its appearances, the expression is valid.
   - description: REDUCE operand type constraints
     query: "SELECT REDUCE(arg1, arg2, arg3) FROM foo"
-    skip_reason: "SQL-3298: Finish support for higher order functions"
     valid_types:
       - { "arg1": ["ARRAY", "NULL"], "arg2": *any, "arg3": *any }


### PR DESCRIPTION
This PR implements parsing for higher order functions according to the [design doc](https://docs.google.com/document/d/15bcFJ1wH6BcQYem7slPP8eG142BSvmjY3UuTNve8r7I/edit?tab=t.0#heading=h.he6cyip700kh). This is the final step that enables higher order functions in the dialect.

In addition to updating the parser, this PR also unskips all remaining higher order function e2e and spec tests, including `error`, `query`, `rewrite`, and `type_constraint` tests. Several of those unskipped tests needed minor alterations since they were incorrectly written initially. The `type_constraint` tests revealed a minor bug in the schema checking module, which was fixed as part of this PR (hence changes in `mir/schema/mod.rs`).

Also, as expected with any `parser` updates, the `pretty_printer` and `pretty_printer_fuzz_test` modules were updated to reflect new parsing behavior.

Finally, the "biggest" change you'll observe in this PR ("biggest" meaning "most files touched") is the addition of `is_delimited` to the `ast::Expression::Identifier` variant, which was necessary to avoid shift-reduce conflicts in the parser for the `FunctionArgument` generation. The issue there was that, syntactically, `NamedFunction::Function`s look exactly the same as `Identifiers`, which obviously causes an ambiguity in the grammer. An example of how this is problematic are these 2 queries:
```
// Query 1
// Here, we refer to the named function, LOG10
SELECT MAP([1, 2, 3], LOG10) FROM [{'LOG10': 'a'}] AS arr

// That query is rewritten into:
SELECT MAP([1, 2, 3], LOG10(this)) FROM [{'LOG10': 'a'}] AS arr

// Query 2
// Here, we refer to a _field_ named "LOG10"
SELECT MAP([1, 2, 3], `LOG10`) FROM [{'LOG10': 'a'}] AS arr
```
Query 1 outputs an array of 3 numbers: `[LOG10(1), LOG10(2), LOG10(3)]`. Query 2 outputs an array of 3 string values, all the same: `['a', 'a', 'a']`. We need to be able to distinguish when an identifier was supposed to be a "named function" vs when it is truly supposed to be an identifier.

Of course, delimiters always indicate that it is an identifier. However, as previously implemented, the parser/ast did not retain information about whether or not a parsed identifier was delimited. That led to the ambiguity I mentioned between `Identifier` expressions vs `NamedFunction::Function`s in the context of higher order functions. `lalrpop` does not tolerate any ambiguities and does not have any knobs or flags to alleviate them -- the only solution is to truly get rid of them. To do this, I created `IdentifierExpr` which tracks `is_delimited`. Using that flag allows us to unambiguously choose if an identifier that happens to use the same name as a function is intended to be a "named function" or an identifier.

This change was far-reaching since there were something like 300 uses of `Expression::Identifier` across many different files. Primarily, these uses are in test files. There were fewer than 10 uses of `Expression::Identifier` in "real" code. I'll highlight in the PR which files were just updated to include `is_delimited` info.