### PR TITLE
[SQL-3387] Support Array Remove with a null check

### DIFF
--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -225,48 +225,36 @@ impl HigherOrderFunctionsAliasVisitor {
             })
         };
 
-        let is_filtering_out_nulls = matches!(remove_expr, Expression::Literal(Literal::Null));
-        if is_filtering_out_nulls {
-            Ok(Self::make_filter(
-                array.clone(),
+        // NOT (this IS NULL AND x IS NULL): drop the element when both sides are NULL.
+        let not_both_null = Expression::Unary(UnaryExpr {
+            op: UnaryOp::Not,
+            expr: Box::new(Self::make_binary(
+                is_null(this()),
+                BinaryOp::And,
+                is_null(remove_expr.clone()),
+            )),
+        });
+
+        // this IS NULL OR x IS NULL OR this <> x: keep the element when exactly one side is
+        // NULL, and otherwise defer to `<>` on two non-NULL operands.
+        let either_null_or_unequal = Self::make_binary(
+            is_null(this()),
+            BinaryOp::Or,
+            Self::make_binary(
+                is_null(remove_expr.clone()),
+                BinaryOp::Or,
                 Self::make_binary(
                     this(),
                     BinaryOp::Comparison(ComparisonOp::Neq),
                     remove_expr.clone(),
                 ),
-            ))
-        } else {
-            // NOT (this IS NULL AND x IS NULL): drop the element when both sides are NULL.
-            let not_both_null = Expression::Unary(UnaryExpr {
-                op: UnaryOp::Not,
-                expr: Box::new(Self::make_binary(
-                    is_null(this()),
-                    BinaryOp::And,
-                    is_null(remove_expr.clone()),
-                )),
-            });
+            ),
+        );
 
-            // this IS NULL OR x IS NULL OR this <> x: keep the element when exactly one side is
-            // NULL, and otherwise defer to `<>` on two non-NULL operands.
-            let either_null_or_unequal = Self::make_binary(
-                is_null(this()),
-                BinaryOp::Or,
-                Self::make_binary(
-                    is_null(remove_expr.clone()),
-                    BinaryOp::Or,
-                    Self::make_binary(
-                        this(),
-                        BinaryOp::Comparison(ComparisonOp::Neq),
-                        remove_expr.clone(),
-                    ),
-                ),
-            );
-
-            Ok(Self::make_filter(
-                array.clone(),
-                Self::make_binary(not_both_null, BinaryOp::And, either_null_or_unequal),
-            ))
-        }
+        Ok(Self::make_filter(
+            array.clone(),
+            Self::make_binary(not_both_null, BinaryOp::And, either_null_or_unequal),
+        ))
     }
 
     /// Rewrite `ARRAY_COUNT_IF(a, f)` into `SIZE(FILTER(a, f))`.

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -200,7 +200,7 @@ impl HigherOrderFunctionsAliasVisitor {
 
         let is_filtering_out_nulls = matches!(remove_expr, Expression::Literal(Literal::Null));
         if is_filtering_out_nulls {
-            // If we're explicitly checking for null, then this is fine.
+            // If we're explicitly filtering out null, we can just use (x <> remove_expr)
             Ok(Self::make_filter(
                 array.clone(),
                 Self::make_binary(
@@ -210,13 +210,13 @@ impl HigherOrderFunctionsAliasVisitor {
                 ),
             ))
         } else {
-            // Not explicitly removing nulls, so null elements must be retained:
-            // FILTER(a, this IS NULL OR this <> remove_expr)
+            // If we're filtering out a literal, include an IS null checks, so we keep them.
             let include_null_values = Expression::Is(IsExpr {
                 expr: Box::new(this()),
                 target_type: TypeOrMissing::Type(Type::Null),
             });
 
+            // `FILTER(a, this IS NULL OR x <> remove_expr)
             Ok(Self::make_filter(
                 array.clone(),
                 Self::make_binary(

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -200,7 +200,7 @@ impl HigherOrderFunctionsAliasVisitor {
 
         let is_filtering_out_nulls = matches!(remove_expr, Expression::Literal(Literal::Null));
         if is_filtering_out_nulls {
-            // If we're explicitly filtering out null, we can just use (x <> remove_expr)
+            // If we're explicitly filtering out null, we can just use (this <> remove_expr)
             Ok(Self::make_filter(
                 array.clone(),
                 Self::make_binary(
@@ -216,7 +216,7 @@ impl HigherOrderFunctionsAliasVisitor {
                 target_type: TypeOrMissing::Type(Type::Null),
             });
 
-            // `FILTER(a, this IS NULL OR x <> remove_expr)
+            // `FILTER(a, this IS NULL OR this <> remove_expr)
             Ok(Self::make_filter(
                 array.clone(),
                 Self::make_binary(

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -196,20 +196,25 @@ impl HigherOrderFunctionsAliasVisitor {
     /// For any other `x`, rewrite `ARRAY_REMOVE(a, x)` into
     /// `FILTER(a, NOT (this IS NULL AND x IS NULL) AND (this IS NULL OR x IS NULL OR this <> x))`.
     ///
-    /// The guards below exist so that `this <> x` is only ever *reached* with two non-NULL
-    /// operands. Writing `A` for `this IS NULL` and `B` for `x IS NULL`, the predicate is
-    /// `NOT (A AND B) AND (A OR B OR this <> x)`, which decides each row as:
+    /// Example:
+    /// ```sql
+    /// SELECT VALUE {'v': ARRAY_REMOVE(a, x)} FROM my_collection
+    /// ```
+    ///
+    /// | row                          | `v`         |
+    /// |------------------------------|-------------|
+    /// | `{a: [1, null, 3], x: 1}`    | `[null, 3]` |
+    /// | `{a: [1, null, 3], x: null}` | `[1, 3]`    |
+    ///
+    /// Writing `A` for `this IS NULL` and `B` for `x IS NULL`, the predicate decides the second
+    /// row element by element as:
     ///
     /// | `this` | `x`  | `NOT (A AND B)` | `A OR B OR this <> x` | result |
     /// |--------|------|-----------------|-----------------------|--------|
-    /// | NULL   | 1    | true            | true (via `A`)        | keep   |
-    /// | 1      | 1    | true            | false                 | drop   |
     /// | 1      | NULL | true            | true (via `B`)        | keep   |
-    /// | NULL   | NULL | false           | -                     | drop   |
+    /// | NULL   | NULL | false           | true (via `A`)        | drop   |
+    /// | 3      | NULL | true            | true (via `B`)        | keep   |
     ///
-    /// In every row where `this <> x` would evaluate to NULL, `A` or `B` is already true, so
-    /// `$sqlOr` yields true and the NULL never propagates. And because `IS` always produces a
-    /// non-NULL boolean, the guards themselves are never NULL.
     fn rewrite_array_remove(args: &[Expression]) -> Result<Expression> {
         let [array, remove_expr] = try_exact_args("ARRAY_REMOVE", args)?;
 

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -227,14 +227,13 @@ impl HigherOrderFunctionsAliasVisitor {
 
         let is_filtering_out_nulls = matches!(remove_expr, Expression::Literal(Literal::Null));
         if is_filtering_out_nulls {
-            // Removing NULL keeps exactly the non-NULL elements, so the general predicate below
-            // collapses to a single NULL check.
             Ok(Self::make_filter(
                 array.clone(),
-                Expression::Unary(UnaryExpr {
-                    op: UnaryOp::Not,
-                    expr: Box::new(is_null(this())),
-                }),
+                Self::make_binary(
+                    this(),
+                    BinaryOp::Comparison(ComparisonOp::Neq),
+                    remove_expr.clone(),
+                ),
             ))
         } else {
             // NOT (this IS NULL AND x IS NULL): drop the element when both sides are NULL.

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -192,7 +192,7 @@ impl HigherOrderFunctionsAliasVisitor {
         ))
     }
 
-    /// Rewrite `ARRAY_REMOVE(a, NULL)` into `FILTER(a, NOT this IS NULL)`.
+    /// Rewrite `ARRAY_REMOVE(a, NULL)` into `FILTER(a, this <> NULL)`.
     /// For any other `x`, rewrite `ARRAY_REMOVE(a, x)` into
     /// `FILTER(a, NOT (this IS NULL AND x IS NULL) AND (this IS NULL OR x IS NULL OR this <> x))`.
     ///

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -192,35 +192,63 @@ impl HigherOrderFunctionsAliasVisitor {
         ))
     }
 
-    /// Rewrite `ARRAY_REMOVE(a, NULL)` into `FILTER(a, this <> NULL)`.
-    /// For any other `x`, null elements must be retained, so rewrite
-    /// `ARRAY_REMOVE(a, x)` into `FILTER(a, this IS NULL OR this <> x)`.
+    /// Rewrite `ARRAY_REMOVE(a, NULL)` into `FILTER(a, NOT this IS NULL)`.
+    /// For any other `x`, rewrite `ARRAY_REMOVE(a, x)` into
+    /// `FILTER(a, NOT (this IS NULL AND x IS NULL) AND (this IS NULL OR x IS NULL OR this <> x))`.
+    ///
+    /// The guards below exist so that `this <> x` is only ever *reached* with two non-NULL
+    /// operands. Writing `A` for `this IS NULL` and `B` for `x IS NULL`, the predicate is
+    /// `NOT (A AND B) AND (A OR B OR this <> x)`, which decides each row as:
+    ///
+    /// | `this` | `x`  | `NOT (A AND B)` | `A OR B OR this <> x` | result |
+    /// |--------|------|-----------------|-----------------------|--------|
+    /// | NULL   | 1    | true            | true (via `A`)        | keep   |
+    /// | 1      | 1    | true            | false                 | drop   |
+    /// | 1      | NULL | true            | true (via `B`)        | keep   |
+    /// | NULL   | NULL | false           | -                     | drop   |
+    ///
+    /// In every row where `this <> x` would evaluate to NULL, `A` or `B` is already true, so
+    /// `$sqlOr` yields true and the NULL never propagates. And because `IS` always produces a
+    /// non-NULL boolean, the guards themselves are never NULL.
     fn rewrite_array_remove(args: &[Expression]) -> Result<Expression> {
         let [array, remove_expr] = try_exact_args("ARRAY_REMOVE", args)?;
 
+        let is_null = |expr: Expression| {
+            Expression::Is(IsExpr {
+                expr: Box::new(expr),
+                target_type: TypeOrMissing::Type(Type::Null),
+            })
+        };
+
         let is_filtering_out_nulls = matches!(remove_expr, Expression::Literal(Literal::Null));
         if is_filtering_out_nulls {
-            // If we're explicitly filtering out null, we can just use (this <> remove_expr)
+            // Removing NULL keeps exactly the non-NULL elements, so the general predicate below
+            // collapses to a single NULL check.
             Ok(Self::make_filter(
                 array.clone(),
-                Self::make_binary(
-                    this(),
-                    BinaryOp::Comparison(ComparisonOp::Neq),
-                    remove_expr.clone(),
-                ),
+                Expression::Unary(UnaryExpr {
+                    op: UnaryOp::Not,
+                    expr: Box::new(is_null(this())),
+                }),
             ))
         } else {
-            // If we're filtering out a literal, include an IS null checks, so we keep them.
-            let include_null_values = Expression::Is(IsExpr {
-                expr: Box::new(this()),
-                target_type: TypeOrMissing::Type(Type::Null),
+            // NOT (this IS NULL AND x IS NULL): drop the element when both sides are NULL.
+            let not_both_null = Expression::Unary(UnaryExpr {
+                op: UnaryOp::Not,
+                expr: Box::new(Self::make_binary(
+                    is_null(this()),
+                    BinaryOp::And,
+                    is_null(remove_expr.clone()),
+                )),
             });
 
-            // `FILTER(a, this IS NULL OR this <> remove_expr)
-            Ok(Self::make_filter(
-                array.clone(),
+            // this IS NULL OR x IS NULL OR this <> x: keep the element when exactly one side is
+            // NULL, and otherwise defer to `<>` on two non-NULL operands.
+            let either_null_or_unequal = Self::make_binary(
+                is_null(this()),
+                BinaryOp::Or,
                 Self::make_binary(
-                    include_null_values,
+                    is_null(remove_expr.clone()),
                     BinaryOp::Or,
                     Self::make_binary(
                         this(),
@@ -228,6 +256,11 @@ impl HigherOrderFunctionsAliasVisitor {
                         remove_expr.clone(),
                     ),
                 ),
+            );
+
+            Ok(Self::make_filter(
+                array.clone(),
+                Self::make_binary(not_both_null, BinaryOp::And, either_null_or_unequal),
             ))
         }
     }

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -192,18 +192,44 @@ impl HigherOrderFunctionsAliasVisitor {
         ))
     }
 
-    /// Rewrite `ARRAY_REMOVE(a, x)` into `FILTER(a, this <> x)`.
+    /// Rewrite `ARRAY_REMOVE(a, NULL)` into `FILTER(a, this <> NULL)`.
+    /// For any other `x`, null elements must be retained, so rewrite
+    /// `ARRAY_REMOVE(a, x)` into `FILTER(a, this IS NULL OR this <> x)`.
     fn rewrite_array_remove(args: &[Expression]) -> Result<Expression> {
         let [array, remove_expr] = try_exact_args("ARRAY_REMOVE", args)?;
 
-        Ok(Self::make_filter(
-            array.clone(),
-            Self::make_binary(
-                this(),
-                BinaryOp::Comparison(ComparisonOp::Neq),
-                remove_expr.clone(),
-            ),
-        ))
+        let is_filtering_out_nulls = matches!(remove_expr, Expression::Literal(Literal::Null));
+        if is_filtering_out_nulls {
+            // If we're explicitly checking for null, then this is fine.
+            Ok(Self::make_filter(
+                array.clone(),
+                Self::make_binary(
+                    this(),
+                    BinaryOp::Comparison(ComparisonOp::Neq),
+                    remove_expr.clone(),
+                ),
+            ))
+        } else {
+            // Not explicitly removing nulls, so null elements must be retained:
+            // FILTER(a, this IS NULL OR this <> remove_expr)
+            let include_null_values = Expression::Is(IsExpr {
+                expr: Box::new(this()),
+                target_type: TypeOrMissing::Type(Type::Null),
+            });
+
+            Ok(Self::make_filter(
+                array.clone(),
+                Self::make_binary(
+                    include_null_values,
+                    BinaryOp::Or,
+                    Self::make_binary(
+                        this(),
+                        BinaryOp::Comparison(ComparisonOp::Neq),
+                        remove_expr.clone(),
+                    ),
+                ),
+            ))
+        }
     }
 
     /// Rewrite `ARRAY_COUNT_IF(a, f)` into `SIZE(FILTER(a, f))`.

--- a/mongosql/src/ast/rewrites/higher_order_functions.rs
+++ b/mongosql/src/ast/rewrites/higher_order_functions.rs
@@ -192,8 +192,7 @@ impl HigherOrderFunctionsAliasVisitor {
         ))
     }
 
-    /// Rewrite `ARRAY_REMOVE(a, NULL)` into `FILTER(a, this <> NULL)`.
-    /// For any other `x`, rewrite `ARRAY_REMOVE(a, x)` into
+    /// Rewrite `ARRAY_REMOVE(a, x)` into
     /// `FILTER(a, NOT (this IS NULL AND x IS NULL) AND (this IS NULL OR x IS NULL OR this <> x))`.
     ///
     /// Example:

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1418,11 +1418,6 @@ mod scalar_functions {
 
 mod higher_order_functions {
     use super::*;
-    test_rewrite!(array_remove_with_field,
-        pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT VALUE {'a': a, 'v': FILTER(a, NOT (this IS NULL AND x IS NULL) AND (this IS NULL OR (x IS NULL OR this <> x)))} FROM array_default_numeric_data AS array_default_numeric_data"),
-        input = "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, x) } FROM `array_default_numeric_data` AS `array_default_numeric_data`",
-    );
 
     test_rewrite!(
         array_cast,

--- a/mongosql/src/ast/rewrites/test.rs
+++ b/mongosql/src/ast/rewrites/test.rs
@@ -1418,6 +1418,11 @@ mod scalar_functions {
 
 mod higher_order_functions {
     use super::*;
+    test_rewrite!(array_remove_with_field,
+        pass = HigherOrderFunctionsRewritePass,
+        expected = Ok("SELECT VALUE {'a': a, 'v': FILTER(a, NOT (this IS NULL AND x IS NULL) AND (this IS NULL OR (x IS NULL OR this <> x)))} FROM array_default_numeric_data AS array_default_numeric_data"),
+        input = "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, x) } FROM `array_default_numeric_data` AS `array_default_numeric_data`",
+    );
 
     test_rewrite!(
         array_cast,
@@ -1486,7 +1491,7 @@ mod higher_order_functions {
     test_rewrite!(
         array_remove,
         pass = HigherOrderFunctionsRewritePass,
-        expected = Ok("SELECT FILTER(a, this <> x)"),
+        expected = Ok("SELECT FILTER(a, NOT (this IS NULL AND x IS NULL) AND (this IS NULL OR (x IS NULL OR this <> x)))"),
         input = "SELECT ARRAY_REMOVE(a, x)",
     );
 

--- a/testdata/spec_tests/query_tests/array_functions.yml
+++ b/testdata/spec_tests/query_tests/array_functions.yml
@@ -4,9 +4,9 @@ dataset:
       name: "array_default_numeric_data"
       docs:
         - { "_id": 0, "a": [] }
-        - { "_id": 1, "a": [ 1 ] }
-        - { "_id": 2, "a": [ 1, 2, 3 ] }
-        - { "_id": 3, "a": [ 1, null, 3 ] }
+        - { "_id": 1, "a": [ 1 ], "x": 1 }
+        - { "_id": 2, "a": [ 1, 2, 3 ], "x": 2 }
+        - { "_id": 3, "a": [ 1, null, 3 ], "x": null}
         - { "_id": 4, "a": null }
         - { "_id": 5 }
     schema:
@@ -23,6 +23,10 @@ dataset:
                 anyOf:
                   - bsonType: "int"
                   - bsonType: !!str "null"
+            - bsonType: !!str "null"
+        x:
+          anyOf:
+            - bsonType: "int"
             - bsonType: !!str "null"
 
   - db: "spec_query_array_functions"

--- a/testdata/spec_tests/query_tests/array_functions.yml
+++ b/testdata/spec_tests/query_tests/array_functions.yml
@@ -4,11 +4,42 @@ dataset:
       name: "array_default_numeric_data"
       docs:
         - { "_id": 0, "a": [] }
-        - { "_id": 1, "a": [ 1 ], "x": 1 }
-        - { "_id": 2, "a": [ 1, 2, 3 ], "x": 2 }
-        - { "_id": 3, "a": [ 1, null, 3 ], "x": null}
+        - { "_id": 1, "a": [ 1 ] }
+        - { "_id": 2, "a": [ 1, 2, 3 ] }
+        - { "_id": 3, "a": [ 1, null, 3 ] }
         - { "_id": 4, "a": null }
         - { "_id": 5 }
+    schema:
+      bsonType: "object"
+      required: [ "_id" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          anyOf:
+            - bsonType: "array"
+              items:
+                anyOf:
+                  - bsonType: "int"
+                  - bsonType: !!str "null"
+            - bsonType: !!str "null"
+
+  # Data for ARRAY_REMOVE(a, x), where x is a field reference. Covers both x NULL with no NULL
+  # elements in a, and x non-NULL with a NULL element in a.
+  - db: "spec_query_array_functions"
+    collection:
+      name: "array_remove_correctness"
+      docs:
+        - { "_id": 0, "a": [], "x": 1 }
+        - { "_id": 1, "a": [ 1 ], "x": 1 }
+        - { "_id": 2, "a": [ -1, 1, 2 ], "x": 1 }
+        - { "_id": 3, "a": [ 1, null, 3 ], "x": null }
+        - { "_id": 4, "a": null, "x": 1 }
+        - { "_id": 5, "x": 1 }
+        - { "_id": 6, "a": [ -1, 1, 2 ], "x": null }
+        - { "_id": 7, "a": [ 1, null, 3 ], "x": 1 }
+        - { "_id": 8, "a": [ 1, 2, 3 ] }
     schema:
       bsonType: "object"
       required: [ "_id" ]

--- a/tests/spec_tests/query_tests/array_functions.yml
+++ b/tests/spec_tests/query_tests/array_functions.yml
@@ -52,25 +52,32 @@ tests:
 
   - description: ARRAY_REMOVE remove NULL correctness test
     current_db: spec_query_array_functions
-    query: "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, NULL) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
+    query: "SELECT VALUE { 'a': a, 'x': x, 'v': ARRAY_REMOVE(a, NULL) } FROM `array_remove_correctness` AS `array_remove_correctness`"
     result:
-      - { '': { "a": [], "v": [] } }
-      - { '': { "a": [1], "v": [1] } }
-      - { '': { "a": [1, 2, 3], "v": [1, 2, 3] } }
-      - { '': { "a": [1, null, 3], "v": [1, 3] } }
-      - { '': { "a": null, "v": null } }
-      - { '': { "v": null } }
+      - { '': { "a": [ ], "x": 1, "v": [ ] } }
+      - { '': { "a": [ 1 ], "x": 1, "v": [ 1 ] } }
+      - { '': { "a": [ -1, 1, 2 ], "x": 1, "v": [ -1, 1, 2 ] } }
+      - { '': { "a": [ 1, null, 3 ], "x": null, "v": [ 1, 3 ] } }
+      - { '': { "a": null, "x": 1, "v": null } }
+      - { '': { "x": 1, "v": null } }
+      - { '': { "a": [ -1, 1, 2 ], "x": null, "v": [ -1, 1, 2 ] } }
+      - { '': { "a": [ 1, null, 3 ], "x": 1, "v": [ 1, 3 ] } }
+      - { '': { "a": [ 1, 2, 3 ], "v": [ 1, 2, 3 ] } }
 
+  # When x is NULL, NULL elements are removed; when x is non-NULL, NULL elements are retained.
   - description: ARRAY_REMOVE remove field correctness test
     current_db: spec_query_array_functions
-    query: "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, x) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
+    query: "SELECT VALUE { 'a': a, 'x': x, 'v': ARRAY_REMOVE(a, x) } FROM `array_remove_correctness` AS `array_remove_correctness`"
     result:
-      - { '': { "a": [ ], "v": [ ] } }
-      - { '': { "a": [ 1 ], "v": [  ] } }
-      - { '': { "a": [ 1, 2, 3 ], "v": [ 1, 3 ] } }
-      - { '': { "a": [ 1, null, 3 ], "v": [ 1, 3 ] } }
-      - { '': { "a": null, "v": null } }
-      - { '': { "v": null } }
+      - { '': { "a": [ ], "x": 1, "v": [ ] } }
+      - { '': { "a": [ 1 ], "x": 1, "v": [ ] } }
+      - { '': { "a": [ -1, 1, 2 ], "x": 1, "v": [ -1, 2 ] } }
+      - { '': { "a": [ 1, null, 3 ], "x": null, "v": [ 1, 3 ] } }
+      - { '': { "a": null, "x": 1, "v": null } }
+      - { '': { "x": 1, "v": null } }
+      - { '': { "a": [ -1, 1, 2 ], "x": null, "v": [ -1, 1, 2 ] } }
+      - { '': { "a": [ 1, null, 3 ], "x": 1, "v": [ null, 3 ] } }
+      - { '': { "a": [ 1, 2, 3 ], "v": [ 1, 2, 3 ] } }
 
   # ARRAY_COUNT_IF counts the number of elements in the input array that satisfy the provided predicate
   - description: ARRAY_COUNT_IF correctness test

--- a/tests/spec_tests/query_tests/array_functions.yml
+++ b/tests/spec_tests/query_tests/array_functions.yml
@@ -42,7 +42,6 @@ tests:
   - description: ARRAY_REMOVE correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, 1) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3387: Implement ARRAY_REMOVE"
     result:
       - { '': { "a": [], "v": [] } }
       - { '': { "a": [1], "v": [] } }
@@ -54,7 +53,6 @@ tests:
   - description: ARRAY_REMOVE remove NULL correctness test
     current_db: spec_query_array_functions
     query: "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, NULL) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
-    skip_reason: "SQL-3387: Implement ARRAY_REMOVE"
     result:
       - { '': { "a": [], "v": [] } }
       - { '': { "a": [1], "v": [1] } }

--- a/tests/spec_tests/query_tests/array_functions.yml
+++ b/tests/spec_tests/query_tests/array_functions.yml
@@ -61,6 +61,17 @@ tests:
       - { '': { "a": null, "v": null } }
       - { '': { "v": null } }
 
+  - description: ARRAY_REMOVE remove field correctness test
+    current_db: spec_query_array_functions
+    query: "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, x) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
+    result:
+      - { '': { "a": [ ], "v": [ ] } }
+      - { '': { "a": [ 1 ], "v": [  ] } }
+      - { '': { "a": [ 1, 2, 3 ], "v": [ 1, 3 ] } }
+      - { '': { "a": [ 1, null, 3 ], "v": [ 1, 3 ] } }
+      - { '': { "a": null, "v": null } }
+      - { '': { "v": null } }
+
   # ARRAY_COUNT_IF counts the number of elements in the input array that satisfy the provided predicate
   - description: ARRAY_COUNT_IF correctness test
     current_db: spec_query_array_functions

--- a/tests/spec_tests/query_tests/higher_order_functions.yml
+++ b/tests/spec_tests/query_tests/higher_order_functions.yml
@@ -20,6 +20,17 @@ tests:
       - { '': { "a": [1, null, 3], "v": [1, 3] } }
       - { '': { "a": null, "v": null } }
       - { '': { "v": null } }
+  - description: FILTER against field correctness test
+    current_db: spec_query_higher_order_functions
+    query: "SELECT VALUE { 'a': a, 'v': FILTER(a, this <> x) } FROM `filter` AS `filter`"
+    result:
+      - { '': { "a": [ ], "v": [ ] } }
+      - { '': { "a": [ 1 ], "v": [ ] } }
+      - { '': { "a": [ -1, 1, 2 ], "v": [ 1, 2 ] } }
+      - { '': { "a": [ 1, null, 3 ], "v": [ 1, 3 ] } }
+      - { '': { "a": null, "v": null } }
+      - { '': { "v": null } }
+
 
   - description: REDUCE correctness test
     current_db: spec_query_higher_order_functions

--- a/tests/spec_tests/query_tests/higher_order_functions.yml
+++ b/tests/spec_tests/query_tests/higher_order_functions.yml
@@ -20,17 +20,6 @@ tests:
       - { '': { "a": [1, null, 3], "v": [1, 3] } }
       - { '': { "a": null, "v": null } }
       - { '': { "v": null } }
-  - description: FILTER against field correctness test
-    current_db: spec_query_higher_order_functions
-    query: "SELECT VALUE { 'a': a, 'v': FILTER(a, this <> x) } FROM `filter` AS `filter`"
-    result:
-      - { '': { "a": [ ], "v": [ ] } }
-      - { '': { "a": [ 1 ], "v": [ ] } }
-      - { '': { "a": [ -1, 1, 2 ], "v": [ 1, 2 ] } }
-      - { '': { "a": [ 1, null, 3 ], "v": [ 1, 3 ] } }
-      - { '': { "a": null, "v": null } }
-      - { '': { "v": null } }
-
 
   - description: REDUCE correctness test
     current_db: spec_query_higher_order_functions

--- a/tests/spec_tests/rewrite_tests/array_functions.yml
+++ b/tests/spec_tests/rewrite_tests/array_functions.yml
@@ -17,9 +17,13 @@ tests:
     query: "SELECT ARRAY_COMPACT(`array`) FROM foo"
     result: "SELECT VALUE {'_1': FILTER(`array`, NOT this IS NULL)} FROM foo AS foo"
 
-  - description: Rewrite ARRAY_REMOVE to FILTER
+  - description: Rewrite ARRAY_REMOVE against a field to FILTER
     query: "SELECT ARRAY_REMOVE(`array`, x) FROM foo"
-    result: "SELECT VALUE {'_1': FILTER(`array`, this <> x)} FROM foo AS foo"
+    result: "SELECT VALUE {'_1': FILTER(`array`, NOT (this IS NULL AND x IS NULL) AND (this IS NULL OR (x IS NULL OR this <> x)))} FROM foo AS foo"
+
+  - description: Rewrite ARRAY_REMOVE against null literal to FILTER
+    query: "SELECT ARRAY_REMOVE(`array`, null) FROM foo"
+    result: "SELECT VALUE {'_1': FILTER(`array`, this <> NULL)} FROM foo AS foo"
 
   - description: Rewrite ARRAY_COUNT_IF to FILTER
     query: "SELECT ARRAY_COUNT_IF(`array`, this > y) FROM foo"

--- a/tests/spec_tests/rewrite_tests/array_functions.yml
+++ b/tests/spec_tests/rewrite_tests/array_functions.yml
@@ -21,10 +21,6 @@ tests:
     query: "SELECT ARRAY_REMOVE(`array`, x) FROM foo"
     result: "SELECT VALUE {'_1': FILTER(`array`, NOT (this IS NULL AND x IS NULL) AND (this IS NULL OR (x IS NULL OR this <> x)))} FROM foo AS foo"
 
-  - description: Rewrite ARRAY_REMOVE against null literal to FILTER
-    query: "SELECT ARRAY_REMOVE(`array`, null) FROM foo"
-    result: "SELECT VALUE {'_1': FILTER(`array`, this <> NULL)} FROM foo AS foo"
-
   - description: Rewrite ARRAY_COUNT_IF to FILTER
     query: "SELECT ARRAY_COUNT_IF(`array`, this > y) FROM foo"
     result: "SELECT VALUE {'_1': SIZE(FILTER(`array`, this > y))} FROM foo AS foo"


### PR DESCRIPTION
## Summary

This pull request updates the rewrite_array_remove() function to add null checks against the remove_expr, and the element being compared 'this', so that we can ensure we keep null elements if null is not explicitly being filtered out.
