### PR TITLE
[SQL-3427] $expr language for mismatched bound types

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -792,8 +792,7 @@ functions:
         working_dir: mongosql-rs/testdata
         script: |
           ${prepare_shell}
-          curl -LO https://mongosql-noexpire.s3.us-east-2.amazonaws.com/schema_manager/schema-builder-library.tar.gz
-
+          curl -LO https://mongosql-noexpire.s3.us-east-2.amazonaws.com/schema_manager/schema-builder-library-new.tar.gz
   "decompress schema-builder-library testdata":
     - command: shell.exec
       params:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -804,7 +804,7 @@ functions:
           rm -rf testdata/schema-builder-library/
           echo "Removal complete"
           echo "Decompressing integration test data..."
-          tar -xzvf testdata/schema-builder-library.tar.gz --directory testdata
+          tar -xzvf testdata/schema-builder-library-new.tar.gz --directory testdata
           echo "Decompression complete"
 
   "generate static code analysis":

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -792,7 +792,7 @@ functions:
         working_dir: mongosql-rs/testdata
         script: |
           ${prepare_shell}
-          curl -LO https://mongosql-noexpire.s3.us-east-2.amazonaws.com/schema_manager/schema-builder-library-new.tar.gz
+          curl -LO https://mongosql-noexpire.s3.us-east-2.amazonaws.com/schema_manager/schema-builder-library.tar.gz
   "decompress schema-builder-library testdata":
     - command: shell.exec
       params:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -804,7 +804,7 @@ functions:
           rm -rf testdata/schema-builder-library/
           echo "Removal complete"
           echo "Decompressing integration test data..."
-          tar -xzvf testdata/schema-builder-library-new.tar.gz --directory testdata
+          tar -xzvf testdata/schema-builder-library.tar.gz --directory testdata
           echo "Decompression complete"
 
   "generate static code analysis":

--- a/schema-builder-library/README.md
+++ b/schema-builder-library/README.md
@@ -16,7 +16,7 @@ The goals of this project are:
 The `schema-builder-library` integration tests cover library method correctness against a live
 database. These tests require a running enterprise mongod server (version at least 6.0). They also
 require that data be loaded in before running the tests. The data is
