### PR TITLE
SQL-3464: Fix And and Or schema checking

### DIFF
--- a/mongosql/src/mir/schema/mod.rs
+++ b/mongosql/src/mir/schema/mod.rs
@@ -1955,12 +1955,40 @@ impl ScalarFunction {
                 // `And` and `Or` are variadic operators, but we require them to have at least two
                 // arguments.
                 self.ensure_minimum_arg_count(arg_schemas.len(), 2)?;
-                self.propagate_variadic_null_arguments(
-                    state,
-                    arg_schemas,
-                    BOOLEAN_OR_NULLISH.clone(),
-                    Schema::Atomic(Atomic::Boolean),
-                )
+
+                // `And` and `Or` evaluate to NULL iff all of their arguments MUST be nullish. If
+                // any of their arguments MAY be nullish, then the result MAY be nullish. Otherwise,
+                // the result is BOOLEAN. We do not use `propagate_variadic_null_arguments` here
+                // because that assumes if at least one argument MUST be nullish, then the result is
+                // NULL. For `And` and `Or`, that assumption is incorrect:
+                //   - `false AND null` is `false`, a boolean; and
+                //   - `true OR null` is `true`, a boolean.
+                let mut all_must_be_nullish = true;
+                let mut any_may_be_nullish = false;
+                for (arg, arg_schema) in arg_schemas.iter() {
+                    if !state.check_satisfies(arg_schema, &BOOLEAN_OR_NULLISH) {
+                        return Err(Error::SchemaChecking {
+                            name: self.as_str(),
+                            required: BOOLEAN_OR_NULLISH.clone().into(),
+                            found: arg_schema.clone().into(),
+                            var_cause: arg.as_var_cause(),
+                        });
+                    }
+                    let sat = arg_schema.satisfies(&NULLISH);
+                    all_must_be_nullish = all_must_be_nullish && sat == Satisfaction::Must;
+                    any_may_be_nullish = any_may_be_nullish || sat != Satisfaction::Not;
+                }
+
+                if all_must_be_nullish {
+                    Ok(Schema::Atomic(Atomic::Null))
+                } else if any_may_be_nullish {
+                    Ok(Schema::AnyOf(set![
+                        Schema::Atomic(Atomic::Boolean),
+                        Schema::Atomic(Atomic::Null),
+                    ]))
+                } else {
+                    Ok(Schema::Atomic(Atomic::Boolean))
+                }
             }
             // Conditional scalar functions.
             NullIf => {

--- a/mongosql/src/mir/schema/test/expressions/scalar_function.rs
+++ b/mongosql/src/mir/schema/test/expressions/scalar_function.rs
@@ -302,7 +302,7 @@ mod and {
     );
 
     test_schema!(
-        may_be_null,
+        may_be_null_because_arg_may_be_null,
         expected = Ok(Schema::AnyOf(set![
             Schema::Atomic(Atomic::Boolean),
             Schema::Atomic(Atomic::Null)
@@ -318,7 +318,7 @@ mod and {
     );
 
     test_schema!(
-        may_be_missing,
+        may_be_null_because_arg_may_be_missing,
         expected = Ok(Schema::AnyOf(set![
             Schema::Atomic(Atomic::Boolean),
             Schema::Atomic(Atomic::Null)
@@ -334,13 +334,30 @@ mod and {
     );
 
     test_schema!(
+        may_be_null_because_arg_must_be_null,
+        expected = Ok(Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Boolean),
+            Schema::Atomic(Atomic::Null)
+        ])),
+        input = Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::And,
+            vec![
+                Expression::Reference(("bar", 0u16).into()),
+                Expression::Literal(LiteralValue::Boolean(true))
+            ],
+        )),
+        schema_env = map! {("bar", 0u16).into() => Schema::Atomic(Atomic::Null)},
+    );
+
+    // AND MUST be NULL iff all arguments MUST be NULL.
+    test_schema!(
         must_be_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = Expression::ScalarFunction(ScalarFunctionApplication::new(
             ScalarFunction::And,
             vec![
                 Expression::Reference(("bar", 0u16).into()),
-                Expression::Literal(LiteralValue::Boolean(true))
+                Expression::Literal(LiteralValue::Null),
             ],
         )),
         schema_env = map! {("bar", 0u16).into() => Schema::Atomic(Atomic::Null)},
@@ -483,7 +500,7 @@ mod or {
     );
 
     test_schema!(
-        may_be_null,
+        may_be_null_because_arg_may_be_null,
         expected = Ok(Schema::AnyOf(set![
             Schema::Atomic(Atomic::Boolean),
             Schema::Atomic(Atomic::Null)
@@ -499,7 +516,7 @@ mod or {
     );
 
     test_schema!(
-        may_be_missing,
+        may_be_null_because_arg_may_be_missing,
         expected = Ok(Schema::AnyOf(set![
             Schema::Atomic(Atomic::Boolean),
             Schema::Atomic(Atomic::Null)
@@ -515,13 +532,30 @@ mod or {
     );
 
     test_schema!(
+        may_be_null_because_arg_must_be_null,
+        expected = Ok(Schema::AnyOf(set![
+            Schema::Atomic(Atomic::Boolean),
+            Schema::Atomic(Atomic::Null)
+        ])),
+        input = Expression::ScalarFunction(ScalarFunctionApplication::new(
+            ScalarFunction::Or,
+            vec![
+                Expression::Reference(("bar", 0u16).into()),
+                Expression::Literal(LiteralValue::Boolean(true))
+            ],
+        )),
+        schema_env = map! {("bar", 0u16).into() => Schema::Atomic(Atomic::Null)},
+    );
+
+    // OR MUST be NULL iff all arguments MUST be NULL.
+    test_schema!(
         must_be_null,
         expected = Ok(Schema::Atomic(Atomic::Null)),
         input = Expression::ScalarFunction(ScalarFunctionApplication::new(
             ScalarFunction::Or,
             vec![
                 Expression::Reference(("bar", 0u16).into()),
-                Expression::Literal(LiteralValue::Boolean(true))
+                Expression::Literal(LiteralValue::Null)
             ],
         )),
         schema_env = map! {("bar", 0u16).into() => Schema::Atomic(Atomic::Null)},

--- a/tests/spec_tests/query_tests/array_functions.yml
+++ b/tests/spec_tests/query_tests/array_functions.yml
@@ -52,17 +52,14 @@ tests:
 
   - description: ARRAY_REMOVE remove NULL correctness test
     current_db: spec_query_array_functions
-    query: "SELECT VALUE { 'a': a, 'x': x, 'v': ARRAY_REMOVE(a, NULL) } FROM `array_remove_correctness` AS `array_remove_correctness`"
+    query: "SELECT VALUE { 'a': a, 'v': ARRAY_REMOVE(a, NULL) } FROM `array_default_numeric_data` AS `array_default_numeric_data`"
     result:
-      - { '': { "a": [ ], "x": 1, "v": [ ] } }
-      - { '': { "a": [ 1 ], "x": 1, "v": [ 1 ] } }
-      - { '': { "a": [ -1, 1, 2 ], "x": 1, "v": [ -1, 1, 2 ] } }
-      - { '': { "a": [ 1, null, 3 ], "x": null, "v": [ 1, 3 ] } }
-      - { '': { "a": null, "x": 1, "v": null } }
-      - { '': { "x": 1, "v": null } }
-      - { '': { "a": [ -1, 1, 2 ], "x": null, "v": [ -1, 1, 2 ] } }
-      - { '': { "a": [ 1, null, 3 ], "x": 1, "v": [ 1, 3 ] } }
-      - { '': { "a": [ 1, 2, 3 ], "v": [ 1, 2, 3 ] } }
+      - { '': { "a": [], "v": [] } }
+      - { '': { "a": [1], "v": [1] } }
+      - { '': { "a": [1, 2, 3], "v": [1, 2, 3] } }
+      - { '': { "a": [1, null, 3], "v": [1, 3] } }
+      - { '': { "a": null, "v": null } }
+      - { '': { "v": null } }
 
   # When x is NULL, NULL elements are removed; when x is non-NULL, NULL elements are retained.
   - description: ARRAY_REMOVE remove field correctness test


### PR DESCRIPTION
This PR fixes the result of `And` and `Or` schema checking. Before this change, the schema checker returned `Null` for these operators if any operator MUST be null. However, that is incorrect: `false AND null` is `false`, a boolean; and `true OR null` is `true`, also a boolean! This is a long-standing bug, it seems.

The reason this caused a problem for `ARRAY_REMOVE` is that `this IS NULL OR NULL IS NULL OR NULL` would be considered equivalent to `NULL` in the constant-folding optimizer, which wreaked havoc on the rewritten `FILTER` condition. By fixing the schema for these operators, we fix the `ARRAY_REMOVE` behavior. (Note: we do not constant fold `... IS NULL` as of [SQL-1640](https://jira.mongodb.org/browse/SQL-1640). I will file a ticket to support it, which is definitely doable -- we just need to check if the `...` expr is null _or_ missing when the target is `NULL`. Anyway, that's completely orthogonal to this bug.)