### PR TITLE
SQL-3465: Fix determine_join_semantics optimizer to not convert LEFT joins into EquiJoins when both fields are nullable

### DIFF
--- a/mongosql/src/mir/optimizer/determine_join_semantics/mod.rs
+++ b/mongosql/src/mir/optimizer/determine_join_semantics/mod.rs
@@ -191,7 +191,7 @@ impl Visitor for JoinSemanticsOptimizerVisitor<'_> {
                             }
 
                             self.changed = true;
-                            if local_field.is_nullable && foreign_field.is_nullable {
+                            if both_nullable {
                                 Stage::MqlIntrinsic(MqlStage::EquiJoin(EquiJoin {
                                     join_type: j.join_type,
                                     source: Box::new(Stage::Filter(Filter {

--- a/mongosql/src/mir/optimizer/determine_join_semantics/mod.rs
+++ b/mongosql/src/mir/optimizer/determine_join_semantics/mod.rs
@@ -1,7 +1,7 @@
 /// Optimizes Join stages by converting them to EquiJoin stages when possible.
 /// If a Join stage's right source is a collection source and the condition is
 /// a simple equality comparison of fields (one from the left and one from the
-/// right), then the Join can be converted into an EquiJoin.
+/// right), then the Join can be converted into an EquiJoin in most cases.
 ///
 /// Note that the intent here is to enable the translator and codegen to produce
 /// an equijoin-style $lookup stage in the final pipeline. This style $lookup
@@ -16,9 +16,14 @@
 ///     replace the Join condition with a literal false value.
 ///   - If the schema indicates either the local or the foreign field must NOT
 ///     be null or missing, no filter is needed.
-///   - Otherwise, the schema indicates both MAY be null or missing. Therefore,
-///     a Filter stage that asserts the existence of the local field is placed
-///     before the EquiJoin stage.
+///   - Otherwise, the schema indicates both MAY be null or missing. For INNER
+///     joins, this case can still be handled by an EquiJoin: a Filter stage
+///     that asserts the existence of the local field is placed before the
+///     EquiJoin stage. For LEFT joins, this case cannot be lowered to an
+///     EquiJoin while still preserving SQL null semantics. This is because we'd
+///     either lose rows where the local field has nullish data by adding a
+///     filter, or we'd lose proper null semantics by omitting the filter and
+///     converting to an unfiltered equijoin $lookup.
 ///
 #[cfg(test)]
 mod test;
@@ -28,7 +33,7 @@ use crate::{
         optimizer::Optimizer,
         schema::{CachedSchema, SchemaCache, SchemaInferenceState},
         visitor::Visitor,
-        EquiJoin, Expression, FieldAccess, FieldPath, Filter, MqlStage, ScalarFunction,
+        EquiJoin, Expression, FieldAccess, FieldPath, Filter, JoinType, MqlStage, ScalarFunction,
         ScalarFunctionApplication, Stage,
     },
     schema::ResultSet,
@@ -173,6 +178,18 @@ impl Visitor for JoinSemanticsOptimizerVisitor<'_> {
                         // -- one from the left and one from the right -- we cannot rewrite.
                         None => node,
                         Some((local_field, foreign_field)) => {
+                            let both_nullable =
+                                local_field.is_nullable && foreign_field.is_nullable;
+
+                            // LEFT JOINs cannot be converted to EquiJoins if both fields are
+                            // nullable. This is because we need to retain all rows on the LHS but
+                            // do not want those rows to match rows from the RHS when the join keys
+                            // are both null. In this case, we skip this optimization in favor of
+                            // these being lowered to LateralJoins later in the optimizer.
+                            if both_nullable && j.join_type == JoinType::Left {
+                                return node;
+                            }
+
                             self.changed = true;
                             if local_field.is_nullable && foreign_field.is_nullable {
                                 Stage::MqlIntrinsic(MqlStage::EquiJoin(EquiJoin {

--- a/mongosql/src/mir/optimizer/determine_join_semantics/mod.rs
+++ b/mongosql/src/mir/optimizer/determine_join_semantics/mod.rs
@@ -25,6 +25,12 @@
 ///     filter, or we'd lose proper null semantics by omitting the filter and
 ///     converting to an unfiltered equijoin $lookup.
 ///
+/// (Important note: recall that there is no such thing as a "RIGHT" join in the
+/// MongoSQL abstract model (mir). RIGHT joins are rewritten to LEFT joins at
+/// algebrization time; similarly, CROSS joins are rewritten to INNER joins.
+/// This is why this optimization is only concerned with the distinction between
+/// LEFT and INNER joins and does not reference RIGHT or CROSS joins.)
+///
 #[cfg(test)]
 mod test;
 

--- a/mongosql/src/mir/optimizer/determine_join_semantics/test.rs
+++ b/mongosql/src/mir/optimizer/determine_join_semantics/test.rs
@@ -87,8 +87,12 @@ macro_rules! test_determine_join_semantics_no_op {
 }
 
 fn make_standard_join(condition: Option<Expression>) -> Stage {
+    make_join_with_type(JoinType::Inner, condition)
+}
+
+fn make_join_with_type(join_type: JoinType, condition: Option<Expression>) -> Stage {
     Stage::Join(Join {
-        join_type: JoinType::Inner,
+        join_type,
         left: mir_project_collection(None, "local", None, None),
         right: mir_project_collection(None, "foreign", None, None),
         condition,
@@ -199,6 +203,17 @@ mod do_not_change {
                 is_nullable: true,
             }
         )))
+    );
+
+    test_determine_join_semantics_no_op!(
+        when_both_may_be_nullable_in_left_join,
+        make_join_with_type(
+            JoinType::Left,
+            Some(make_equality_condition(
+                *mir_field_access("local", "may_be_null", true),
+                *mir_field_access("foreign", "may_be_null", true),
+            ))
+        )
     );
 }
 

--- a/testdata/spec_tests/query_tests/join.yml
+++ b/testdata/spec_tests/query_tests/join.yml
@@ -67,6 +67,7 @@ dataset:
       docs:
         - { "_id": 1, "nullable_field": 10, "non_nullable_field": 10 }
         - { "_id": 2, "nullable_field": null, "non_nullable_field": 10 }
+        - { "_id": 3, "nullable_field": 2500, "non_nullable_field": 2500 }
     schema:
       bsonType: "object"
       required: [ "_id", "nullable_field", "non_nullable_field" ]
@@ -87,6 +88,7 @@ dataset:
       docs:
         - { "_id": 1, "nullable_field": 10, "non_nullable_field": 10 }
         - { "_id": 2, "nullable_field": null, "non_nullable_field": 10 }
+        - { "_id": 3, "nullable_field": 24, "non_nullable_field": 24 }
     schema:
       bsonType: "object"
       required: [ "_id", "nullable_field", "non_nullable_field" ]

--- a/testdata/spec_tests/query_tests/join.yml
+++ b/testdata/spec_tests/query_tests/join.yml
@@ -60,3 +60,39 @@ dataset:
       properties:
         x:
           bsonType: "int"
+
+  - db: "spec_query_join"
+    collection:
+      name: "parents"
+      docs:
+        - { "_id": 1, "name": "P1" }
+        - { "_id": null, "name": "P2"}
+    schema:
+      bsonType: "object"
+      required: [ "_id", "name" ]
+      additionalProperties: false
+      properties:
+        _id:
+          anyOf:
+            - bsonType: "int"
+            - bsonType: !!str "null"
+        name:
+          bsonType: "string"
+
+  - db: "spec_query_join"
+    collection:
+      name: "children"
+      docs:
+        - { "_id": 1, "parentId": 1 }
+        - { "_id": 2, "parentId": null }
+    schema:
+      bsonType: "object"
+      required: [ "_id", "parentId" ]
+      additionalProperties: false
+      properties:
+        _id:
+          bsonType: "int"
+        parentId:
+          anyOf:
+            - bsonType: "int"
+            - bsonType: !!str "null"

--- a/testdata/spec_tests/query_tests/join.yml
+++ b/testdata/spec_tests/query_tests/join.yml
@@ -65,34 +65,38 @@ dataset:
     collection:
       name: "parents"
       docs:
-        - { "_id": 1, "name": "P1" }
-        - { "_id": null, "name": "P2"}
+        - { "_id": 1, "nullable_field": 10, "non_nullable_field": 10 }
+        - { "_id": 2, "nullable_field": null, "non_nullable_field": 10 }
     schema:
       bsonType: "object"
-      required: [ "_id", "name" ]
+      required: [ "_id", "nullable_field", "non_nullable_field" ]
       additionalProperties: false
       properties:
         _id:
+          bsonType: "int"
+        nullable_field:
           anyOf:
             - bsonType: "int"
             - bsonType: !!str "null"
-        name:
-          bsonType: "string"
+        non_nullable_field:
+          bsonType: "int"
 
   - db: "spec_query_join"
     collection:
       name: "children"
       docs:
-        - { "_id": 1, "parentId": 1 }
-        - { "_id": 2, "parentId": null }
+        - { "_id": 1, "nullable_field": 10, "non_nullable_field": 10 }
+        - { "_id": 2, "nullable_field": null, "non_nullable_field": 10 }
     schema:
       bsonType: "object"
-      required: [ "_id", "parentId" ]
+      required: [ "_id", "nullable_field", "non_nullable_field" ]
       additionalProperties: false
       properties:
         _id:
           bsonType: "int"
-        parentId:
+        nullable_field:
           anyOf:
             - bsonType: "int"
             - bsonType: !!str "null"
+        non_nullable_field:
+          bsonType: "int"

--- a/tests/spec_tests/query_tests/join.yml
+++ b/tests/spec_tests/query_tests/join.yml
@@ -31,13 +31,6 @@ tests:
         }
       - { "bar2": { "_id": 1, "foo": 43 } }
 
-  - description: left join retains all rows from left hand side including those with with null data on the join key
-    current_db: spec_query_join
-    query: "SELECT c._id AS child_id, p.name AS parent_name FROM children AS c LEFT JOIN parents AS p ON c.parentId = p._id"
-    result:
-      - { "": { "child_id": 1, "parent_name": "P1" } }
-      - { "": { "child_id": 2 } }
-
   - description: right join correctness test
     current_db: spec_query_join
     query: "SELECT * from bar2 AS bar2 RIGHT JOIN bar as bar ON bar2.foo = bar.foo"
@@ -48,12 +41,125 @@ tests:
         }
       - { "bar": { "_id": 0, "foo": 1 } }
 
-  - description: right join retains all rows from right hand side including those with with null data on the join key
+  # INNER JOIN with non-nullable fields on both sides of the ON condition retains all matching rows
+  - description: inner join with non_nullable join keys
     current_db: spec_query_join
-    query: "SELECT p.name AS parent_name, c._id AS child_id FROM children c RIGHT JOIN parents p ON c.parentId = p._id"
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c INNER JOIN parents p ON c.non_nullable_field = p.non_nullable_field"
     result:
-      - { "": { "parent_name": "P1", "child_id": 1 } }
-      - { "": { "parent_name": "P2" } }
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+
+  # INNER JOIN with non-nullable LHS join key and nullable RHS join key retains all matching rows where the RHS join key
+  # is not null.
+  - description: inner join with non_nullable LHS join key and nullable RHS join key
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.nullable_field AS parent_data FROM children c INNER JOIN parents p ON c.non_nullable_field = p.nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+
+  # INNER JOIN with nullable LHS join key and non-nullable RHS join key retains all matching rows where the LHS join key
+  # is not null.
+  - description: inner join with nullable LHS join key nullable and non_nullable RHS join key
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c INNER JOIN parents p ON c.nullable_field = p.non_nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+
+  # INNER JOIN with nullable join keys on both sides of the ON condition retains all matching rows where neither join
+  # key is null.
+  - description: inner join with nullable join keys
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.nullable_field AS parent_data FROM children c INNER JOIN parents p ON c.nullable_field = p.nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+
+  # LEFT JOIN with non-nullable join keys on both sides of the ON condition retains all matching rows and all rows from
+  # the left hand side that do not match. For this data, all rows from the left hand side match.
+  - description: left join with non_nullable join keys
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c LEFT JOIN parents p ON c.non_nullable_field = p.non_nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+
+  # LEFT JOIN with non-nullable LHS join key and nullable RHS join key retains all matching rows where the RHS join key
+  # is not null and all rows from the left hand side that do not match. For this data, all rows from the left hand side
+  # match non-null data.
+  - description: left join with non_nullable LHS join key and nullable RHS join key
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.nullable_field AS parent_data FROM children c LEFT JOIN parents p ON c.non_nullable_field = p.nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+
+  # LEFT JOIN with nullable LHS join key and non-nullable RHS join key retains all matching rows where the LHS join key
+  # is not null and all rows from the left hand side that do not match. For this data, that includes a row with null LHS
+  # join key data; in that row, no parent_id or parent_data is returned.
+  - description: left join with nullable LHS join key nullable and non_nullable RHS join key
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c LEFT JOIN parents p ON c.nullable_field = p.non_nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "child_data": null } }
+
+  # LEFT JOIN with nullable join keys on both sides of the ON condition retains all matching rows where neither join key
+  # is null and all rows from the left hand side that do not match. For this data, that includes a row with null LHS
+  # join key data; in that row, no parent_id or parent_data is returned.
+  - description: left join with nullable join keys
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.nullable_field AS parent_data FROM children c LEFT JOIN parents p ON c.nullable_field = p.nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "child_data": null } }
+
+  # RIGHT JOIN with non-nullable join keys on both sides of the ON condition retains all matching rows and all rows from
+  # the right hand side that do not match. For this data, all rows from the right hand side match.
+  - description: right join with non_nullable join keys
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c RIGHT JOIN parents p ON c.non_nullable_field = p.non_nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+
+  # RIGHT JOIN with non-nullable LHS join key and nullable RHS join key retains all matching rows where the RHS join key
+  # is not null and all rows from the right hand side that do not match. For this data, that includes a row with null
+  # RHS join key data; in that row, no child_id or child_data is returned.
+  - description: right join with non_nullable LHS join key and nullable RHS join key
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.nullable_field AS parent_data FROM children c RIGHT JOIN parents p ON c.non_nullable_field = p.nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "parent_id": 2, "parent_data": null } }
+
+  # RIGHT JOIN with nullable LHS join key and non-nullable RHS join key retains all matching rows where the LHS join key
+  # is not null and all rows from the right hand side that do not match. For this data, all rows from the right hand
+  # side match non-null data.
+  - description: right join with nullable LHS join key nullable and non_nullable RHS join key
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c RIGHT JOIN parents p ON c.nullable_field = p.non_nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+
+  # RIGHT JOIN with nullable join keys on both sides of the ON condition retains all matching rows where neither join
+  # key is null and all rows from the right hand side that do not match. For this data, that includes a row with null
+  # RHS join key data; in that row, no parent_id or parent_data is returned.
+  - description: right join with nullable join keys
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.nullable_field AS parent_data FROM children c RIGHT JOIN parents p ON c.nullable_field = p.nullable_field"
+    result:
+      - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "parent_id": 2, "parent_data": null } }
 
   - description: natural join is not supported
     current_db: spec_query_join

--- a/tests/spec_tests/query_tests/join.yml
+++ b/tests/spec_tests/query_tests/join.yml
@@ -78,7 +78,7 @@ tests:
       - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
 
   # LEFT JOIN with non-nullable join keys on both sides of the ON condition retains all matching rows and all rows from
-  # the left hand side that do not match. For this data, all rows from the left hand side match.
+  # the LHS that do not match. For rows that do not match, no parent_id or parent_data is returned.
   - description: left join with non_nullable join keys
     current_db: spec_query_join
     query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c LEFT JOIN parents p ON c.non_nullable_field = p.non_nullable_field"
@@ -87,20 +87,22 @@ tests:
       - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 2, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 3, "child_data": 24 } }
 
   # LEFT JOIN with non-nullable LHS join key and nullable RHS join key retains all matching rows where the RHS join key