-stored [here](https://mongosql-noexpire.s3.us-east-2.amazonaws.com/schema_manager/schema-builder-library.tar.gz).
+stored [here](https://mongosql-noexpire.s3.us-east-2.amazonaws.com/schema_manager/schema-builder-library-new.tar.gz).
 After decompressing the data, to load it into the database,
 use the [sql-engines-common-test-infra](https://github.com/mongodb/sql-engines-common-test-infra)
 `data-loader` tool. See `cargo run --bin data-loader -- --help` in that repo for more details.

--- a/schema-builder-library/src/internal_integration_tests/consts.rs
+++ b/schema-builder-library/src/internal_integration_tests/consts.rs
@@ -110,6 +110,13 @@ lazy_static! {
         is_max_bound_inclusive: true,
     },];
 
+    pub static ref MISMATCHED_ID_TYPES_PARTITIONS: Vec<Partition> = vec![Partition {
+        min: Bson::Int64(1),
+        max: Bson::String("Z".to_string()),
+        is_max_bound_inclusive: true,
+    },];
+
+
     // Using the same math above, we know that
     // 90MB / 400B = 235929
     pub static ref NUM_DOCS_IN_SMALL_COLLECTION: i64 =

--- a/schema-builder-library/src/internal_integration_tests/get_partitions.rs
+++ b/schema-builder-library/src/internal_integration_tests/get_partitions.rs
@@ -1,5 +1,10 @@
-use test_utils::schema_builder_library_integration_test_consts::{MISMATCHED_TYPES_COLL_NAME, MISMATCHED_TYPES_DB_NAME};
-use crate::internal_integration_tests::consts::{DEFAULT_COLLECTION_INFO, DEFAULT_HINT, DEFAULT_PARTITION_KEY, MISMATCHED_ID_TYPES_PARTITIONS, SMALL_PARTITIONS};
+use crate::internal_integration_tests::consts::{
+    DEFAULT_COLLECTION_INFO, DEFAULT_HINT, DEFAULT_PARTITION_KEY, MISMATCHED_ID_TYPES_PARTITIONS,
+    SMALL_PARTITIONS,
+};
+use test_utils::schema_builder_library_integration_test_consts::{
+    MISMATCHED_TYPES_COLL_NAME, MISMATCHED_TYPES_DB_NAME,
+};
 
 macro_rules! test_get_partitions {
     ($test_name:ident, expected = $expected:expr, input_db = $input_db:expr, input_coll = $input_coll:expr $(, ignore = $ignore:expr)?) => {

--- a/schema-builder-library/src/internal_integration_tests/get_partitions.rs
+++ b/schema-builder-library/src/internal_integration_tests/get_partitions.rs
@@ -1,6 +1,5 @@
-use crate::internal_integration_tests::consts::{
-    DEFAULT_COLLECTION_INFO, DEFAULT_HINT, DEFAULT_PARTITION_KEY, SMALL_PARTITIONS,
-};
+use test_utils::schema_builder_library_integration_test_consts::{MISMATCHED_TYPES_COLL_NAME, MISMATCHED_TYPES_DB_NAME};
+use crate::internal_integration_tests::consts::{DEFAULT_COLLECTION_INFO, DEFAULT_HINT, DEFAULT_PARTITION_KEY, MISMATCHED_ID_TYPES_PARTITIONS, SMALL_PARTITIONS};
 
 macro_rules! test_get_partitions {
     ($test_name:ident, expected = $expected:expr, input_db = $input_db:expr, input_coll = $input_coll:expr $(, ignore = $ignore:expr)?) => {
@@ -79,6 +78,13 @@ test_get_partitions!(
     expected = SMALL_PARTITIONS,
     input_db = NONUNIFORM_DB_NAME,
     input_coll = SMALL_COLL_NAME
+);
+
+test_get_partitions!(
+    mismatched_types_small,
+    expected = MISMATCHED_ID_TYPES_PARTITIONS,
+    input_db = MISMATCHED_TYPES_DB_NAME,
+    input_coll = MISMATCHED_TYPES_COLL_NAME
 );
 
 #[cfg(feature = "integration")]

--- a/schema-builder-library/src/partitioning/partition.rs
+++ b/schema-builder-library/src/partitioning/partition.rs
@@ -22,6 +22,33 @@ fn bounds_are_comparable(min: &Bson, max: &Bson) -> bool {
         || min.element_type() == max.element_type()
 }
 
+/// Returns the string `$type` reports for `bound`, for use in `$expr` type predicates.
+fn type_name(bound: &Bson) -> &'static str {
+    match bound {
+        Bson::Double(_) => "double",
+        Bson::String(_) => "string",
+        Bson::Array(_) => "array",
+        Bson::Document(_) => "object",
+        Bson::Boolean(_) => "bool",
+        Bson::Null => "null",
+        Bson::RegularExpression(_) => "regex",
+        Bson::JavaScriptCode(_) => "javascript",
+        Bson::JavaScriptCodeWithScope(_) => "javascriptWithScope",
+        Bson::Int32(_) => "int",
+        Bson::Int64(_) => "long",
+        Bson::Timestamp(_) => "timestamp",
+        Bson::Binary(_) => "binData",
+        Bson::ObjectId(_) => "objectId",
+        Bson::DateTime(_) => "date",
+        Bson::Symbol(_) => "symbol",
+        Bson::Decimal128(_) => "decimal",
+        Bson::Undefined => "undefined",
+        Bson::MaxKey => "maxKey",
+        Bson::MinKey => "minKey",
+        Bson::DbPointer(_) => "dbPointer",
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct Partition {
     pub min: Bson,
@@ -34,6 +61,9 @@ impl Partition {
     // optional schema, and a list of _id values to ignore. If the Schema is None, the $match will
     // only be based on the Partition bounds and the ignored_ids list.
     // If the min and max bounds are not comparable in match language, the $expr language will be used.
+    //
+    // Both branches share the same logic: a document is in the partition if its partition key type
+    // matches the type of one of the bounds.
     #[instrument(level = "trace", skip_all)]
     pub fn generate_match(
         &self,
@@ -51,14 +81,27 @@ impl Partition {
         // $expr language
         if !bounds_are_comparable(&self.min, &self.max) {
             let key_path = format!("${partition_key}");
+            // Each bound constrains only documents of that bound's own BSON type. Note that partition key
+            // values whose type matches neither bound are excluded.
+            // So if the bound types are (ObjectId, String) but some ids are Int32, those ids will be excluded.
             let mut expr_body = doc! {
                 "$expr": {
                     "$and": [
-                        doc! {"$gte": [&key_path, self.min.clone()]},
-                        doc! {lt_op: [&key_path, self.max.clone()]},
                         // $literal keeps a $-prefixed ignored value from being read as a
                         // field path.
                         doc! {"$not": {"$in": [&key_path, {"$literal": ignored_ids.to_vec()}]}},
+                        doc! {
+                            "$or": [
+                                doc! {"$and": [
+                                    doc! {"$eq": [{"$type": &key_path}, type_name(&self.min)]},
+                                    doc! {"$gte": [&key_path, self.min.clone()]},
+                                ]},
+                                doc! {"$and": [
+                                    doc! {"$eq": [{"$type": &key_path}, type_name(&self.max)]},
+                                    doc! {lt_op: [&key_path, self.max.clone()]},
+                                ]},
+                            ]
+                        },
                     ]
                 }
             };

--- a/schema-builder-library/src/partitioning/partition.rs
+++ b/schema-builder-library/src/partitioning/partition.rs
@@ -3,6 +3,25 @@ use tracing::instrument;
 
 pub const PARTITION_SIZE_IN_BYTES: i64 = 100 * 1024 * 1024; // 100 MB
 
+/// Returns true when `min` and `max` can be compared using match-language range operators.
+fn bounds_are_comparable(min: &Bson, max: &Bson) -> bool {
+    fn is_wildcard(bound: &Bson) -> bool {
+        matches!(bound, Bson::MinKey | Bson::MaxKey)
+    }
+
+    fn is_numeric(bound: &Bson) -> bool {
+        matches!(
+            bound,
+            Bson::Int32(_) | Bson::Int64(_) | Bson::Double(_) | Bson::Decimal128(_)
+        )
+    }
+
+    is_wildcard(min)
+        || is_wildcard(max)
+        || (is_numeric(min) && is_numeric(max))
+        || min.element_type() == max.element_type()
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct Partition {
     pub min: Bson,
@@ -27,18 +46,45 @@ impl Partition {
             "$lt"
         };
 
-        let mut match_body = doc! {
-            partition_key: {
-                "$nin": ignored_ids,
-                "$gte": self.min.clone(),
-                lt_op: self.max.clone(),
+        // If the min and max bounds are not comparable in match language, fall back to the
+        // $expr language, whose comparison operators do not order values across BSON types.
+        if !bounds_are_comparable(&self.min, &self.max) {
+            let key_path = format!("${partition_key}");
+            let mut expr_body = doc! {
+                "$expr": {
+                    "$and": [
+                        doc! {"$gte": [&key_path, self.min.clone()]},
+                        doc! {lt_op: [&key_path, self.max.clone()]},
+                        // $literal keeps a $-prefixed ignored value from being read as a
+                        // field path.
+                        doc! {"$not": {"$in": [&key_path, {"$literal": ignored_ids.to_vec()}]}},
+                    ]
+                }
+            };
+
+            // $jsonSchema has no $expr equivalent, so the schema exclusion stays in match
+            // language as a sibling of $expr, which is valid within a single $match.
+            if let Some(schema) = doc {
+                expr_body.insert("$nor", vec![schema]);
             }
-        };
-        if let Some(schema) = doc {
-            match_body.insert("$nor", vec![schema]);
-        }
-        doc! {
-            "$match": match_body
+
+            doc! {
+                "$match": expr_body
+            }
+        } else {
+            let mut match_body = doc! {
+                partition_key: {
+                    "$nin": ignored_ids,
+                    "$gte": self.min.clone(),
+                    lt_op: self.max.clone(),
+                }
+            };
+            if let Some(schema) = doc {
+                match_body.insert("$nor", vec![schema]);
+            }
+            doc! {
+                "$match": match_body
+            }
         }
     }
 }

--- a/schema-builder-library/src/partitioning/partition.rs
+++ b/schema-builder-library/src/partitioning/partition.rs
@@ -33,6 +33,7 @@ impl Partition {
     // generate_partition_match generates the $match stage for sampling based on the partition, an
     // optional schema, and a list of _id values to ignore. If the Schema is None, the $match will
     // only be based on the Partition bounds and the ignored_ids list.
+    // If the min and max bounds are not comparable in match language, the $expr language will be used.
     #[instrument(level = "trace", skip_all)]
     pub fn generate_match(
         &self,
@@ -47,7 +48,7 @@ impl Partition {
         };
 
         // If the min and max bounds are not comparable in match language, fall back to the
-        // $expr language, whose comparison operators do not order values across BSON types.
+        // $expr language
         if !bounds_are_comparable(&self.min, &self.max) {
             let key_path = format!("${partition_key}");
             let mut expr_body = doc! {

--- a/schema-builder-library/src/partitioning/partition.rs
+++ b/schema-builder-library/src/partitioning/partition.rs
@@ -5,10 +5,6 @@ pub const PARTITION_SIZE_IN_BYTES: i64 = 100 * 1024 * 1024; // 100 MB
 
 /// Returns true when `min` and `max` can be compared using match-language range operators.
 fn bounds_are_comparable(min: &Bson, max: &Bson) -> bool {
-    fn is_wildcard(bound: &Bson) -> bool {
-        matches!(bound, Bson::MinKey | Bson::MaxKey)
-    }
-
     fn is_numeric(bound: &Bson) -> bool {
         matches!(
             bound,
@@ -16,10 +12,7 @@ fn bounds_are_comparable(min: &Bson, max: &Bson) -> bool {
         )
     }
 
-    is_wildcard(min)
-        || is_wildcard(max)
-        || (is_numeric(min) && is_numeric(max))
-        || min.element_type() == max.element_type()
+    (is_numeric(min) && is_numeric(max)) || min.element_type() == max.element_type()
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/schema-builder-library/src/partitioning/partition.rs
+++ b/schema-builder-library/src/partitioning/partition.rs
@@ -22,33 +22,6 @@ fn bounds_are_comparable(min: &Bson, max: &Bson) -> bool {
         || min.element_type() == max.element_type()
 }
 
-/// Returns the string `$type` reports for `bound`, for use in `$expr` type predicates.
-fn type_name(bound: &Bson) -> &'static str {
-    match bound {
-        Bson::Double(_) => "double",
-        Bson::String(_) => "string",
-        Bson::Array(_) => "array",
-        Bson::Document(_) => "object",
-        Bson::Boolean(_) => "bool",
-        Bson::Null => "null",
-        Bson::RegularExpression(_) => "regex",
-        Bson::JavaScriptCode(_) => "javascript",
-        Bson::JavaScriptCodeWithScope(_) => "javascriptWithScope",
-        Bson::Int32(_) => "int",
-        Bson::Int64(_) => "long",
-        Bson::Timestamp(_) => "timestamp",
-        Bson::Binary(_) => "binData",
-        Bson::ObjectId(_) => "objectId",
-        Bson::DateTime(_) => "date",
-        Bson::Symbol(_) => "symbol",
-        Bson::Decimal128(_) => "decimal",
-        Bson::Undefined => "undefined",
-        Bson::MaxKey => "maxKey",
-        Bson::MinKey => "minKey",
-        Bson::DbPointer(_) => "dbPointer",
-    }
-}
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct Partition {
     pub min: Bson,
@@ -62,8 +35,8 @@ impl Partition {
     // only be based on the Partition bounds and the ignored_ids list.
     // If the min and max bounds are not comparable in match language, the $expr language will be used.
     //
-    // Both branches share the same logic: a document is in the partition if its partition key type
-    // matches the type of one of the bounds.
+    //  $expr comparisons use BSON total ort order, so a partition key of any type can fall between the bounds, while match language
+    // is type-bracketed and only matches keys that have the exact type as bound's type.
     #[instrument(level = "trace", skip_all)]
     pub fn generate_match(
         &self,
@@ -81,27 +54,14 @@ impl Partition {
         // $expr language
         if !bounds_are_comparable(&self.min, &self.max) {
             let key_path = format!("${partition_key}");
-            // Each bound constrains only documents of that bound's own BSON type. Note that partition key
-            // values whose type matches neither bound are excluded.
-            // So if the bound types are (ObjectId, String) but some ids are Int32, those ids will be excluded.
             let mut expr_body = doc! {
                 "$expr": {
                     "$and": [
                         // $literal keeps a $-prefixed ignored value from being read as a
                         // field path.
                         doc! {"$not": {"$in": [&key_path, {"$literal": ignored_ids.to_vec()}]}},
-                        doc! {
-                            "$or": [
-                                doc! {"$and": [
-                                    doc! {"$eq": [{"$type": &key_path}, type_name(&self.min)]},
-                                    doc! {"$gte": [&key_path, self.min.clone()]},
-                                ]},
-                                doc! {"$and": [
-                                    doc! {"$eq": [{"$type": &key_path}, type_name(&self.max)]},
-                                    doc! {lt_op: [&key_path, self.max.clone()]},
-                                ]},
-                            ]
-                        },
+                        doc! {"$gte": [&key_path, self.min.clone()]},
+                        doc! {lt_op: [&key_path, self.max.clone()]},
                     ]
                 }
             };

--- a/schema-builder-library/src/partitioning/partition.rs
+++ b/schema-builder-library/src/partitioning/partition.rs
@@ -46,9 +46,23 @@ impl Partition {
             "$lt"
         };
 
-        // If the min and max bounds are not comparable in match language, fall back to the
-        // $expr language
-        if !bounds_are_comparable(&self.min, &self.max) {
+        if bounds_are_comparable(&self.min, &self.max) {
+            let mut match_body = doc! {
+                partition_key: {
+                    "$nin": ignored_ids,
+                    "$gte": self.min.clone(),
+                    lt_op: self.max.clone(),
+                }
+            };
+            if let Some(schema) = doc {
+                match_body.insert("$nor", vec![schema]);
+            }
+            doc! {
+                "$match": match_body
+            }
+        } else {
+            // If the min and max bounds are not comparable in match language, fall back to
+            // $expr language
             let key_path = format!("${partition_key}");
             let mut expr_body = doc! {
                 "$expr": {
@@ -70,20 +84,6 @@ impl Partition {
 
             doc! {
                 "$match": expr_body
-            }
-        } else {
-            let mut match_body = doc! {
-                partition_key: {
-                    "$nin": ignored_ids,
-                    "$gte": self.min.clone(),
-                    lt_op: self.max.clone(),
-                }
-            };
-            if let Some(schema) = doc {
-                match_body.insert("$nor", vec![schema]);
-            }
-            doc! {
-                "$match": match_body
             }
         }
     }

--- a/schema-builder-library/src/partitioning/partition.rs
+++ b/schema-builder-library/src/partitioning/partition.rs
@@ -4,6 +4,7 @@ use tracing::instrument;
 pub const PARTITION_SIZE_IN_BYTES: i64 = 100 * 1024 * 1024; // 100 MB
 
 /// Returns true when `min` and `max` can be compared using match-language range operators.
+/// They can be compared if they are both numeric types, if they are the same type, or if one is MinKey and the other is MaxKey
 fn bounds_are_comparable(min: &Bson, max: &Bson) -> bool {
     fn is_numeric(bound: &Bson) -> bool {
         matches!(
@@ -12,7 +13,9 @@ fn bounds_are_comparable(min: &Bson, max: &Bson) -> bool {
         )
     }
 
-    (is_numeric(min) && is_numeric(max)) || min.element_type() == max.element_type()
+    (is_numeric(min) && is_numeric(max))
+        || min.element_type() == max.element_type()
+        || matches!((min, max), (Bson::MinKey, Bson::MaxKey))
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -28,8 +31,8 @@ impl Partition {
     // only be based on the Partition bounds and the ignored_ids list.
     // If the min and max bounds are not comparable in match language, the $expr language will be used.
     //
-    //  $expr comparisons use BSON total ort order, so a partition key of any type can fall between the bounds, while match language
-    // is type-bracketed and only matches keys that have the exact type as bound's type.
+    //  $expr comparisons use BSON total sort order, so a partition key of any type can fall between the bounds, while match language
+    // is type-bracketed and only matches keys that have the same type as the bound.
     #[instrument(level = "trace", skip_all)]
     pub fn generate_match(
         &self,

--- a/schema-builder-library/src/partitioning/test.rs
+++ b/schema-builder-library/src/partitioning/test.rs
@@ -26,10 +26,18 @@ mod test {
             doc! {
                 "$match": {
                     "$expr": {
-                           "$and": [
-                            {"$gte": ["$_id", Bson::String("my_user_id".to_string())]},
-                            {"$lte": ["$_id", Bson::Int64(5000)]},
-                            {"$not": {"$in": ["$_id", {"$literal": vec![Bson::Int64(100), Bson::Int64(200)]}]}}
+                        "$and": [
+                            {"$not": {"$in": ["$_id", {"$literal": vec![Bson::Int64(100), Bson::Int64(200)]}]}},
+                            {"$or": [
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "string"]},
+                                    {"$gte": ["$_id", Bson::String("my_user_id".to_string())]}
+                                ]},
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "long"]},
+                                    {"$lte": ["$_id", Bson::Int64(5000)]}
+                                ]}
+                            ]}
                         ]
                     }
                 }
@@ -67,9 +75,17 @@ mod test {
                 "$match": {
                     "$expr": {
                         "$and": [
-                            {"$gte": ["$_id", Bson::Int64(0)]},
-                            {"$lte": ["$_id", Bson::String("my_user_id".to_string())]},
-                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}}
+                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
+                            {"$or": [
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "long"]},
+                                    {"$gte": ["$_id", Bson::Int64(0)]}
+                                ]},
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "string"]},
+                                    {"$lte": ["$_id", Bson::String("my_user_id".to_string())]}
+                                ]}
+                            ]}
                         ]
                     },
                     "$nor": [{
@@ -144,9 +160,17 @@ mod test {
                 "$match": {
                     "$expr": {
                         "$and": [
-                            {"$gte": ["$_id", Bson::String("my_user_id".to_string())]},
-                            {"$lt": ["$_id", Bson::Int64(5000)]},
-                            {"$not": {"$in": ["$_id", {"$literal": vec![Bson::Int64(100)]}]}}
+                            {"$not": {"$in": ["$_id", {"$literal": vec![Bson::Int64(100)]}]}},
+                            {"$or": [
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "string"]},
+                                    {"$gte": ["$_id", Bson::String("my_user_id".to_string())]}
+                                ]},
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "long"]},
+                                    {"$lt": ["$_id", Bson::Int64(5000)]}
+                                ]}
+                            ]}
                         ]
                     }
                 }
@@ -280,6 +304,79 @@ mod test {
                     "$nor": [{
                         "$jsonSchema": bson_schema
                     }]
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_generate_partition_match_with_mismatched_id_fields_dataset_bounds() {
+        // Bounds taken from the `mismatched_id_fields_small` dataset, whose `_id` values mix
+        // int64, string, and ObjectId. int64 and string are not comparable in match language,
+        // so this exercises the `$expr` fallback.
+        let partition = Partition {
+            min: Bson::Int64(10),
+            max: Bson::String("S".to_string()),
+            is_max_bound_inclusive: true,
+        };
+
+        let ignored_ids = vec![Bson::Int64(13), Bson::String("id_string_0001".to_string())];
+        let match_stage = partition.generate_match(None, &ignored_ids, &DEFAULT_PARTITION_KEY);
+        assert_eq!(
+            match_stage,
+            doc! {
+                "$match": {
+                    "$expr": {
+                        "$and": [
+                            {"$not": {"$in": ["$_id", {"$literal": ignored_ids.clone()}]}},
+                            {"$or": [
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "long"]},
+                                    {"$gte": ["$_id", Bson::Int64(10)]}
+                                ]},
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "string"]},
+                                    {"$lte": ["$_id", Bson::String("S".to_string())]}
+                                ]}
+                            ]}
+                        ]
+                    }
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_generate_partition_match_with_long_and_object_id_bounds_excludes_strings() {
+        // Only documents whose `_id` is a long or an ObjectId fall in this partition; string
+        // `_id`s sorting between the bounds are intentionally excluded.
+        let partition = Partition {
+            min: Bson::Int64(10),
+            max: Bson::ObjectId(ObjectId::new()),
+            is_max_bound_inclusive: true,
+        };
+
+        let ignored_ids = vec![Bson::Int64(13)];
+        let match_stage = partition.generate_match(None, &ignored_ids, &DEFAULT_PARTITION_KEY);
+        assert_eq!(
+            match_stage,
+            doc! {
+                "$match": {
+                    "$expr": {
+                        "$and": [
+                            {"$not": {"$in": ["$_id", {"$literal": ignored_ids.clone()}]}},
+                            {"$or": [
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "long"]},
+                                    {"$gte": ["$_id", Bson::Int64(10)]}
+                                ]},
+                                {"$and": [
+                                    {"$eq": [{"$type": "$_id"}, "objectId"]},
+                                    {"$lte": ["$_id", partition.max.clone()]}
+                                ]}
+                            ]}
+                        ]
+                    }
                 }
             }
         );

--- a/schema-builder-library/src/partitioning/test.rs
+++ b/schema-builder-library/src/partitioning/test.rs
@@ -155,32 +155,6 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_mismatched_bson_types_non_id_partition_key() {
-        let partition = Partition {
-            min: Bson::String("my_user_id".to_string()),
-            max: Bson::Int64(5000),
-            is_max_bound_inclusive: true,
-        };
-
-        let ignored_ids = vec![Bson::Int64(100)];
-        let match_stage = partition.generate_match(None, &ignored_ids, "timestamp");
-        assert_eq!(
-            match_stage,
-            doc! {
-                "$match": {
-                    "$expr": {
-                        "$and": [
-                            {"$gte": ["$timestamp", Bson::String("my_user_id".to_string())]},
-                            {"$lte": ["$timestamp", Bson::Int64(5000)]},
-                            {"$not": {"$in": ["$timestamp", {"$literal": vec![Bson::Int64(100)]}]}}
-                        ]
-                    }
-                }
-            }
-        );
-    }
-
-    #[test]
     fn test_generate_partition_match_without_schema_doc_max_bound_inclusive() {
         let partition = Partition {
             min: Bson::MinKey,

--- a/schema-builder-library/src/partitioning/test.rs
+++ b/schema-builder-library/src/partitioning/test.rs
@@ -12,6 +12,175 @@ mod test {
     use crate::partitioning::partition::PARTITION_SIZE_IN_BYTES;
 
     #[test]
+    fn test_generate_partition_match_with_mismatched_bson_types() {
+        let partition = Partition {
+            min: Bson::String("my_user_id".to_string()),
+            max: Bson::Int64(5000),
+            is_max_bound_inclusive: true,
+        };
+
+        let ignored_ids = vec![Bson::Int64(100), Bson::Int64(200)];
+        let match_stage = partition.generate_match(None, &ignored_ids, &DEFAULT_PARTITION_KEY);
+        assert_eq!(
+            match_stage,
+            doc! {
+                "$match": {
+                    "$expr": {
+                           "$and": [
+                            {"$gte": ["$_id", Bson::String("my_user_id".to_string())]},
+                            {"$lte": ["$_id", Bson::Int64(5000)]},
+                            {"$not": {"$in": ["$_id", {"$literal": vec![Bson::Int64(100), Bson::Int64(200)]}]}}
+                        ]
+                    }
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_generate_partition_match_with_mismatched_bson_types_and_schema() {
+        let partition = Partition {
+            min: Bson::Int64(0),
+            max: Bson::String("my_user_id".to_string()),
+            is_max_bound_inclusive: true,
+        };
+
+        let schema = schema_for_document(&doc! {
+            "name": "AzureDiamond",
+            "password": "hunter2",
+            "iq": 140,
+        });
+
+        let ignored_ids = vec![Bson::ObjectId(ObjectId::new())];
+        let match_stage = partition.generate_match(
+            Some(Document::try_from(schema.clone()).unwrap()),
+            &ignored_ids,
+            DEFAULT_PARTITION_KEY.as_str(),
+        );
+        let bson_schema = json_schema::Schema::try_from(schema)
+            .unwrap()
+            .to_bson()
+            .unwrap();
+        assert_eq!(
+            match_stage,
+            doc! {
+                "$match": {
+                    "$expr": {
+                        "$and": [
+                            {"$gte": ["$_id", Bson::Int64(0)]},
+                            {"$lte": ["$_id", Bson::String("my_user_id".to_string())]},
+                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}}
+                        ]
+                    },
+                    "$nor": [{
+                        "$jsonSchema": bson_schema
+                    }]
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_generate_partition_match_with_mixed_numeric_bounds_uses_match_language() {
+        let partition = Partition {
+            min: Bson::Int64(1),
+            max: Bson::Double(5000.0),
+            is_max_bound_inclusive: false,
+        };
+
+        let ignored_ids = vec![Bson::Int64(100)];
+        let match_stage = partition.generate_match(None, &ignored_ids, &DEFAULT_PARTITION_KEY);
+        assert_eq!(
+            match_stage,
+            doc! {
+                "$match": {
+                    "_id": {
+                        "$nin": [Bson::Int64(100)],
+                        "$gte": Bson::Int64(1),
+                        "$lt": Bson::Double(5000.0)
+                    }
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_generate_partition_match_with_wildcard_min_uses_match_language() {
+        let partition = Partition {
+            min: Bson::MinKey,
+            max: Bson::String("my_user_id".to_string()),
+            is_max_bound_inclusive: true,
+        };
+
+        let ignored_ids = vec![Bson::ObjectId(ObjectId::new())];
+        let match_stage = partition.generate_match(None, &ignored_ids, &DEFAULT_PARTITION_KEY);
+        assert_eq!(
+            match_stage,
+            doc! {
+                "$match": {
+                    "_id": {
+                        "$nin": [ignored_ids[0].clone()],
+                        "$gte": Bson::MinKey,
+                        "$lte": Bson::String("my_user_id".to_string())
+                    }
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_generate_partition_match_with_mismatched_bson_types_max_bound_exclusive() {
+        let partition = Partition {
+            min: Bson::String("my_user_id".to_string()),
+            max: Bson::Int64(5000),
+            is_max_bound_inclusive: false,
+        };
+
+        let ignored_ids = vec![Bson::Int64(100)];
+        let match_stage = partition.generate_match(None, &ignored_ids, &DEFAULT_PARTITION_KEY);
+        assert_eq!(
+            match_stage,
+            doc! {
+                "$match": {
+                    "$expr": {
+                        "$and": [
+                            {"$gte": ["$_id", Bson::String("my_user_id".to_string())]},
+                            {"$lt": ["$_id", Bson::Int64(5000)]},
+                            {"$not": {"$in": ["$_id", {"$literal": vec![Bson::Int64(100)]}]}}
+                        ]
+                    }
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_generate_partition_match_with_mismatched_bson_types_non_id_partition_key() {
+        let partition = Partition {
+            min: Bson::String("my_user_id".to_string()),
+            max: Bson::Int64(5000),
+            is_max_bound_inclusive: true,
+        };
+
+        let ignored_ids = vec![Bson::Int64(100)];
+        let match_stage = partition.generate_match(None, &ignored_ids, "timestamp");
+        assert_eq!(
+            match_stage,
+            doc! {
+                "$match": {
+                    "$expr": {
+                        "$and": [
+                            {"$gte": ["$timestamp", Bson::String("my_user_id".to_string())]},
+                            {"$lte": ["$timestamp", Bson::Int64(5000)]},
+                            {"$not": {"$in": ["$timestamp", {"$literal": vec![Bson::Int64(100)]}]}}
+                        ]
+                    }
+                }
+            }
+        );
+    }
+
+    #[test]
     fn test_generate_partition_match_without_schema_doc_max_bound_inclusive() {
         let partition = Partition {
             min: Bson::MinKey,

--- a/schema-builder-library/src/partitioning/test.rs
+++ b/schema-builder-library/src/partitioning/test.rs
@@ -105,7 +105,7 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_wildcard_min_uses_match_language() {
+    fn test_generate_partition_match_with_wildcard_min_uses_expr() {
         let partition = Partition {
             min: Bson::MinKey,
             max: Bson::String("my_user_id".to_string()),
@@ -118,10 +118,12 @@ mod test {
             match_stage,
             doc! {
                 "$match": {
-                    "_id": {
-                        "$nin": [ignored_ids[0].clone()],
-                        "$gte": Bson::MinKey,
-                        "$lte": Bson::String("my_user_id".to_string())
+                    "$expr": {
+                        "$and": [
+                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
+                            {"$gte": ["$_id", Bson::MinKey]},
+                            {"$lte": ["$_id", Bson::String("my_user_id".to_string())]}
+                        ]
                     }
                 }
             }
@@ -168,10 +170,12 @@ mod test {
             match_stage,
             doc! {
                 "$match": {
-                    "_id": {
-                        "$nin": [ignored_ids[0].clone()],
-                        "$gte": Bson::MinKey,
-                        "$lte": Bson::MaxKey
+                    "$expr": {
+                        "$and": [
+                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
+                            {"$gte": ["$_id", Bson::MinKey]},
+                            {"$lte": ["$_id", Bson::MaxKey]}
+                        ]
                     }
                 }
             }
@@ -193,10 +197,12 @@ mod test {
             match_stage,
             doc! {
                 "$match": {
-                    "_id": {
-                        "$nin": [ignored_ids[0].clone()],
-                        "$gte": Bson::MinKey,
-                        "$lt": Bson::MaxKey
+                    "$expr": {
+                        "$and": [
+                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
+                            {"$gte": ["$_id", Bson::MinKey]},
+                            {"$lt": ["$_id", Bson::MaxKey]}
+                        ]
                     }
                 }
             }
@@ -231,10 +237,12 @@ mod test {
             match_stage,
             doc! {
                 "$match": {
-                    "_id": {
-                        "$nin": [ignored_ids[0].clone()],
-                        "$gte": Bson::MinKey,
-                        "$lte": Bson::MaxKey
+                    "$expr": {
+                        "$and": [
+                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
+                            {"$gte": ["$_id", Bson::MinKey]},
+                            {"$lte": ["$_id", Bson::MaxKey]}
+                        ]
                     },
                     "$nor": [{
                         "$jsonSchema": bson_schema
@@ -272,10 +280,12 @@ mod test {
             match_stage,
             doc! {
                 "$match": {
-                    "_id": {
-                        "$nin": [ignored_ids[0].clone()],
-                        "$gte": Bson::MinKey,
-                        "$lt": Bson::MaxKey
+                    "$expr": {
+                        "$and": [
+                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
+                            {"$gte": ["$_id", Bson::MinKey]},
+                            {"$lt": ["$_id", Bson::MaxKey]}
+                        ]
                     },
                     "$nor": [{
                         "$jsonSchema": bson_schema

--- a/schema-builder-library/src/partitioning/test.rs
+++ b/schema-builder-library/src/partitioning/test.rs
@@ -38,7 +38,7 @@ mod test {
     }
 
     #[test]
-    fn generate_partition_match_with_mismatched_bson_types_and_schema_inclusive() {
+    fn generate_partition_match_with_mismatched_bson_types_with_schema_inclusive() {
         let partition = Partition {
             min: Bson::Int64(0),
             max: Bson::String("my_user_id".to_string()),
@@ -106,7 +106,7 @@ mod test {
     }
 
     #[test]
-    fn generate_partition_match_with_wildcard_min_uses_expr() {
+    fn generate_partition_match_with_wildcard_min_without_schema_inclusive_uses_expr() {
         let partition = Partition {
             min: Bson::MinKey,
             max: Bson::String("my_user_id".to_string()),
@@ -124,6 +124,32 @@ mod test {
                             {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
                             {"$gte": ["$_id", Bson::MinKey]},
                             {"$lte": ["$_id", Bson::String("my_user_id".to_string())]}
+                        ]
+                    }
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn generate_partition_match_with_wildcard_max_without_schema_inclusive_uses_expr() {
+        let partition = Partition {
+            min: Bson::String("my_user_id".to_string()),
+            max: Bson::MaxKey,
+            is_max_bound_inclusive: true,
+        };
+
+        let ignored_ids = vec![Bson::ObjectId(ObjectId::new())];
+        let match_stage = partition.generate_match(None, &ignored_ids, &DEFAULT_PARTITION_KEY);
+        assert_eq!(
+            match_stage,
+            doc! {
+                "$match": {
+                    "$expr": {
+                        "$and": [
+                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
+                            {"$gte": ["$_id", Bson::String("my_user_id".to_string())]},
+                            {"$lte": ["$_id", Bson::MaxKey]}
                         ]
                     }
                 }

--- a/schema-builder-library/src/partitioning/test.rs
+++ b/schema-builder-library/src/partitioning/test.rs
@@ -28,16 +28,8 @@ mod test {
                     "$expr": {
                         "$and": [
                             {"$not": {"$in": ["$_id", {"$literal": vec![Bson::Int64(100), Bson::Int64(200)]}]}},
-                            {"$or": [
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "string"]},
-                                    {"$gte": ["$_id", Bson::String("my_user_id".to_string())]}
-                                ]},
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "long"]},
-                                    {"$lte": ["$_id", Bson::Int64(5000)]}
-                                ]}
-                            ]}
+                            {"$gte": ["$_id", Bson::String("my_user_id".to_string())]},
+                            {"$lte": ["$_id", Bson::Int64(5000)]}
                         ]
                     }
                 }
@@ -76,16 +68,8 @@ mod test {
                     "$expr": {
                         "$and": [
                             {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
-                            {"$or": [
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "long"]},
-                                    {"$gte": ["$_id", Bson::Int64(0)]}
-                                ]},
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "string"]},
-                                    {"$lte": ["$_id", Bson::String("my_user_id".to_string())]}
-                                ]}
-                            ]}
+                            {"$gte": ["$_id", Bson::Int64(0)]},
+                            {"$lte": ["$_id", Bson::String("my_user_id".to_string())]}
                         ]
                     },
                     "$nor": [{
@@ -161,16 +145,8 @@ mod test {
                     "$expr": {
                         "$and": [
                             {"$not": {"$in": ["$_id", {"$literal": vec![Bson::Int64(100)]}]}},
-                            {"$or": [
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "string"]},
-                                    {"$gte": ["$_id", Bson::String("my_user_id".to_string())]}
-                                ]},
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "long"]},
-                                    {"$lt": ["$_id", Bson::Int64(5000)]}
-                                ]}
-                            ]}
+                            {"$gte": ["$_id", Bson::String("my_user_id".to_string())]},
+                            {"$lt": ["$_id", Bson::Int64(5000)]}
                         ]
                     }
                 }
@@ -329,16 +305,8 @@ mod test {
                     "$expr": {
                         "$and": [
                             {"$not": {"$in": ["$_id", {"$literal": ignored_ids.clone()}]}},
-                            {"$or": [
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "long"]},
-                                    {"$gte": ["$_id", Bson::Int64(10)]}
-                                ]},
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "string"]},
-                                    {"$lte": ["$_id", Bson::String("S".to_string())]}
-                                ]}
-                            ]}
+                            {"$gte": ["$_id", Bson::Int64(10)]},
+                            {"$lte": ["$_id", Bson::String("S".to_string())]}
                         ]
                     }
                 }
@@ -347,9 +315,10 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_long_and_object_id_bounds_excludes_strings() {
-        // Only documents whose `_id` is a long or an ObjectId fall in this partition; string
-        // `_id`s sorting between the bounds are intentionally excluded.
+    fn test_generate_partition_match_with_long_and_object_id_bounds() {
+        // `$expr` comparisons use BSON total sort order, so this partition covers every key
+        // between the bounds regardless of type -- including the string `_id`s that sort
+        // between longs and ObjectIds.
         let partition = Partition {
             min: Bson::Int64(10),
             max: Bson::ObjectId(ObjectId::new()),
@@ -365,16 +334,8 @@ mod test {
                     "$expr": {
                         "$and": [
                             {"$not": {"$in": ["$_id", {"$literal": ignored_ids.clone()}]}},
-                            {"$or": [
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "long"]},
-                                    {"$gte": ["$_id", Bson::Int64(10)]}
-                                ]},
-                                {"$and": [
-                                    {"$eq": [{"$type": "$_id"}, "objectId"]},
-                                    {"$lte": ["$_id", partition.max.clone()]}
-                                ]}
-                            ]}
+                            {"$gte": ["$_id", Bson::Int64(10)]},
+                            {"$lte": ["$_id", partition.max.clone()]}
                         ]
                     }
                 }

--- a/schema-builder-library/src/partitioning/test.rs
+++ b/schema-builder-library/src/partitioning/test.rs
@@ -12,7 +12,7 @@ mod test {
     use crate::partitioning::partition::PARTITION_SIZE_IN_BYTES;
 
     #[test]
-    fn test_generate_partition_match_with_mismatched_bson_types() {
+    fn generate_partition_match_with_mismatched_bson_types_without_schema_inclusive() {
         let partition = Partition {
             min: Bson::String("my_user_id".to_string()),
             max: Bson::Int64(5000),
@@ -38,7 +38,7 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_mismatched_bson_types_and_schema() {
+    fn generate_partition_match_with_mismatched_bson_types_and_schema_inclusive() {
         let partition = Partition {
             min: Bson::Int64(0),
             max: Bson::String("my_user_id".to_string()),
@@ -81,7 +81,8 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_mixed_numeric_bounds_uses_match_language() {
+    fn generate_partition_match_with_mixed_numeric_bounds_without_schema_exclusive_uses_match_language()
+     {
         let partition = Partition {
             min: Bson::Int64(1),
             max: Bson::Double(5000.0),
@@ -105,7 +106,7 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_wildcard_min_uses_expr() {
+    fn generate_partition_match_with_wildcard_min_uses_expr() {
         let partition = Partition {
             min: Bson::MinKey,
             max: Bson::String("my_user_id".to_string()),
@@ -131,7 +132,7 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_mismatched_bson_types_max_bound_exclusive() {
+    fn generate_partition_match_with_mismatched_bson_types_max_bound_exclusive() {
         let partition = Partition {
             min: Bson::String("my_user_id".to_string()),
             max: Bson::Int64(5000),
@@ -157,7 +158,7 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_without_schema_doc_max_bound_inclusive() {
+    fn generate_partition_match_without_schema_doc_max_bound_inclusive() {
         let partition = Partition {
             min: Bson::MinKey,
             max: Bson::MaxKey,
@@ -181,7 +182,7 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_without_schema_doc_max_bound_exclusive() {
+    fn generate_partition_match_without_schema_doc_max_bound_exclusive() {
         let partition = Partition {
             min: Bson::MinKey,
             max: Bson::MaxKey,
@@ -206,7 +207,7 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_schema_doc_max_bound_inclusive() {
+    fn generate_partition_match_with_schema_doc_max_bound_inclusive() {
         let partition = Partition {
             min: Bson::MinKey,
             max: Bson::MaxKey,
@@ -247,7 +248,7 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_schema_doc_max_bound_exclusive() {
+    fn generate_partition_match_with_schema_doc_max_bound_exclusive() {
         let partition = Partition {
             min: Bson::MinKey,
             max: Bson::MaxKey,
@@ -288,58 +289,43 @@ mod test {
     }
 
     #[test]
-    fn test_generate_partition_match_with_mismatched_id_fields_dataset_bounds() {
-        // Bounds taken from the `mismatched_id_fields_small` dataset, whose `_id` values mix
-        // int64, string, and ObjectId. int64 and string are not comparable in match language,
-        // so this exercises the `$expr` fallback.
+    fn generate_schema_with_mismatched_bson_types_with_schema_exclusive() {
         let partition = Partition {
-            min: Bson::Int64(10),
-            max: Bson::String("S".to_string()),
-            is_max_bound_inclusive: true,
+            min: Bson::Int64(0),
+            max: Bson::String("my_user_id".to_string()),
+            is_max_bound_inclusive: false,
         };
 
-        let ignored_ids = vec![Bson::Int64(13), Bson::String("id_string_0001".to_string())];
-        let match_stage = partition.generate_match(None, &ignored_ids, &DEFAULT_PARTITION_KEY);
-        assert_eq!(
-            match_stage,
-            doc! {
-                "$match": {
-                    "$expr": {
-                        "$and": [
-                            {"$not": {"$in": ["$_id", {"$literal": ignored_ids.clone()}]}},
-                            {"$gte": ["$_id", Bson::Int64(10)]},
-                            {"$lte": ["$_id", Bson::String("S".to_string())]}
-                        ]
-                    }
-                }
-            }
+        let schema = schema_for_document(&doc! {
+            "name": "AzureDiamond",
+            "password": "hunter2",
+            "iq": 140,
+        });
+
+        let ignored_ids = vec![Bson::ObjectId(ObjectId::new())];
+        let match_stage = partition.generate_match(
+            Some(Document::try_from(schema.clone()).unwrap()),
+            &ignored_ids,
+            DEFAULT_PARTITION_KEY.as_str(),
         );
-    }
-
-    #[test]
-    fn test_generate_partition_match_with_long_and_object_id_bounds() {
-        // `$expr` comparisons use BSON total sort order, so this partition covers every key
-        // between the bounds regardless of type -- including the string `_id`s that sort
-        // between longs and ObjectIds.
-        let partition = Partition {
-            min: Bson::Int64(10),
-            max: Bson::ObjectId(ObjectId::new()),
-            is_max_bound_inclusive: true,
-        };
-
-        let ignored_ids = vec![Bson::Int64(13)];
-        let match_stage = partition.generate_match(None, &ignored_ids, &DEFAULT_PARTITION_KEY);
+        let bson_schema = json_schema::Schema::try_from(schema)
+            .unwrap()
+            .to_bson()
+            .unwrap();
         assert_eq!(
             match_stage,
             doc! {
                 "$match": {
                     "$expr": {
                         "$and": [
-                            {"$not": {"$in": ["$_id", {"$literal": ignored_ids.clone()}]}},
-                            {"$gte": ["$_id", Bson::Int64(10)]},
-                            {"$lte": ["$_id", partition.max.clone()]}
+                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
+                            {"$gte": ["$_id", Bson::Int64(0)]},
+                            {"$lt": ["$_id", Bson::String("my_user_id".to_string())]}
                         ]
-                    }
+                    },
+                    "$nor": [{
+                        "$jsonSchema": bson_schema
+                    }]
                 }
             }
         );

--- a/schema-builder-library/src/partitioning/test.rs
+++ b/schema-builder-library/src/partitioning/test.rs
@@ -170,12 +170,10 @@ mod test {
             match_stage,
             doc! {
                 "$match": {
-                    "$expr": {
-                        "$and": [
-                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
-                            {"$gte": ["$_id", Bson::MinKey]},
-                            {"$lte": ["$_id", Bson::MaxKey]}
-                        ]
+                    "_id": {
+                        "$nin": &ignored_ids,
+                        "$gte": Bson::MinKey,
+                        "$lte": Bson::MaxKey
                     }
                 }
             }
@@ -197,12 +195,10 @@ mod test {
             match_stage,
             doc! {
                 "$match": {
-                    "$expr": {
-                        "$and": [
-                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
-                            {"$gte": ["$_id", Bson::MinKey]},
-                            {"$lt": ["$_id", Bson::MaxKey]}
-                        ]
+                    "_id": {
+                        "$nin": &ignored_ids,
+                        "$gte": Bson::MinKey,
+                        "$lt": Bson::MaxKey
                     }
                 }
             }
@@ -237,12 +233,10 @@ mod test {
             match_stage,
             doc! {
                 "$match": {
-                    "$expr": {
-                        "$and": [
-                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
-                            {"$gte": ["$_id", Bson::MinKey]},
-                            {"$lte": ["$_id", Bson::MaxKey]}
-                        ]
+                    "_id": {
+                        "$nin": &ignored_ids,
+                        "$gte": Bson::MinKey,
+                        "$lte": Bson::MaxKey
                     },
                     "$nor": [{
                         "$jsonSchema": bson_schema
@@ -280,12 +274,10 @@ mod test {
             match_stage,
             doc! {
                 "$match": {
-                    "$expr": {
-                        "$and": [
-                            {"$not": {"$in": ["$_id", {"$literal": vec![ignored_ids[0].clone()]}]}},
-                            {"$gte": ["$_id", Bson::MinKey]},
-                            {"$lt": ["$_id", Bson::MaxKey]}
-                        ]
+                    "_id": {
+                        "$nin": &ignored_ids,
+                        "$gte": Bson::MinKey,
+                        "$lt": Bson::MaxKey
                     },
                     "$nor": [{
                         "$jsonSchema": bson_schema

--- a/schema-builder-library/tests/wasm/tests/service.test.ts
+++ b/schema-builder-library/tests/wasm/tests/service.test.ts
@@ -24,9 +24,9 @@ describe("service impl", () => {
             "admin",
             "config",
             "local",
+            "mismatched_id_fields_small",
             "nonuniform",
             "uniform",
-            "mismatched_id_fields_small"
           ]
         `);
     });

--- a/schema-builder-library/tests/wasm/tests/service.test.ts
+++ b/schema-builder-library/tests/wasm/tests/service.test.ts
@@ -26,6 +26,7 @@ describe("service impl", () => {
             "local",
             "nonuniform",
             "uniform",
+            "mismatched_id_fields_small"
           ]
         `);
     });

--- a/test-utils/src/schema_builder_library_integration_test_consts.rs
+++ b/test-utils/src/schema_builder_library_integration_test_consts.rs
@@ -130,7 +130,10 @@ lazy_static! {
 
 pub const UNIFORM_DB_NAME: &str = "uniform";
 pub const NONUNIFORM_DB_NAME: &str = "nonuniform";
+pub const MISMATCHED_TYPES_DB_NAME : &str = "mismatched_id_fields_small";
+
 pub const SMALL_COLL_NAME: &str = "small";
 pub const LARGE_COLL_NAME: &str = "large";
 pub const UNITARY_COLL_NAME: &str = "unit";
+pub const MISMATCHED_TYPES_COLL_NAME : &str = "small";
 pub const VIEW_NAME: &str = "test_view";

--- a/test-utils/src/schema_builder_library_integration_test_consts.rs
+++ b/test-utils/src/schema_builder_library_integration_test_consts.rs
@@ -130,10 +130,10 @@ lazy_static! {
 
 pub const UNIFORM_DB_NAME: &str = "uniform";
 pub const NONUNIFORM_DB_NAME: &str = "nonuniform";
-pub const MISMATCHED_TYPES_DB_NAME : &str = "mismatched_id_fields_small";
+pub const MISMATCHED_TYPES_DB_NAME: &str = "mismatched_id_fields_small";
 
 pub const SMALL_COLL_NAME: &str = "small";
 pub const LARGE_COLL_NAME: &str = "large";
 pub const UNITARY_COLL_NAME: &str = "unit";
-pub const MISMATCHED_TYPES_COLL_NAME : &str = "small";
+pub const MISMATCHED_TYPES_COLL_NAME: &str = "small";
 pub const VIEW_NAME: &str = "test_view";


### PR DESCRIPTION
## Summary

This pull request updates the generate_match() function in schema-builder-library to use $expr language if it encounters partition bounds that are not comparable BSON types.

Previously, generate_match() used $match language for generating the aggregation pipeline for finding partition documents. However, $match language uses type-bracketing, which means if a collection has a polymorphic "_id" field, this function would fail to find those bounds.

## Changes
Partition::generate_match previously always used match-language ($gte/$lt/$lte) against the partition key. Match language is type-bracketed. We don't want this when the min/max bounds for the partition are different types.                              
                                                                                                                                                                                     
  This change adds bounds_are_comparable and branches on it:                                                                                                                         
                                                                                                                                                                                     
  - Match language (default): used when min and max are the same BSON type, or when both are numeric (Int32/Int64/Double/Decimal128), since numerics compare across their types in   
    match language. This is the common case and keeps the simpler, index-friendlier query shape.                                                                                     
  - $expr (fallback): used when the bounds are different BSON types. $expr comparisons use BSON ordering, so a partition key of any type can fall between the bounds.

2. Added a dataset mismatched_id_fields_small.yml with a small dataset to validate that we generate partitions with mismatched types. This was uploaded to S3, and has a corresponding change in the evergreen.yaml to pull down that file for integration testing.

## How I tested this

1. I built schema-build-library locally, generated a dataset with mismatched _id fields, and ran schema-manager-rs to validate that we can derive a schema.
2. Validated that I could then write a MongoSQL query against that collection.
