### PR TITLE
SQL-3435: Update macos-13-arm64 to macos-14-arm64

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -1551,7 +1551,7 @@ buildvariants:
 
   - name: macos-arm64
     display_name: "macOS arm64"
-    run_on: [macos-13-arm64]
+    run_on: [macos-14-arm64]
     modules:
       - sql-engines-common-test-infra
     tasks:

--- a/evergreen/mongosqltranslate.yml
+++ b/evergreen/mongosqltranslate.yml
@@ -498,7 +498,7 @@ buildvariants:
   - name: mongosqltranslate-macos-arm
     tags: ["mongosqltranslate-release-variant"]
     display_name: "Mongosqltranslate - macOS arm64"
-    run_on: [macos-13-arm64]
+    run_on: [macos-14-arm64]
     modules:
       - sql-engines-common-test-infra
     tasks:

--- a/mongosql/src/air/desugarer/sql_null_semantics_operators.rs
+++ b/mongosql/src/air/desugarer/sql_null_semantics_operators.rs
@@ -252,14 +252,11 @@ impl SqlNullSemanticsOperatorsDesugarerVisitor {
             }
         }
 
-        let false_check_cond_else_statement = literal_null_found.map_or(
-            make_cond_expr!(
-                Self::literal_check_args(let_vars.clone(), MqlOperator::Lte, LiteralValue::Null),
-                Literal(LiteralValue::Null),
-                Literal(LiteralValue::Boolean(true))
-            ),
-            |x| x,
-        );
+        let false_check_cond_else_statement = literal_null_found.unwrap_or(make_cond_expr!(
+            Self::literal_check_args(let_vars.clone(), MqlOperator::Lte, LiteralValue::Null),
+            Literal(LiteralValue::Null),
+            Literal(LiteralValue::Boolean(true))
+        ));
 
         // If any of the arguments are false, return false.
         // Otherwise, if any of the arguments are null, return null. Otherwise, return true.
@@ -296,14 +293,11 @@ impl SqlNullSemanticsOperatorsDesugarerVisitor {
             }
         }
 
-        let true_check_cond_else_statement = literal_null_found.map_or(
-            make_cond_expr!(
-                Self::literal_check_args(let_vars.clone(), MqlOperator::Lte, LiteralValue::Null),
-                Literal(LiteralValue::Null),
-                Literal(LiteralValue::Boolean(false))
-            ),
-            |x| x,
-        );
+        let true_check_cond_else_statement = literal_null_found.unwrap_or(make_cond_expr!(
+            Self::literal_check_args(let_vars.clone(), MqlOperator::Lte, LiteralValue::Null),
+            Literal(LiteralValue::Null),
+            Literal(LiteralValue::Boolean(false))
+        ));
 
         // If any of the arguments are true, return true.
         // Otherwise, if any of the arguments are null, return null. Otherwise, return false.


### PR DESCRIPTION
This PR updates `macos-13-arm64` to `macos-14-arm64` for the two MacOS buildvariants in this project (one for mongosql and one for mongosqltranslate) since the macos-13 fleet is being decommissioned by DevProd.