-  # is not null and all rows from the left hand side that do not match. For this data, all rows from the left hand side
-  # match non-null data.
+  # is not null and all rows from the LHS that do not match. For rows that do not match, no parent_id or parent_data is
+  # returned.
   - description: left join with non_nullable LHS join key and nullable RHS join key
     current_db: spec_query_join
     query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.nullable_field AS parent_data FROM children c LEFT JOIN parents p ON c.non_nullable_field = p.nullable_field"
     result:
       - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
+      - { "": { "child_id": 3, "child_data": 24 } }
 
   # LEFT JOIN with nullable LHS join key and non-nullable RHS join key retains all matching rows where the LHS join key
-  # is not null and all rows from the left hand side that do not match. For this data, that includes a row with null LHS
-  # join key data; in that row, no parent_id or parent_data is returned.
+  # is not null and all rows from the LHS that do not match. For this data, that includes a row with null LHS join key
+  # data and a row with non-null data that does not match; in those rows, no parent_id or parent_data is returned.
   - description: left join with nullable LHS join key nullable and non_nullable RHS join key
     current_db: spec_query_join
     query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c LEFT JOIN parents p ON c.nullable_field = p.non_nullable_field"
@@ -108,19 +110,21 @@ tests:
       - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 2, "child_data": null } }
