### PR TITLE
[SQL-3349] Merge adjacent match filter stages

### DIFF
--- a/mongosql/src/mir/optimizer/merge_neighboring_matches/mod.rs
+++ b/mongosql/src/mir/optimizer/merge_neighboring_matches/mod.rs
@@ -78,12 +78,11 @@ impl Visitor for MergeNeighboringMatchesVisitor {
                     // instead of nesting a new $and inside it
                     MatchQuery::Logical(MatchLanguageLogical {
                         op: MatchLanguageLogicalOp::And,
-                        args,
+                        mut args,
                         ..
                     }) => {
-                        let mut conditions = args;
-                        conditions.push(this_condition);
-                        conditions
+                        args.push(this_condition);
+                        args
                     }
                     // otherwise, create a vector with the child condition, and the condition of this filter
                     combined_conditions => vec![combined_conditions, this_condition],

--- a/mongosql/src/mir/optimizer/merge_neighboring_matches/mod.rs
+++ b/mongosql/src/mir/optimizer/merge_neighboring_matches/mod.rs
@@ -57,42 +57,53 @@ impl MergeNeighboringMatchesVisitor {
 }
 
 impl Visitor for MergeNeighboringMatchesVisitor {
-    fn visit_mql_stage(&mut self, node: MqlStage) -> MqlStage {
-        match node {
-            MqlStage::MatchFilter(match_filter) => {
-                let match_filter = self.visit_match_filter(*match_filter);
-                match match_filter.source.as_ref() {
-                    Stage::MqlIntrinsic(MqlStage::MatchFilter(child)) => {
-                        let conditions = match &child.condition {
-                            // the child is already a $and, append this condition to that and
-                            // instead of nesting a new $and inside it
-                            MatchQuery::Logical(MatchLanguageLogical {
-                                op: MatchLanguageLogicalOp::And,
-                                args,
-                                ..
-                            }) => {
-                                let mut conditions = args.clone();
-                                conditions.push(match_filter.condition.clone());
-                                conditions
-                            }
-                            // otherwise, create a $and with the two match filter conditions
-                            _ => vec![child.condition.clone(), match_filter.condition.clone()],
-                        };
-                        MqlStage::MatchFilter(Box::new(MatchFilter {
-                            source: child.source.clone(),
-                            condition: MatchQuery::Logical(MatchLanguageLogical {
-                                op: MatchLanguageLogicalOp::And,
-                                args: conditions,
-                                cache: Default::default(),
-                            }),
-                            cache: match_filter.cache.clone(),
-                        }))
+    fn visit_match_filter(&mut self, node: MatchFilter) -> MatchFilter {
+        // Recurse first so that we've already merged children before we try to merge this node.
+        let MatchFilter {
+            source,
+            condition,
+            cache,
+        } = node.walk(self);
+        match *source {
+            Stage::MqlIntrinsic(MqlStage::MatchFilter(child)) => {
+                let MatchFilter {
+                    source: child_source,
+                    condition: child_condition,
+                    ..
+                } = *child;
+
+                // Combine the child condition with the parent condition
+                let conditions: Vec<MatchQuery> = match child_condition {
+                    // the child is already a $and, append this condition to that and
+                    // instead of nesting a new $and inside it
+                    MatchQuery::Logical(MatchLanguageLogical {
+                        op: MatchLanguageLogicalOp::And,
+                        args,
+                        ..
+                    }) => {
+                        let mut conditions = args;
+                        conditions.push(condition);
+                        conditions
                     }
-                    // nothing to merge, return the filter as-is
-                    _ => MqlStage::MatchFilter(Box::new(match_filter)),
+                    // otherwise, create a vector with the child condition, and the condition of this filter
+                    child_match_query => vec![child_match_query, condition],
+                };
+                MatchFilter {
+                    source: child_source,
+                    condition: MatchQuery::Logical(MatchLanguageLogical {
+                        op: MatchLanguageLogicalOp::And,
+                        args: conditions,
+                        cache: Default::default(),
+                    }),
+                    cache,
                 }
             }
-            _ => node.walk(self),
+            // nothing to merge; rebuild the filter from its own (unchanged) fields
+            other => MatchFilter {
+                source: Box::new(other),
+                condition,
+                cache,
+            },
         }
     }
 

--- a/mongosql/src/mir/optimizer/merge_neighboring_matches/mod.rs
+++ b/mongosql/src/mir/optimizer/merge_neighboring_matches/mod.rs
@@ -11,6 +11,7 @@ mod test;
 
 use super::Optimizer;
 use crate::mir::optimizer::util::ContainsSubqueryVisitor;
+use crate::mir::{MatchFilter, MatchLanguageLogical, MatchLanguageLogicalOp, MatchQuery, MqlStage};
 use crate::{
     mir::{
         schema::SchemaInferenceState, visitor::Visitor, Expression, Filter, ScalarFunction,
@@ -56,6 +57,45 @@ impl MergeNeighboringMatchesVisitor {
 }
 
 impl Visitor for MergeNeighboringMatchesVisitor {
+    fn visit_mql_stage(&mut self, node: MqlStage) -> MqlStage {
+        match node {
+            MqlStage::MatchFilter(match_filter) => {
+                let match_filter = self.visit_match_filter(*match_filter);
+                match match_filter.source.as_ref() {
+                    Stage::MqlIntrinsic(MqlStage::MatchFilter(child)) => {
+                        let conditions = match &child.condition {
+                            // the child is already a $and, append this condition to that and
+                            // instead of nesting a new $and inside it
+                            MatchQuery::Logical(MatchLanguageLogical {
+                                op: MatchLanguageLogicalOp::And,
+                                args,
+                                ..
+                            }) => {
+                                let mut conditions = args.clone();
+                                conditions.push(match_filter.condition.clone());
+                                conditions
+                            }
+                            // otherwise, create a $and with the two match filter conditions
+                            _ => vec![child.condition.clone(), match_filter.condition.clone()],
+                        };
+                        MqlStage::MatchFilter(Box::new(MatchFilter {
+                            source: child.source.clone(),
+                            condition: MatchQuery::Logical(MatchLanguageLogical {
+                                op: MatchLanguageLogicalOp::And,
+                                args: conditions,
+                                cache: Default::default(),
+                            }),
+                            cache: match_filter.cache.clone(),
+                        }))
+                    }
+                    // nothing to merge, return the filter as-is
+                    _ => MqlStage::MatchFilter(Box::new(match_filter)),
+                }
+            }
+            _ => node.walk(self),
+        }
+    }
+
     fn visit_filter(&mut self, node: Filter) -> Filter {
         let node = node.walk(self);
         match node.source.as_ref() {

--- a/mongosql/src/mir/optimizer/merge_neighboring_matches/mod.rs
+++ b/mongosql/src/mir/optimizer/merge_neighboring_matches/mod.rs
@@ -60,20 +60,20 @@ impl Visitor for MergeNeighboringMatchesVisitor {
     fn visit_match_filter(&mut self, node: MatchFilter) -> MatchFilter {
         // Recurse first so that we've already merged children before we try to merge this node.
         let MatchFilter {
-            source,
-            condition,
-            cache,
+            source: this_source,
+            condition: this_condition,
+            cache: this_cache,
         } = node.walk(self);
-        match *source {
+        match *this_source {
             Stage::MqlIntrinsic(MqlStage::MatchFilter(child)) => {
                 let MatchFilter {
-                    source: child_source,
-                    condition: child_condition,
+                    source: other_source,
+                    condition: other_condition,
                     ..
                 } = *child;
 
                 // Combine the child condition with the parent condition
-                let conditions: Vec<MatchQuery> = match child_condition {
+                let conditions: Vec<MatchQuery> = match other_condition {
                     // the child is already a $and, append this condition to that and
                     // instead of nesting a new $and inside it
                     MatchQuery::Logical(MatchLanguageLogical {
@@ -82,27 +82,27 @@ impl Visitor for MergeNeighboringMatchesVisitor {
                         ..
                     }) => {
                         let mut conditions = args;
-                        conditions.push(condition);
+                        conditions.push(this_condition);
                         conditions
                     }
                     // otherwise, create a vector with the child condition, and the condition of this filter
-                    child_match_query => vec![child_match_query, condition],
+                    combined_conditions => vec![combined_conditions, this_condition],
                 };
                 MatchFilter {
-                    source: child_source,
+                    source: other_source,
                     condition: MatchQuery::Logical(MatchLanguageLogical {
                         op: MatchLanguageLogicalOp::And,
                         args: conditions,
                         cache: Default::default(),
                     }),
-                    cache,
+                    cache: this_cache,
                 }
             }
             // nothing to merge; rebuild the filter from its own (unchanged) fields
             other => MatchFilter {
                 source: Box::new(other),
-                condition,
-                cache,
+                condition: this_condition,
+                cache: this_cache,
             },
         }
     }

--- a/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
+++ b/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
@@ -78,15 +78,6 @@ mod merge_neighboring_matches_tests {
     );
 
     #[cfg(test)]
-    pub(crate) fn mir_collection(db_name: &str, collection_name: &str) -> Box<mir::Stage> {
-        Box::new(mir::Stage::Collection(mir::Collection {
-            db: db_name.to_string(),
-            collection: collection_name.to_string(),
-            cache: mir::schema::SchemaCache::new(),
-        }))
-    }
-
-    #[cfg(test)]
     fn make_key(key_name: &str) -> Key {
         if key_name == "__bot__" {
             Key::bot(0)

--- a/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
+++ b/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
@@ -1,4 +1,5 @@
 mod merge_neighboring_matches_tests {
+    use crate::util::mir_field_path;
     use crate::{
         map,
         mir::{
@@ -7,7 +8,6 @@ mod merge_neighboring_matches_tests {
         },
         set, unchecked_unique_linked_hash_map, util,
     };
-    use crate::util::mir_field_path;
 
     macro_rules! test_merge_neighboring_matches {
         ($func_name:ident, expected = $expected:expr, input = $input:expr,) => {

--- a/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
+++ b/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
@@ -1,12 +1,13 @@
 mod merge_neighboring_matches_tests {
     use crate::{
-        map,
+        map, mir,
         mir::{
             binding_tuple::DatasourceName::Bottom, schema::SchemaCache, Expression::*,
             LiteralValue::*,
         },
         set, unchecked_unique_linked_hash_map, util,
     };
+    use mongosql_datastructures::binding_tuple::Key;
 
     macro_rules! test_merge_neighboring_matches {
         ($func_name:ident, expected = $expected:expr, input = $input:expr,) => {
@@ -74,6 +75,272 @@ mod merge_neighboring_matches_tests {
             condition: Literal(Integer(2)),
             cache: SchemaCache::new(),
         }),
+    );
+
+    #[cfg(test)]
+    pub(crate) fn mir_collection(db_name: &str, collection_name: &str) -> Box<mir::Stage> {
+        Box::new(mir::Stage::Collection(mir::Collection {
+            db: db_name.to_string(),
+            collection: collection_name.to_string(),
+            cache: mir::schema::SchemaCache::new(),
+        }))
+    }
+
+    #[cfg(test)]
+    fn make_key(key_name: &str) -> Key {
+        if key_name == "__bot__" {
+            Key::bot(0)
+        } else {
+            Key::named(key_name, 0)
+        }
+    }
+    #[cfg(test)]
+    pub(crate) fn mir_field_path(datasource_name: &str, field_names: Vec<&str>) -> mir::FieldPath {
+        mir::FieldPath::new(
+            make_key(datasource_name),
+            field_names
+                .into_iter()
+                .map(std::string::String::from)
+                .collect(),
+        )
+    }
+
+    test_merge_neighboring_matches!(
+        two_match_filters_get_merged,
+        expected = Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(MatchFilter {
+            source: Box::new(Stage::Sentinel),
+            condition: MatchQuery::Logical(MatchLanguageLogical {
+                op: MatchLanguageLogicalOp::And,
+                args: vec![
+                    MatchQuery::Comparison(MatchLanguageComparison {
+                        function: MatchLanguageComparisonOp::Eq,
+                        input: Some(mir_field_path("foo", vec!["x"])),
+                        arg: LiteralValue::Integer(42),
+                        cache: Default::default(),
+                    }),
+                    MatchQuery::Comparison(MatchLanguageComparison {
+                        function: MatchLanguageComparisonOp::Eq,
+                        input: Some(mir_field_path("bar", vec!["y"])),
+                        arg: LiteralValue::Integer(43),
+                        cache: SchemaCache::new(),
+                    })
+                ],
+                cache: SchemaCache::new(),
+            }),
+            cache: SchemaCache::new(),
+        }))),
+        input = Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(MatchFilter {
+            source: Box::new(Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(
+                MatchFilter {
+                    source: Box::new(Stage::Sentinel),
+                    condition: MatchQuery::Comparison(MatchLanguageComparison {
+                        function: MatchLanguageComparisonOp::Eq,
+                        input: Some(mir_field_path("foo", vec!["x"])),
+                        arg: LiteralValue::Integer(42),
+                        cache: Default::default(),
+                    }),
+                    cache: Default::default(),
+                }
+            )))),
+            condition: MatchQuery::Comparison(MatchLanguageComparison {
+                function: MatchLanguageComparisonOp::Eq,
+                input: Some(mir_field_path("bar", vec!["y"])),
+                arg: LiteralValue::Integer(43),
+                cache: SchemaCache::new(),
+            }),
+            cache: SchemaCache::new(),
+        }))),
+    );
+
+    test_merge_neighboring_matches!(
+        two_non_adjacent_match_filters_not_merged,
+        expected = Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(MatchFilter {
+            source: Box::new(Stage::Project(Project {
+                is_add_fields: false,
+                source: Box::new(Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(
+                    MatchFilter {
+                        source: Box::new(Stage::Sentinel),
+                        condition: MatchQuery::Comparison(MatchLanguageComparison {
+                            function: MatchLanguageComparisonOp::Eq,
+                            input: Some(mir_field_path("foo", vec!["x"])),
+                            arg: LiteralValue::Integer(1),
+                            cache: Default::default(),
+                        }),
+                        cache: SchemaCache::new(),
+                    }
+                )))),
+                expression: map! {
+                    (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
+                        document: unchecked_unique_linked_hash_map! {
+                            "c".to_string() =>
+                            Expression::Literal(LiteralValue::Integer(1),),
+                        },
+                    }),
+                },
+                cache: SchemaCache::new(),
+            })),
+            condition: MatchQuery::Comparison(MatchLanguageComparison {
+                function: MatchLanguageComparisonOp::Eq,
+                input: Some(mir_field_path("bar", vec!["y"])),
+                arg: LiteralValue::Integer(3),
+                cache: Default::default(),
+            }),
+            cache: SchemaCache::new(),
+        }))),
+        input = Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(MatchFilter {
+            source: Box::new(Stage::Project(Project {
+                is_add_fields: false,
+                source: Box::new(Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(
+                    MatchFilter {
+                        source: Box::new(Stage::Sentinel),
+                        condition: MatchQuery::Comparison(MatchLanguageComparison {
+                            function: MatchLanguageComparisonOp::Eq,
+                            input: Some(mir_field_path("foo", vec!["x"])),
+                            arg: LiteralValue::Integer(1),
+                            cache: Default::default(),
+                        }),
+                        cache: SchemaCache::new(),
+                    }
+                )))),
+                expression: map! {
+                    (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
+                        document: unchecked_unique_linked_hash_map! {
+                            "c".to_string() =>
+                            Expression::Literal(LiteralValue::Integer(1),),
+                        },
+                    }),
+                },
+                cache: SchemaCache::new(),
+            })),
+            condition: MatchQuery::Comparison(MatchLanguageComparison {
+                function: MatchLanguageComparisonOp::Eq,
+                input: Some(mir_field_path("bar", vec!["y"])),
+                arg: LiteralValue::Integer(3),
+                cache: Default::default(),
+            }),
+            cache: SchemaCache::new(),
+        }))),
+    );
+
+    // Two Match Filters: Filter(A), Filter(B) - Project(C) followed by a project, followed by two more match filters
+    // Filter(C), Filter(D)
+    // Expect it to become Filter(A,B), Project(C), Filter(C,D)
+    test_merge_neighboring_matches!(
+        nested_match_filters_merged_through_project,
+        expected = Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(MatchFilter {
+            source: Box::new(Stage::Project(Project {
+                is_add_fields: false,
+                source: Box::new(Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(
+                    MatchFilter {
+                        source: Box::new(Stage::Sentinel),
+                        condition: MatchQuery::Logical(MatchLanguageLogical {
+                            op: MatchLanguageLogicalOp::And,
+                            args: vec![
+                                MatchQuery::Comparison(MatchLanguageComparison {
+                                    function: MatchLanguageComparisonOp::Eq,
+                                    input: Some(mir_field_path("foo", vec!["a"])),
+                                    arg: LiteralValue::Integer(1),
+                                    cache: Default::default(),
+                                }),
+                                MatchQuery::Comparison(MatchLanguageComparison {
+                                    function: MatchLanguageComparisonOp::Eq,
+                                    input: Some(mir_field_path("foo", vec!["b"])),
+                                    arg: LiteralValue::Integer(2),
+                                    cache: Default::default(),
+                                }),
+                            ],
+                            cache: SchemaCache::new(),
+                        }),
+                        cache: SchemaCache::new(),
+                    }
+                )))),
+                expression: map! {
+                    (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
+                        document: unchecked_unique_linked_hash_map! {
+                            "c".to_string() =>
+                            Expression::Literal(LiteralValue::Integer(1),),
+                        },
+                    }),
+                },
+                cache: SchemaCache::new(),
+            })),
+            condition: MatchQuery::Logical(MatchLanguageLogical {
+                op: MatchLanguageLogicalOp::And,
+                args: vec![
+                    MatchQuery::Comparison(MatchLanguageComparison {
+                        function: MatchLanguageComparisonOp::Eq,
+                        input: Some(mir_field_path("bar", vec!["c"])),
+                        arg: LiteralValue::Integer(3),
+                        cache: Default::default(),
+                    }),
+                    MatchQuery::Comparison(MatchLanguageComparison {
+                        function: MatchLanguageComparisonOp::Eq,
+                        input: Some(mir_field_path("bar", vec!["d"])),
+                        arg: LiteralValue::Integer(4),
+                        cache: SchemaCache::new(),
+                    }),
+                ],
+                cache: SchemaCache::new(),
+            }),
+            cache: SchemaCache::new(),
+        }))),
+        input = Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(MatchFilter {
+            source: Box::new(Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(
+                MatchFilter {
+                    source: Box::new(Stage::Project(Project {
+                        is_add_fields: false,
+                        source: Box::new(Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(
+                            MatchFilter {
+                                source: Box::new(Stage::MqlIntrinsic(MqlStage::MatchFilter(
+                                    Box::new(MatchFilter {
+                                        source: Box::new(Stage::Sentinel),
+                                        condition: MatchQuery::Comparison(
+                                            MatchLanguageComparison {
+                                                function: MatchLanguageComparisonOp::Eq,
+                                                input: Some(mir_field_path("foo", vec!["a"])),
+                                                arg: LiteralValue::Integer(1),
+                                                cache: Default::default(),
+                                            }
+                                        ),
+                                        cache: Default::default(),
+                                    })
+                                ))),
+                                condition: MatchQuery::Comparison(MatchLanguageComparison {
+                                    function: MatchLanguageComparisonOp::Eq,
+                                    input: Some(mir_field_path("foo", vec!["b"])),
+                                    arg: LiteralValue::Integer(2),
+                                    cache: Default::default(),
+                                }),
+                                cache: Default::default(),
+                            }
+                        )))),
+                        expression: map! {
+                            (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
+                                document: unchecked_unique_linked_hash_map! {
+                                    "c".to_string() =>
+                                    Expression::Literal(LiteralValue::Integer(1),),
+                                },
+                            }),
+                        },
+                        cache: SchemaCache::new(),
+                    })),
+                    condition: MatchQuery::Comparison(MatchLanguageComparison {
+                        function: MatchLanguageComparisonOp::Eq,
+                        input: Some(mir_field_path("bar", vec!["c"])),
+                        arg: LiteralValue::Integer(3),
+                        cache: Default::default(),
+                    }),
+                    cache: Default::default(),
+                }
+            )))),
+            condition: MatchQuery::Comparison(MatchLanguageComparison {
+                function: MatchLanguageComparisonOp::Eq,
+                input: Some(mir_field_path("bar", vec!["d"])),
+                arg: LiteralValue::Integer(4),
+                cache: Default::default(),
+            }),
+            cache: Default::default(),
+        }))),
     );
 
     test_merge_neighboring_matches!(

--- a/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
+++ b/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
@@ -1,13 +1,13 @@
 mod merge_neighboring_matches_tests {
     use crate::{
-        map, mir,
+        map,
         mir::{
             binding_tuple::DatasourceName::Bottom, schema::SchemaCache, Expression::*,
             LiteralValue::*,
         },
         set, unchecked_unique_linked_hash_map, util,
     };
-    use mongosql_datastructures::binding_tuple::Key;
+    use crate::util::mir_field_path;
 
     macro_rules! test_merge_neighboring_matches {
         ($func_name:ident, expected = $expected:expr, input = $input:expr,) => {
@@ -76,25 +76,6 @@ mod merge_neighboring_matches_tests {
             cache: SchemaCache::new(),
         }),
     );
-
-    #[cfg(test)]
-    fn make_key(key_name: &str) -> Key {
-        if key_name == "__bot__" {
-            Key::bot(0)
-        } else {
-            Key::named(key_name, 0)
-        }
-    }
-    #[cfg(test)]
-    pub(crate) fn mir_field_path(datasource_name: &str, field_names: Vec<&str>) -> mir::FieldPath {
-        mir::FieldPath::new(
-            make_key(datasource_name),
-            field_names
-                .into_iter()
-                .map(std::string::String::from)
-                .collect(),
-        )
-    }
 
     test_merge_neighboring_matches!(
         two_match_filters_get_merged,

--- a/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
+++ b/mongosql/src/mir/optimizer/merge_neighboring_matches/test.rs
@@ -25,17 +25,14 @@ mod merge_neighboring_matches_tests {
         };
     }
 
-    test_merge_neighboring_matches!(
+    macro_rules! test_merge_neighboring_matches_no_op {
+        ($func_name:ident, input = $input:expr,) => {
+            test_merge_neighboring_matches!($func_name, expected = $input, input = $input,);
+        };
+    }
+
+    test_merge_neighboring_matches_no_op!(
         simple_filter_no_merge,
-        expected = Stage::Filter(Filter {
-            source: Box::new(Stage::Array(ArraySource {
-                array: vec![],
-                alias: "foo".into(),
-                cache: SchemaCache::new()
-            })),
-            condition: Literal(Integer(42)),
-            cache: SchemaCache::new(),
-        }),
         input = Stage::Filter(Filter {
             source: Box::new(Stage::Array(ArraySource {
                 array: vec![],
@@ -124,41 +121,8 @@ mod merge_neighboring_matches_tests {
         }))),
     );
 
-    test_merge_neighboring_matches!(
+    test_merge_neighboring_matches_no_op!(
         two_non_adjacent_match_filters_not_merged,
-        expected = Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(MatchFilter {
-            source: Box::new(Stage::Project(Project {
-                is_add_fields: false,
-                source: Box::new(Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(
-                    MatchFilter {
-                        source: Box::new(Stage::Sentinel),
-                        condition: MatchQuery::Comparison(MatchLanguageComparison {
-                            function: MatchLanguageComparisonOp::Eq,
-                            input: Some(mir_field_path("foo", vec!["x"])),
-                            arg: LiteralValue::Integer(1),
-                            cache: Default::default(),
-                        }),
-                        cache: SchemaCache::new(),
-                    }
-                )))),
-                expression: map! {
-                    (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
-                        document: unchecked_unique_linked_hash_map! {
-                            "c".to_string() =>
-                            Expression::Literal(LiteralValue::Integer(1),),
-                        },
-                    }),
-                },
-                cache: SchemaCache::new(),
-            })),
-            condition: MatchQuery::Comparison(MatchLanguageComparison {
-                function: MatchLanguageComparisonOp::Eq,
-                input: Some(mir_field_path("bar", vec!["y"])),
-                arg: LiteralValue::Integer(3),
-                cache: Default::default(),
-            }),
-            cache: SchemaCache::new(),
-        }))),
         input = Stage::MqlIntrinsic(MqlStage::MatchFilter(Box::new(MatchFilter {
             source: Box::new(Stage::Project(Project {
                 is_add_fields: false,
@@ -390,33 +354,8 @@ mod merge_neighboring_matches_tests {
         }),
     );
 
-    test_merge_neighboring_matches!(
+    test_merge_neighboring_matches_no_op!(
         non_adjacent_filters_not_merged,
-        expected = Stage::Filter(Filter {
-            source: Box::new(Stage::Project(Project {
-                is_add_fields: false,
-                source: Box::new(Stage::Filter(Filter {
-                    source: Box::new(Stage::Array(ArraySource {
-                        array: vec![],
-                        alias: "foo".into(),
-                        cache: SchemaCache::new()
-                    })),
-                    condition: Literal(Integer(1)),
-                    cache: SchemaCache::new(),
-                })),
-                expression: map! {
-                    (Bottom, 0u16).into() => Expression::Document(DocumentExpr {
-                        document: unchecked_unique_linked_hash_map! {
-                            "c".to_string() =>
-                            Expression::Literal(LiteralValue::Integer(1),),
-                        },
-                    }),
-                },
-                cache: SchemaCache::new(),
-            })),
-            condition: Literal(Integer(3)),
-            cache: SchemaCache::new(),
-        }),
         input = Stage::Filter(Filter {
             source: Box::new(Stage::Project(Project {
                 is_add_fields: false,
@@ -444,47 +383,8 @@ mod merge_neighboring_matches_tests {
         }),
     );
 
-    test_merge_neighboring_matches!(
+    test_merge_neighboring_matches_no_op!(
         subquery_filter_at_start_not_merged,
-        expected = Stage::Filter(Filter {
-            source: Box::new(Stage::Filter(Filter {
-                source: Box::new(Stage::Array(ArraySource {
-                    array: vec![],
-                    alias: "foo".into(),
-                    cache: SchemaCache::new()
-                })),
-                condition: Expression::ScalarFunction(ScalarFunctionApplication {
-                    function: ScalarFunction::Gt,
-                    args: vec![
-                        *util::mir_field_access("__bot__", "x", false),
-                        Literal(Integer(10)),
-                    ],
-                    is_nullable: false,
-                }),
-                cache: SchemaCache::new(),
-            })),
-            condition: Subquery(SubqueryExpr {
-                output_expr: util::mir_field_access("__bot__", "y", true),
-                subquery: Box::new(Stage::Filter(Filter {
-                    source: Box::new(Stage::Array(ArraySource {
-                        array: vec![],
-                        alias: "bar".into(),
-                        cache: SchemaCache::new()
-                    })),
-                    condition: Expression::ScalarFunction(ScalarFunctionApplication {
-                        function: ScalarFunction::Eq,
-                        args: vec![
-                            *util::mir_field_access("__bot__", "z", false),
-                            Literal(Integer(5)),
-                        ],
-                        is_nullable: false,
-                    }),
-                    cache: SchemaCache::new(),
-                })),
-                is_nullable: true,
-            }),
-            cache: SchemaCache::new(),
-        }),
         input = Stage::Filter(Filter {
             source: Box::new(Stage::Filter(Filter {
                 source: Box::new(Stage::Array(ArraySource {


### PR DESCRIPTION
## Summary

Extends the`MergeNeighboringMatchesOptimizer` to merge adjacent Mql MatchFilter stages. Adds parity to our existing logic for regular Filter stages. 

Today, a query like:

```sql
 SELECT * FROM movies WHERE year > 1950 AND num_mflix_comments > 20
```

Creates an aggregation pipeline with two match stages. One for each side of the AND expression:
```javascript
[
    { "$match": { "year": { "$gt": 1950 } } },
    { "$match": { "num_mflix_comments": { "$gt": 20 } } },
    { "$project": { "movies": "$$ROOT", "_id": 0 } },
]
```

There are potential performance gains by merging the two match stages so we don't need to perform two collection scans at each match stage. These changes now generate:
```javascript
[
    { "$match": { "$and": [{ "year": { "$gt": 1950 } }, { "num_mflix_comments": { "$gt": 20 } }] } },
    { "$project": { "movies": "$$ROOT", "_id": 0 } },
]
```

Where we create a single match stage that uses the $and operator to combine the conjoin the conditions, just as we do for regular filter stages.

### Note
It appears that this optimization may already exist on the server based on their docs:
 https://www.mongodb.com/docs/manual/core/aggregation-pipeline-optimization/#match--match-coalescence
 
 However, when running the non-coalesced aggregation pipeline, the explain plan doesn't seem to optimize the query:
 ```javascript
[
    { "$match": { "year": { "$gt": 1950 } } },
    { "$match": { "num_mflix_comments": { "$gt": 20 } } },
    { "$project": { "movies": "$$ROOT", "_id": 0 } },
]
```

But I don't know if indexes or other factors impact this.
 
 I think this makes sense to add from a completeness perspective, we do the same optimization for regular filters, so there's not reason not to include here, but I suspect this will get taken care of for us.