### PR TITLE
SQL-3453: Fix constant folding and desugaring in the context of higher order functions

### DIFF
--- a/mongosql/src/air/desugarer/sql_null_semantics_operators.rs
+++ b/mongosql/src/air/desugarer/sql_null_semantics_operators.rs
@@ -324,9 +324,14 @@ impl SqlNullSemanticsOperatorsDesugarerVisitor {
         let mut let_vars: Vec<LetVariable> = Vec::new();
 
         for (let_vars_idx, expr) in sql_operator.args.clone().into_iter().enumerate() {
-            // The mir optimizer ensures we will never have null literals as arguments to
-            // any of these operators.
-            let mql_operator_arg = if matches!(expr, Literal(_)) {
+            // The mir optimizer ensures we will never have null literals as arguments to any of
+            // these operators. However, we still handle the case where we have a null literal to
+            // account for changes to the optimizer that could cause this to happen. For example,
+            // consider new expressions that do not have constant folding implemented but require
+            // SQL semantics.
+            let mql_operator_arg = if matches!(expr, Literal(LiteralValue::Null)) {
+                return Literal(LiteralValue::Null);
+            } else if matches!(expr, Literal(_)) {
                 expr
             } else {
                 let let_var = LetVariable {

--- a/mongosql/src/air/desugarer/testdata/desugar_sql_null_semantics.yml
+++ b/mongosql/src/air/desugarer/testdata/desugar_sql_null_semantics.yml
@@ -1709,3 +1709,87 @@ tests:
               },
           },
       }
+
+  - name: "desugar $sqlEq literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlEq": ["$a", { "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlIndexOfCP literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlIndexOfCP": ["$a", { "$literal": null }, "$b", "$c"] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlLt literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlLt": ["$a", { "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlLte literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlLte": ["$a", { "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlGt literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlGt": ["$a", { "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlGte literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlGte": ["$a", { "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlNe literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlNe": ["$a", { "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlNot literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlNot": [{ "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlSize literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlSize": [{ "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlStrLenBytes literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlStrLenBytes": [{ "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlStrLenCP literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlStrLenCP": [{ "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlSubstrCP literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlSubstrCP": ["$a", { "$literal": null }, "$b"] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlToLower literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlToLower": [{ "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }
+
+  - name: "desugar $sqlToUpper literal null"
+    input:
+      - { "$project": { "_id": 0, "expr": { "$sqlToUpper": [{ "$literal": null }] } } }
+    expected:
+      - { "$project": { "_id": 0, "expr": { "$literal": null } } }

--- a/mongosql/src/mir/optimizer/constant_folding/lib.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/lib.rs
@@ -6,12 +6,18 @@
 ///
 use crate::{
     catalog::Catalog,
-    mir::{definitions::*, schema::SchemaInferenceState, visitor::Visitor},
+    map,
+    mir::{
+        definitions::*,
+        schema::{SchemaInferenceState, THIS_VARIABLE, VALUE_VARIABLE},
+        visitor::Visitor,
+    },
     schema::{Atomic, Satisfaction, Schema, NULLISH},
 };
 use bson::{oid::ObjectId, Decimal128};
 use chrono::Utc;
 use lazy_static::lazy_static;
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 #[derive(Clone)]
@@ -66,6 +72,23 @@ impl ConstantFoldExprVisitor<'_> {
             },
             _ => false,
         }
+    }
+
+    /// Helper to visit an expression with additional variables in scope. This is particularly
+    /// useful when visiting the function argument of a higher order function.
+    fn visit_with_variables(
+        &mut self,
+        expr: Expression,
+        variables: &mut BTreeMap<&'static str, Schema>,
+    ) -> Expression {
+        let new_state = self.state.with_variables(variables);
+        let mut sub_visitor = ConstantFoldExprVisitor {
+            state: &new_state,
+            changed: false,
+        };
+        let result = sub_visitor.visit_expression(expr);
+        self.changed |= sub_visitor.changed;
+        result
     }
 
     // Constant folds boolean functions
@@ -1641,6 +1664,72 @@ impl Visitor for ConstantFoldExprVisitor<'_> {
 
         self.changed |= changed;
         folded
+    }
+
+    // When visiting a higher order function, we need to ensure that variables
+    // `this` and `value` exist in the SchemaInferenceState as appropriate
+    // (`this` exists in `Map`, `Filter`, and `Reduce`, and `value` exists in
+    // `Reduce` only). This is necessary because variables do not appear in the
+    // global state that is provided to the optimizer at the top-level. If an
+    // expression nested inside a higher order function references `this` or
+    // `value`, this optimizer may fail to fold that expression because it will
+    // not be able to fetch the schema for these variables.
+    //
+    // TODO: SQL-3454: Implement improved constant folding for higher order
+    // functions. Currently, we always map `this` and `value` to Schema::Any
+    // when they appear. SQL-3454 will improve this by using the actual schemas
+    // of these variables.
+    fn visit_higher_order_function_application(
+        &mut self,
+        node: HigherOrderFunctionApplication,
+    ) -> HigherOrderFunctionApplication {
+        match node {
+            HigherOrderFunctionApplication::Map(n) => {
+                let array = self.visit_expression(*n.array);
+                let f = self.visit_with_variables(
+                    *n.f,
+                    &mut map! {
+                        THIS_VARIABLE => Schema::Any
+                    },
+                );
+                HigherOrderFunctionApplication::Map(MapExpr {
+                    array: Box::new(array),
+                    f: Box::new(f),
+                    is_nullable: n.is_nullable,
+                })
+            }
+            HigherOrderFunctionApplication::Filter(n) => {
+                let array = self.visit_expression(*n.array);
+                let f = self.visit_with_variables(
+                    *n.f,
+                    &mut map! {
+                        THIS_VARIABLE => Schema::Any
+                    },
+                );
+                HigherOrderFunctionApplication::Filter(FilterExpr {
+                    array: Box::new(array),
+                    f: Box::new(f),
+                    is_nullable: n.is_nullable,
+                })
+            }
+            HigherOrderFunctionApplication::Reduce(n) => {
+                let array = self.visit_expression(*n.array);
+                let init_value = self.visit_expression(*n.init_value);
+                let f = self.visit_with_variables(
+                    *n.f,
+                    &mut map! {
+                        THIS_VARIABLE => Schema::Any,
+                        VALUE_VARIABLE => Schema::Any,
+                    },
+                );
+                HigherOrderFunctionApplication::Reduce(ReduceExpr {
+                    array: Box::new(array),
+                    init_value: Box::new(init_value),
+                    f: Box::new(f),
+                    is_nullable: n.is_nullable,
+                })
+            }
+        }
     }
 
     fn visit_stage(&mut self, st: Stage) -> Stage {

--- a/mongosql/src/mir/optimizer/constant_folding/test.rs
+++ b/mongosql/src/mir/optimizer/constant_folding/test.rs
@@ -4450,3 +4450,119 @@ mod cast {
         );
     }
 }
+
+mod higher_order_functions {
+    use super::*;
+
+    use crate::mir::schema::THIS_VARIABLE;
+
+    test_constant_fold!(
+        fold_nested_scalar_function_with_null_literal_argument_to_null_inside_hof_map,
+        expected = Stage::Array(ArraySource {
+            alias: "".into(),
+            array: vec![Expression::HigherOrderFunction(
+                HigherOrderFunctionApplication::Map(MapExpr {
+                    array: Box::new(Expression::Array(ArrayExpr { array: vec![] })),
+                    f: Box::new(Expression::Literal(LiteralValue::Null)),
+                    is_nullable: true,
+                })
+            )],
+            cache: SchemaCache::new(),
+        }),
+        expected_changed = true,
+        input = Stage::Array(ArraySource {
+            alias: "".into(),
+            array: vec![Expression::HigherOrderFunction(
+                HigherOrderFunctionApplication::Map(MapExpr {
+                    array: Box::new(Expression::Array(ArrayExpr { array: vec![] })),
+                    f: Box::new(Expression::ScalarFunction(ScalarFunctionApplication::new(
+                        ScalarFunction::Add,
+                        vec![
+                            Expression::Literal(LiteralValue::Null),
+                            Expression::Variable(Variable {
+                                name: THIS_VARIABLE.to_string(),
+                                is_nullable: false,
+                            }),
+                        ],
+                    ))),
+                    is_nullable: true,
+                })
+            )],
+            cache: SchemaCache::new(),
+        }),
+    );
+
+    test_constant_fold!(
+        fold_nested_scalar_function_with_null_literal_argument_to_null_inside_hof_filter,
+        expected = Stage::Array(ArraySource {
+            alias: "".into(),
+            array: vec![Expression::HigherOrderFunction(
+                HigherOrderFunctionApplication::Filter(FilterExpr {
+                    array: Box::new(Expression::Array(ArrayExpr { array: vec![] })),
+                    f: Box::new(Expression::Literal(LiteralValue::Null)),
+                    is_nullable: true,
+                })
+            )],
+            cache: SchemaCache::new(),
+        }),
+        expected_changed = true,
+        input = Stage::Array(ArraySource {
+            alias: "".into(),
+            array: vec![Expression::HigherOrderFunction(
+                HigherOrderFunctionApplication::Filter(FilterExpr {
+                    array: Box::new(Expression::Array(ArrayExpr { array: vec![] })),
+                    f: Box::new(Expression::ScalarFunction(ScalarFunctionApplication::new(
+                        ScalarFunction::Lte,
+                        vec![
+                            Expression::Variable(Variable {
+                                name: THIS_VARIABLE.to_string(),
+                                is_nullable: false,
+                            }),
+                            Expression::Literal(LiteralValue::Null),
+                        ],
+                    ))),
+                    is_nullable: true,
+                })
+            )],
+            cache: SchemaCache::new(),
+        }),
+    );
+
+    test_constant_fold!(
+        fold_nested_scalar_function_with_null_literal_argument_to_null_inside_hof_reduce,
+        expected = Stage::Array(ArraySource {
+            alias: "".into(),
+            array: vec![Expression::HigherOrderFunction(
+                HigherOrderFunctionApplication::Reduce(ReduceExpr {
+                    array: Box::new(Expression::Array(ArrayExpr { array: vec![] })),
+                    init_value: Box::new(Expression::Literal(LiteralValue::Integer(0))),
+                    f: Box::new(Expression::Literal(LiteralValue::Null)),
+                    is_nullable: true,
+                })
+            )],
+            cache: SchemaCache::new(),
+        }),
+        expected_changed = true,
+        input = Stage::Array(ArraySource {
+            alias: "".into(),
+            array: vec![Expression::HigherOrderFunction(
+                HigherOrderFunctionApplication::Reduce(ReduceExpr {
+                    array: Box::new(Expression::Array(ArrayExpr { array: vec![] })),
+                    init_value: Box::new(Expression::Literal(LiteralValue::Integer(0))),
+                    f: Box::new(Expression::ScalarFunction(ScalarFunctionApplication::new(
+                        ScalarFunction::Sub,
+                        vec![
+                            Expression::Variable(Variable {
+                                name: THIS_VARIABLE.to_string(),
+                                is_nullable: false,
+                            }),
+                            Expression::Literal(LiteralValue::Null),
+                        ],
+                    ))),
+                    is_nullable: true,
+                })
+            )],
+            cache: SchemaCache::new(),
+        }),
+    );
+}

--- a/testdata/e2e_tests/queries.yml
+++ b/testdata/e2e_tests/queries.yml
@@ -333,3 +333,29 @@ dataset:
           bsonType: "int"
         y:
           bsonType: "int"
+
+  - db: "higher_order_function_nested_sql_semantics"
+    collection:
+      name: "filter_array"
+      docs:
+        - { "_id": 0, "a": [] }
+        - { "_id": 1, "a": [ 1 ] }
+        - { "_id": 2, "a": [ 1, 2, 3 ] }
+        - { "_id": 3, "a": [ 1, null, 3 ] }
+        - { "_id": 4, "a": null }
+        - { "_id": 5 }
+    schema:
+      bsonType: "object"
+      required: [ "_id" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        a:
+          anyOf:
+            - bsonType: "array"
+              items:
+                anyOf:
+                  - bsonType: "int"
+                  - bsonType: !!str "null"
+            - bsonType: !!str "null"

--- a/tests/e2e_tests/queries.yml
+++ b/tests/e2e_tests/queries.yml
@@ -665,13 +665,18 @@ tests:
         - { "foo_flatten_group": { "x": 1 } }
         - { "foo_flatten_group": { "x": 2 } }
 
+  # The initial implementation of higher order functions relied on several incomplete and incorrect implementations in
+  # the translation pipeline. First, the optimizer did not properly handle Variable expressions when constant folding
+  # expressions nested within higher order functions. Second, the desugarer assumed the optimizer always successfully
+  # folded away null literals in expressions that required special SQL null semantics. These two issues in concert led
+  # to this test failing since `v1` would fail to properly assert SQL semantics and `v2` would fold to `NULL`.
   - description: Higher order functions must handle SQL semantics correctly and consistently
     current_db: higher_order_function_nested_sql_semantics
     query: "SELECT VALUE { 'a': a, 'v1': v1, 'v2': v2, 'v1_eq_v2': v1 = v2 } FROM (SELECT VALUE { 'a': a, 'v1': FILTER(a, this > NULL), 'v2': FILTER(a, NULL < this) } FROM filter_array) q"
     result:
         - { '': { "a": [], "v1": [], "v2": [], "v1_eq_v2": true } }
-        - { '': { "a": [1], "v1": [1], "v2": [1], "v1_eq_v2": true } }
-        - { '': { "a": [1, 2, 3], "v1": [1, 2, 3], "v2": [1, 2, 3], "v1_eq_v2": true } }
-        - { '': { "a": [1, null, 3], "v1": [1, 3], "v2": [1, 3], "v1_eq_v2": true } }
+        - { '': { "a": [1], "v1": [], "v2": [], "v1_eq_v2": true } }
+        - { '': { "a": [1, 2, 3], "v1": [], "v2": [], "v1_eq_v2": true } }
+        - { '': { "a": [1, null, 3], "v1": [], "v2": [], "v1_eq_v2": true } }
         - { '': { "a": null, "v1": null, "v2": null, "v1_eq_v2": null } }
         - { '': { "v1": null, "v2": null, "v1_eq_v2": null } }

--- a/tests/e2e_tests/queries.yml
+++ b/tests/e2e_tests/queries.yml
@@ -664,3 +664,14 @@ tests:
     result:
         - { "foo_flatten_group": { "x": 1 } }
         - { "foo_flatten_group": { "x": 2 } }
+
+  - description: Higher order functions must handle SQL semantics correctly and consistently
+    current_db: higher_order_function_nested_sql_semantics
+    query: "SELECT VALUE { 'a': a, 'v1': v1, 'v2': v2, 'v1_eq_v2': v1 = v2 } FROM (SELECT VALUE { 'a': a, 'v1': FILTER(a, this > NULL), 'v2': FILTER(a, NULL < this) } FROM filter_array) q"
+    result:
+        - { '': { "a": [], "v1": [], "v2": [], "v1_eq_v2": true } }
+        - { '': { "a": [1], "v1": [1], "v2": [1], "v1_eq_v2": true } }
+        - { '': { "a": [1, 2, 3], "v1": [1, 2, 3], "v2": [1, 2, 3], "v1_eq_v2": true } }
+        - { '': { "a": [1, null, 3], "v1": [1, 3], "v2": [1, 3], "v1_eq_v2": true } }
+        - { '': { "a": null, "v1": null, "v2": null, "v1_eq_v2": null } }
+        - { '': { "v1": null, "v2": null, "v1_eq_v2": null } }


### PR DESCRIPTION
This PR updates the `constant_folding` optimizer and `sql_null_semantic_operators` desugarer to properly handle cases that could arise in the context of higher order function expressions. See the ticket or the new e2e test introduced in this PR to see a correctness bug that exists without these fixes.
  
The issue in `constant_folding` was primarily that the `SchemaInferenceState` used by the visitor did not contain any variable information, which caused `has_null_arg` to return false since it would always encounter an error when requesting the schema of a `Variable` ([link](https://github.com/mongodb/mongosql/blob/bd8f89c8a50004ed32fd8894e29a9cab222f2689/mongosql/src/mir/optimizer/constant_folding/lib.rs#L41)). That meant that order mattered when specifying arguments to the function argument of a higher order function -- if a `Variable` appeared before a definitely-nullish argument, then the result was unconditionally `false` even if a literal null was present. See the e2e test for an example of this. This PR addresses this in an imprecise way, indicating that `this` and `value` are available in the `SchemaInferenceState` with the `Schema::Any` schema. SQL-3454 tracks work to make this more precise. For now, though, this is acceptable behavior.
  
The issue in the `sql_null_semantic_operators` desugarer was really a consequence of constant folding failing in the context of higher order functions ([link](https://github.com/mongodb/mongosql/blob/bd8f89c8a50004ed32fd8894e29a9cab222f2689/mongosql/src/air/desugarer/sql_null_semantics_operators.rs#L327-L328)). This PR updates the desugarer to handle null literals even though it anticipates never encountering them. It is best to have that implemented correctly and unused than incorrectly in any circumstance.