+      - { "": { "child_id": 3, "child_data": 24 } }
 
   # LEFT JOIN with nullable join keys on both sides of the ON condition retains all matching rows where neither join key
-  # is null and all rows from the left hand side that do not match. For this data, that includes a row with null LHS
-  # join key data; in that row, no parent_id or parent_data is returned.
+  # is null and all rows from the LHS that do not match. For this data, that includes a row with null LHS join key data
+  # and a row with non-null data that does not match; in those rows, no parent_id or parent_data is returned.
   - description: left join with nullable join keys
     current_db: spec_query_join
     query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.nullable_field AS parent_data FROM children c LEFT JOIN parents p ON c.nullable_field = p.nullable_field"
     result:
       - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 2, "child_data": null } }
+      - { "": { "child_id": 3, "child_data": 24 } }
 
   # RIGHT JOIN with non-nullable join keys on both sides of the ON condition retains all matching rows and all rows from
-  # the right hand side that do not match. For this data, all rows from the right hand side match.
+  # the RHS that do not match. For rows that do not match, no child_id or child_data is returned.
   - description: right join with non_nullable join keys
     current_db: spec_query_join
     query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c RIGHT JOIN parents p ON c.non_nullable_field = p.non_nullable_field"
@@ -129,10 +133,11 @@ tests:
       - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 2, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+      - { "": { "parent_id": 3, "parent_data": 2500 } }
 
   # RIGHT JOIN with non-nullable LHS join key and nullable RHS join key retains all matching rows where the RHS join key
-  # is not null and all rows from the right hand side that do not match. For this data, that includes a row with null
-  # RHS join key data; in that row, no child_id or child_data is returned.
+  # is not null and all rows from the RHS that do not match. For this data, that includes a row with null RHS join key
+  # data and a row with non-null data that does not match; in those rows, no child_id or child_data is returned.
   - description: right join with non_nullable LHS join key and nullable RHS join key
     current_db: spec_query_join
     query: "SELECT c._id AS child_id, p._id AS parent_id, c.non_nullable_field AS child_data, p.nullable_field AS parent_data FROM children c RIGHT JOIN parents p ON c.non_nullable_field = p.nullable_field"
@@ -140,26 +145,29 @@ tests:
       - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 2, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
       - { "": { "parent_id": 2, "parent_data": null } }
+      - { "": { "parent_id": 3, "parent_data": 2500 } }
 
   # RIGHT JOIN with nullable LHS join key and non-nullable RHS join key retains all matching rows where the LHS join key
-  # is not null and all rows from the right hand side that do not match. For this data, all rows from the right hand
-  # side match non-null data.
+  # is not null and all rows from the RHS that do not match. For rows that do not match, no parent_id or parent_data is
+  # returned.
   - description: right join with nullable LHS join key nullable and non_nullable RHS join key
     current_db: spec_query_join
     query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.non_nullable_field AS parent_data FROM children c RIGHT JOIN parents p ON c.nullable_field = p.non_nullable_field"
     result:
       - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
       - { "": { "child_id": 1, "parent_id": 2, "child_data": 10, "parent_data": 10 } }
+      - { "": { "parent_id": 3, "parent_data": 2500 } }
 
   # RIGHT JOIN with nullable join keys on both sides of the ON condition retains all matching rows where neither join
-  # key is null and all rows from the right hand side that do not match. For this data, that includes a row with null
-  # RHS join key data; in that row, no parent_id or parent_data is returned.
+  # key is null and all rows from the RHS that do not match. For this data, that includes a row with null RHS join key
+  #  # data and a row with non-null data that does not match; in those rows, no child_id or child_data is returned.
   - description: right join with nullable join keys
     current_db: spec_query_join
     query: "SELECT c._id AS child_id, p._id AS parent_id, c.nullable_field AS child_data, p.nullable_field AS parent_data FROM children c RIGHT JOIN parents p ON c.nullable_field = p.nullable_field"
     result:
       - { "": { "child_id": 1, "parent_id": 1, "child_data": 10, "parent_data": 10 } }
       - { "": { "parent_id": 2, "parent_data": null } }
+      - { "": { "parent_id": 3, "parent_data": 2500 } }
 
   - description: natural join is not supported
     current_db: spec_query_join

--- a/tests/spec_tests/query_tests/join.yml
+++ b/tests/spec_tests/query_tests/join.yml
@@ -31,6 +31,13 @@ tests:
         }
       - { "bar2": { "_id": 1, "foo": 43 } }
 
+  - description: left join retains all rows from left hand side including those with with null data on the join key
+    current_db: spec_query_join
+    query: "SELECT c._id AS child_id, p.name AS parent_name FROM children AS c LEFT JOIN parents AS p ON c.parentId = p._id"
+    result:
+      - { "": { "child_id": 1, "parent_name": "P1" } }
+      - { "": { "child_id": 2 } }
+
   - description: right join correctness test
     current_db: spec_query_join
     query: "SELECT * from bar2 AS bar2 RIGHT JOIN bar as bar ON bar2.foo = bar.foo"
@@ -40,6 +47,13 @@ tests:
           "bar2": { "_id": 0, "foo": 42, "baz": 63 },
         }
       - { "bar": { "_id": 0, "foo": 1 } }
+
+  - description: right join retains all rows from right hand side including those with with null data on the join key
+    current_db: spec_query_join
+    query: "SELECT p.name AS parent_name, c._id AS child_id FROM children c RIGHT JOIN parents p ON c.parentId = p._id"
+    result:
+      - { "": { "parent_name": "P1", "child_id": 1 } }
+      - { "": { "parent_name": "P2" } }
 
   - description: natural join is not supported
     current_db: spec_query_join


### PR DESCRIPTION
This PR addresses a correctness bug in the `determine_join_semantics` optimization. The `determine_join_semantics` optimizer does not consider `join_type` at all when it really should. The issue causing this bug is [here](https://github.com/mongodb/mongosql/blob/e7f5933c47ad6b5bcd3d479bdfeade1cc1800728/mongosql/src/mir/optimizer/determine_join_semantics/mod.rs#L177) where we semi-conditionally insert a filter before the `EquiJoin` to remove null values from the LHS. For a LEFT join, we do not want to remove those values.

The fix is not to simply amend that condition to also say `&& j.join_type == JoinType::Inner` since that would fall-through to the else branch which returns an `EquiJoin` that does not use SQL semantics (i.e., "null = null" will be true when we still want that to be false).

Instead, the fix in this PR is to _not_ convert a `Join` into an `EquiJoin` when both the local and foreign fields are nullable _and_ it is a `LEFT` join; instead we return the node unchanged. (It will be converted to a `LateralJoin` instead; there is no way to represent a SQL-semantic `LEFT` join using equi-`$lookup` syntax.)

New spec tests have been added to demonstrate this works for `LEFT` and `RIGHT` joins, and a new unit test was added to the optimization to demonstrate this case does not get rewritten.