### PR TITLE
SQL-3051: Fix e2e and spec query test result set comparison algorithm

### DIFF
--- a/evergreen/suite-tasks.yml
+++ b/evergreen/suite-tasks.yml
@@ -383,6 +383,25 @@ tasks:
           mongodb_version: rapid
     
 
+  - name: test-spec-query_latest-standalone
+    tags: [latest, standalone]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: latest
+          TOPOLOGY: server
+      - func: "install rust toolchain"
+      - func: "run data loader"
+        vars:
+          working_dir: ${common_test_infra_dir}
+          data_loader_args: "--mongod-uri mongodb://localhost:27017 -d ../testdata/spec_tests/query_tests"
+      - func: "run rust tests"
+        vars:
+          description: run spec query tests
+          cargo_test_flags: --features=query --package=e2e-tests
+          mongodb_version: latest
+
+
   - name: test-index-usage_latest-standalone
     tags: [latest, standalone]
     commands:

--- a/test-utils/src/query/mod.rs
+++ b/test-utils/src/query/mod.rs
@@ -10,7 +10,7 @@ use sql_engines_common_test_infra::{
     parse_yaml_test_file, sanitize_description, Error as cti_err, TestGenerator, YamlTestCase,
     YamlTestFile,
 };
-use std::{collections::HashSet, env, fs::File, io::Write, path::PathBuf};
+use std::{env, fs::File, io::Write, path::PathBuf};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct QueryTestExpectations {
@@ -121,60 +121,36 @@ impl TestGenerator for QueryTestGenerator {
 
 /// Compare arrays of Bson values, allowing for NaN == NaN == true.
 ///
-/// This is not ideal (ballooning O). Because arrays may contain duplicate values,
-/// we MUST check every value in the expected array against every value in the actual array. Using the HashSet
-/// to mark seen indices, we can ensure that we don't check the same value twice.
-/// Since the query tests are small, this shouldn't be much of an impact.
+/// Note that arrays are considered ordered in MongoDB and in MongoSQL. This
+/// function should never be modified to make array comparisons unordered as
+/// that would break the contract of what arrays mean in MongoDB and MongoSQL.
 pub fn compare_arrays(expected: &[Bson], actual: &[Bson], type_compare: bool) -> bool {
     if expected.len() != actual.len() {
         return false;
     }
-    let mut seen_indices = HashSet::new();
-    expected.iter().all(|e| {
-        actual.iter().enumerate().any(|(i, a)| {
-            if seen_indices.contains(&i) {
-                return false;
-            }
-            if let Bson::Document(d) = e {
-                if let Bson::Document(ad) = a {
-                    if compare_documents(d, ad, type_compare) {
-                        return seen_indices.insert(i);
-                    }
-                } else {
-                    return false;
-                }
-            }
-            if let Bson::Array(ea) = e {
-                if let Bson::Array(aa) = a {
-                    if compare_arrays(ea, aa, type_compare) {
-                        return seen_indices.insert(i);
-                    }
-                } else {
-                    return false;
-                }
-            }
-            if type_compare {
-                if e.element_type() == a.element_type() {
-                    return seen_indices.insert(i);
-                } else {
-                    return false;
-                }
-            }
-            if is_numeric(e) && is_numeric(a) {
-                let d = numeric_to_double(e);
-                let ad = numeric_to_double(a);
-                if compare_doubles_for_test(d, ad) {
-                    return seen_indices.insert(i);
-                } else {
-                    return false;
-                }
-            }
-            if e == a {
-                return seen_indices.insert(i);
-            }
-            false
+
+    expected
+        .iter()
+        .zip(actual.iter())
+        .all(|(expected_value, actual_value)| {
+            compare_bson_values(expected_value, actual_value, type_compare)
         })
-    })
+}
+
+fn compare_bson_values(expected: &Bson, actual: &Bson, type_compare: bool) -> bool {
+    match (expected, actual) {
+        (Bson::Document(expected_document), Bson::Document(actual_document)) => {
+            compare_documents(expected_document, actual_document, type_compare)
+        }
+        (Bson::Array(expected_array), Bson::Array(actual_array)) => {
+            compare_arrays(expected_array, actual_array, type_compare)
+        }
+        _ if type_compare => expected.element_type() == actual.element_type(),
+        _ if is_numeric(expected) && is_numeric(actual) => {
+            compare_doubles_for_test(numeric_to_double(expected), numeric_to_double(actual))
+        }
+        _ => expected == actual,
+    }
 }
 
 // According to the IEEE 754 standard, a 64-bit floating-point number (double precision) has a
@@ -274,22 +250,7 @@ pub fn compare_documents(expected: &Document, actual: &Document, type_compare: b
     expected
         .iter()
         .all(|(ek, expected_value)| match actual.get(ek) {
-            Some(actual_value) => match (expected_value, actual_value) {
-                (Bson::Document(expected_document), Bson::Document(actual_document)) => {
-                    compare_documents(expected_document, actual_document, type_compare)
-                }
-                (Bson::Array(expected_array), Bson::Array(actual_array)) => {
-                    compare_arrays(expected_array, actual_array, type_compare)
-                }
-                _ if type_compare => expected_value.element_type() == actual_value.element_type(),
-                _ if is_numeric(expected_value) && is_numeric(actual_value) => {
-                    compare_doubles_for_test(
-                        numeric_to_double(expected_value),
-                        numeric_to_double(actual_value),
-                    )
-                }
-                _ => expected_value == actual_value,
-            },
+            Some(actual_value) => compare_bson_values(expected_value, actual_value, type_compare),
             None => false,
         })
 }
@@ -548,6 +509,82 @@ mod test {
     fn assert_result_sets_not_equal_ordered_duplicate_expecteds() {
         let expected = vec![doc! {"a": 1}, doc! {"a": 1}];
         let actual = vec![doc! {"a": 1}, doc! {"b": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_unordered_with_arrays() {
+        let expected = vec![doc! {"a": [1, 2, 3]}, doc! {"a": [4, 5, 6]}];
+        let actual = vec![doc! {"a": [4, 5, 6]}, doc! {"a": [1, 2, 3]}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_ordered_with_arrays() {
+        let expected = vec![doc! {"a": [1, 2, 3]}, doc! {"a": [4, 5, 6]}];
+        let actual = vec![doc! {"a": [1, 2, 3]}, doc! {"a": [4, 5, 6]}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_with_arrays_different_values() {
+        let expected = vec![doc! {"a": [1, 2, 3]}, doc! {"a": [4, 5, 6]}];
+        let actual = vec![doc! {"a": [4, 5, 6]}, doc! {"a": [1, 20, 30]}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_with_arrays_different_values() {
+        let expected = vec![doc! {"a": [1, 2, 3]}, doc! {"a": [4, 5, 6]}];
+        let actual = vec![doc! {"a": [1, 2, 3]}, doc! {"a": [4, 50, 6]}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_with_arrays_same_values_different_order() {
+        let expected = vec![doc! {"a": [1, 2, 3]}, doc! {"a": [4, 5, 6]}];
+        let actual = vec![doc! {"a": [4, 5, 6]}, doc! {"a": [2, 1, 3]}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_with_arrays_same_values_different_order() {
+        let expected = vec![doc! {"a": [1, 2, 3]}, doc! {"a": [4, 5, 6]}];
+        let actual = vec![doc! {"a": [1, 2, 3]}, doc! {"a": [4, 6, 5]}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_unordered_with_nested_arrays() {
+        let expected = vec![doc! {"a": [[1], [2, 3]]}, doc! {"a": [[4, 5, 6]]}];
+        let actual = vec![doc! {"a": [[4, 5, 6]]}, doc! {"a": [[1], [2, 3]]}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_ordered_with_nested_arrays() {
+        let expected = vec![doc! {"a": [[1], [2, 3]]}, doc! {"a": [[4, 5, 6]]}];
+        let actual = vec![doc! {"a": [[1], [2, 3]]}, doc! {"a": [[4, 5, 6]]}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_with_nested_arrays() {
+        let expected = vec![doc! {"a": [[1], [2], [3]]}, doc! {"a": [[4], [5, 6]]}];
+        let actual = vec![doc! {"a": [[4], [5, 6]]}, doc! {"a": [[1], [3], [2]]}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_with_nested_arrays() {
+        let expected = vec![doc! {"a": [[1], [2, 3]]}, doc! {"a": [[4, 5, 6]]}];
+        let actual = vec![doc! {"a": [[1], [2, 3]]}, doc! {"a": [[6]]}];
         assert_result_sets_equal(expected, actual, false, true, "test".into());
     }
 }

--- a/test-utils/src/query/mod.rs
+++ b/test-utils/src/query/mod.rs
@@ -343,3 +343,212 @@ pub fn run_query(client: &Client, translation: Translation) -> Result<Vec<Docume
 
     Ok(result.into_iter().map(|d| d.unwrap()).collect())
 }
+
+/// assert_result_sets_equal compares two result sets for equality. It ensures
+/// that all expected results appear in the actual result set, and that no
+/// extra results appear in the actual result set.
+pub fn assert_result_sets_equal(
+    mut expected: Vec<Document>,
+    actual: Vec<Document>,
+    type_compare: bool,
+    ordered: bool,
+    desc: String,
+) {
+    assert_eq!(
+        expected.len(),
+        actual.len(),
+        "{}: unexpected number of query results\nexpected results: {:?}\nactual results: {:?}",
+        desc,
+        expected,
+        actual,
+    );
+
+    if ordered {
+        for (index, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+            assert!(
+                // because NaN != NaN, we have to use custom comparison functions
+                compare_documents(e, a, type_compare),
+                "unexpected query result for {} at index {}, \nexpected: {:?}\nactual: {:?}",
+                desc,
+                index,
+                e,
+                a
+            );
+        }
+    } else {
+        let og_expected = expected.clone();
+        for a in actual.iter() {
+            match expected
+                .iter()
+                .position(|e| compare_documents(e, a, type_compare))
+            {
+                None => assert!(
+                    false,
+                    "unexpected query result for {}\nexpected results: {:?}\nactual results: {:?}",
+                    desc, og_expected, actual
+                ),
+                Some(idx) => {
+                    expected.remove(idx);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::assert_result_sets_equal;
+    use mongodb::bson::doc;
+
+    #[test]
+    fn assert_result_sets_equal_unordered_empty() {
+        let expected = vec![];
+        let actual = vec![];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_ordered_empty() {
+        let expected = vec![];
+        let actual = vec![];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_unordered_singleton() {
+        let expected = vec![doc! {"a": 1}];
+        let actual = vec![doc! {"a": 1}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_ordered_singleton() {
+        let expected = vec![doc! {"a": 1}];
+        let actual = vec![doc! {"a": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_singleton() {
+        let expected = vec![doc! {"a": 1}];
+        let actual = vec![doc! {"b": 1}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_singleton() {
+        let expected = vec![doc! {"a": 1}];
+        let actual = vec![doc! {"b": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_unordered_multiple() {
+        let expected = vec![doc! {"a": 1}, doc! {"b": 1}, doc! {"c": 1}];
+        let actual = vec![doc! {"b": 1}, doc! {"c": 1}, doc! {"a": 1}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_ordered_multiple() {
+        let expected = vec![doc! {"a": 1}, doc! {"b": 1}, doc! {"c": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"b": 1}, doc! {"c": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_multiple() {
+        let expected = vec![doc! {"a": 1}, doc! {"b": 1}, doc! {"c": 1}];
+        let actual = vec![doc! {"c": 1}, doc! {"x": 1}, doc! {"a": 1}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_multiple() {
+        let expected = vec![doc! {"a": 1}, doc! {"b": 1}, doc! {"c": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"c": 1}, doc! {"b": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_different_lengths() {
+        let expected = vec![doc! {"a": 1}, doc! {"b": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"b": 1}, doc! {"c": 1}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_different_lengths() {
+        let expected = vec![doc! {"a": 1}, doc! {"b": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"b": 1}, doc! {"c": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_unordered_duplicates() {
+        let expected = vec![doc! {"a": 1}, doc! {"a": 1}, doc! {"b": 1}, doc! {"b": 1}];
+        let actual = vec![doc! {"b": 1}, doc! {"a": 1}, doc! {"b": 1}, doc! {"a": 1}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_ordered_duplicates() {
+        let expected = vec![doc! {"a": 1}, doc! {"a": 1}, doc! {"b": 1}, doc! {"b": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"a": 1}, doc! {"b": 1}, doc! {"b": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_duplicates() {
+        let expected = vec![doc! {"a": 1}, doc! {"a": 1}, doc! {"c": 1}, doc! {"c": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"c": 1}, doc! {"a": 1}, doc! {"b": 1}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_duplicates() {
+        let expected = vec![doc! {"a": 1}, doc! {"a": 1}, doc! {"b": 1}, doc! {"b": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"a": 1}, doc! {"b": 1}, doc! {"c": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_duplicate_actuals() {
+        let expected = vec![doc! {"a": 1}, doc! {"b": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"a": 1}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_duplicate_expecteds() {
+        let expected = vec![doc! {"a": 1}, doc! {"a": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"b": 1}];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_duplicate_actuals() {
+        let expected = vec![doc! {"a": 1}, doc! {"b": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"a": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_duplicate_expecteds() {
+        let expected = vec![doc! {"a": 1}, doc! {"a": 1}];
+        let actual = vec![doc! {"a": 1}, doc! {"b": 1}];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+}

--- a/test-utils/src/query/mod.rs
+++ b/test-utils/src/query/mod.rs
@@ -382,8 +382,7 @@ pub fn assert_result_sets_equal(
                 .iter()
                 .position(|e| compare_documents(e, a, type_compare))
             {
-                None => assert!(
-                    false,
+                None => panic!(
                     "unexpected query result for {}\nexpected results: {:?}\nactual results: {:?}",
                     desc, og_expected, actual
                 ),

--- a/test-utils/src/query/mod.rs
+++ b/test-utils/src/query/mod.rs
@@ -329,7 +329,7 @@ pub fn assert_result_sets_equal(
             assert!(
                 // because NaN != NaN, we have to use custom comparison functions
                 compare_documents(e, a, type_compare),
-                "unexpected query result for {} at index {}, \nexpected: {:?}\nactual: {:?}",
+                "unexpected query result for {desc} at index {index}, \nexpected: {e:?}\nactual: {a:?}",
                 desc,
                 index,
                 e,

--- a/test-utils/src/query/mod.rs
+++ b/test-utils/src/query/mod.rs
@@ -330,10 +330,6 @@ pub fn assert_result_sets_equal(
                 // because NaN != NaN, we have to use custom comparison functions
                 compare_documents(e, a, type_compare),
                 "unexpected query result for {desc} at index {index}, \nexpected: {e:?}\nactual: {a:?}",
-                desc,
-                index,
-                e,
-                a
             );
         }
     } else {

--- a/test-utils/src/query/mod.rs
+++ b/test-utils/src/query/mod.rs
@@ -587,4 +587,96 @@ mod test {
         let actual = vec![doc! {"a": [[1], [2, 3]]}, doc! {"a": [[6]]}];
         assert_result_sets_equal(expected, actual, false, true, "test".into());
     }
+
+    #[test]
+    fn assert_result_sets_equal_unordered_with_nested_documents() {
+        let expected = vec![
+            doc! {"a": {"b": 1}},
+            doc! {"a": {"b": 2}},
+            doc! {"a": {"b": 3}},
+        ];
+        let actual = vec![
+            doc! {"a": {"b": 3}},
+            doc! {"a": {"b": 2}},
+            doc! {"a": {"b": 1}},
+        ];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_ordered_with_nested_documents() {
+        let expected = vec![
+            doc! {"a": {"b": 1}},
+            doc! {"a": {"b": 2}},
+            doc! {"a": {"b": 3}},
+        ];
+        let actual = vec![
+            doc! {"a": {"b": 1}},
+            doc! {"a": {"b": 2}},
+            doc! {"a": {"b": 3}},
+        ];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_unordered_with_nested_documents_different_values() {
+        let expected = vec![
+            doc! {"a": {"b": 1}},
+            doc! {"a": {"b": 2}},
+            doc! {"a": {"b": 3}},
+        ];
+        let actual = vec![
+            doc! {"a": {"b": 3}},
+            doc! {"a": {"b": 2}},
+            doc! {"a": {"b": 4}},
+        ];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_result_sets_not_equal_ordered_with_nested_documents_different_values() {
+        let expected = vec![
+            doc! {"a": {"b": 1}},
+            doc! {"a": {"b": 2}},
+            doc! {"a": {"b": 3}},
+        ];
+        let actual = vec![
+            doc! {"a": {"b": 1}},
+            doc! {"a": {"b": 4}},
+            doc! {"a": {"b": 3}},
+        ];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_unordered_with_nested_documents_same_values_different_order() {
+        let expected = vec![
+            doc! {"a": {"b": 1, "c": 1}},
+            doc! {"a": {"b": 2, "c": 2}},
+            doc! {"a": {"b": 3, "c": 3}},
+        ];
+        let actual = vec![
+            doc! {"a": {"c": 3, "b": 3}},
+            doc! {"a": {"c": 1, "b": 1}},
+            doc! {"a": {"b": 2, "c": 2}},
+        ];
+        assert_result_sets_equal(expected, actual, false, false, "test".into());
+    }
+
+    #[test]
+    fn assert_result_sets_equal_ordered_with_nested_documents_same_values_different_order() {
+        let expected = vec![
+            doc! {"a": {"b": 1, "c": 1}},
+            doc! {"a": {"b": 2, "c": 2}},
+            doc! {"a": {"b": 3, "c": 3}},
+        ];
+        let actual = vec![
+            doc! {"a": {"c": 1, "b": 1}},
+            doc! {"a": {"b": 2, "c": 2}},
+            doc! {"a": {"c": 3, "b": 3}},
+        ];
+        assert_result_sets_equal(expected, actual, false, true, "test".into());
+    }
 }

--- a/test-utils/src/templates/query_test_body_template
+++ b/test-utils/src/templates/query_test_body_template
@@ -83,40 +83,12 @@ pub fn {name}() {{
     let type_compare = test.options.type_compare.unwrap_or(false);
 
     if let Some(expected_results) = test.expectations.result.clone() {{
-        assert_eq!(
-            expected_results.len(),
-            result.len(),
-            "{{}}: unexpected number of query results\nexpected results: {{:?}}\nactual results: {{:?}}",
-            test.description,
+        assert_result_sets_equal(
             expected_results,
-            result
+            result,
+            type_compare,
+            test.options.ordered.unwrap_or(false),
+            test.description.clone()
         );
-
-        if test.options.ordered.unwrap_or(false) {{
-            for (index, (expected, actual)) in expected_results.iter().zip(result.iter()).enumerate() {{
-                assert!(
-                    // because NaN != NaN, we have to use custom comparison functions
-                    compare_documents(expected, actual, type_compare),
-                    "unexpected query result for {{}} at index {{}}, \nexpected: {{:?}}\nactual: {{:?}}",
-                    test.description,
-                    index,
-                    expected,
-                    actual
-                );
-            }}
-        }} else {{
-            for actual in result.iter() {{
-                assert!(
-                    expected_results.iter().any(|expected| {{
-                        // because NaN != NaN, we have to use custom comparison functions
-                        compare_documents(expected, actual, type_compare)
-                    }}),
-                    "unexpected query result for {{}}, \nexpected results: {{:?}}\nactual results: {{:?}}",
-                    test.description,
-                    expected_results,
-                    actual
-                );
-            }}
-        }}
     }}
 }}

--- a/tests/spec_tests/query_tests/scalar_functions.yml
+++ b/tests/spec_tests/query_tests/scalar_functions.yml
@@ -325,42 +325,42 @@ tests:
 
   - description: MOD correctness tests
     current_db: spec_query_scalar_functions
-    query: "SELECT VALUE {'v': v, 'divisor': divisor, 'n': MOD(v, divisor)} FROM mod AS c"
+    query: "SELECT VALUE {'_id': _id, 'v': v, 'divisor': divisor, 'n': MOD(v, divisor)} FROM mod AS c"
     result:
-      - {'': {'v': { "$numberInt": "-80" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberInt": "-3" }}}
-      - {'': {'v': { "$numberInt": "0" }, 'divisor': { "$numberLong": "7" }, 'n': { "$numberLong": "0" }}}
-      - {'': {'v': { "$numberInt": "80" }, 'divisor': { "$numberDouble": "-7" }, 'n': { "$numberInt": "3" }}}
-      - {'': {'v': { "$numberInt": "80" }, 'divisor': { "$numberDecimal": "0" }, 'n': null }}
-      - {'': {'v': { "$numberInt": "80" }, 'divisor': null, 'n': null }}
-      - {'': {'v': { "$numberInt": "80" }, 'n': null }}
-      - {'': { 'v': { "$numberLong": "80" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberLong": "3" }}}
-      - {'': { 'v': { "$numberLong": "80" }, 'divisor': { "$numberLong": "7" }, 'n': { "$numberLong": "3" }}}
-      - {'': { 'v': { "$numberLong": "80" }, 'divisor': { "$numberDouble": "7" }, 'n': { "$numberLong": "3" }}}
-      - {'': { 'v': { "$numberLong": "80" }, 'divisor': { "$numberDecimal": "7" }, 'n': { "$numberDecimal": "3" }}}
-      - {'': { 'v': { "$numberLong": "80" }, 'divisor': null, 'n': null }}
-      - {'': { 'v': { "$numberLong": "80" }, 'n': null }}
-      - {'': { 'v': { "$numberDouble": "80" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDouble": "3" }}}
-      - {'': { 'v': { "$numberDouble": "80" }, 'divisor': { "$numberLong": "7" }, 'n': { "$numberDouble": "3" }}}
-      - {'': { 'v': { "$numberDouble": "80" }, 'divisor': { "$numberDouble": "7" }, 'n': { "$numberDouble": "3" }}}
-      - {'': { 'v': { "$numberDouble": "80" }, 'divisor': { "$numberDecimal": "7" }, 'n': { "$numberDecimal": "3.0000000000000e1" }}}
-      - {'': { 'v': { "$numberDouble": "80" }, 'divisor': null, 'n': null }}
-      - {'': { 'v': { "$numberDouble": "80" }, 'n': null }}
-      - {'': { 'v': { "$numberDecimal": "80" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDecimal": "3" }}}
-      - {'': { 'v': { "$numberDecimal": "80" }, 'divisor': { "$numberLong": "7" }, 'n': { "$numberDecimal": "3" }}}
-      - {'': { 'v': { "$numberDecimal": "80" }, 'divisor': { "$numberDouble": "7" }, 'n': { "$numberDecimal": "3.00000000000000E1" }}}
-      - {'': { 'v': { "$numberDecimal": "80" }, 'divisor': { "$numberDecimal": "7" }, 'n': { "$numberDecimal": "3" }}}
-      - {'': { 'v': { "$numberDecimal": "80" }, 'divisor': null, 'n': null }}
-      - {'': { 'v': { "$numberDecimal": "80" }, 'n': null }}
-      - {'': { 'v': { "$numberDouble": "NaN" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDouble": "NaN" }}}
-      - {'': { 'v': { "$numberInt": "80" }, 'divisor': { "$numberDouble": "NaN" }, 'n': { "$numberDouble": "NaN" }}}
-      - {'': { 'v': { "$numberDouble": "Infinity" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDouble": "NaN" }}}
-      - {'': { 'v': { "$numberInt": "80" }, 'divisor': { "$numberDouble": "Infinity" }, 'n': { "$numberDouble": "80" }}}
-      - {'': { 'v': { "$numberDouble": "-Infinity" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDouble": "NaN" }}}
-      - {'': { 'v': { "$numberInt": "80" }, 'divisor': { "$numberDouble": "-Infinity" }, 'n': { "$numberDouble": "80" }}}
-      - {'': { 'v': null, 'divisor': { "$numberInt": "7" }, 'n': null }}
-      - {'': { 'v': null, 'divisor': null, 'n': null }}
-      - {'': { 'v': null, 'n': null }}
-      - {'': { 'n': null }}
+      - {'': { "_id": 0, 'v': { "$numberInt": "-80" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberInt": "-3" }}}
+      - {'': { "_id": 1, 'v': { "$numberInt": "0" }, 'divisor': { "$numberLong": "7" }, 'n': { "$numberLong": "0" }}}
+      - {'': { "_id": 2, 'v': { "$numberInt": "80" }, 'divisor': { "$numberDouble": "-7" }, 'n': { "$numberInt": "3" }}}
+      - {'': { "_id": 3, 'v': { "$numberInt": "80" }, 'divisor': { "$numberDecimal": "0" }, 'n': null }}
+      - {'': { "_id": 4, 'v': { "$numberInt": "80" }, 'divisor': null, 'n': null }}
+      - {'': { "_id": 5, 'v': { "$numberInt": "80" }, 'n': null }}
+      - {'': { "_id": 6, 'v': { "$numberLong": "80" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberLong": "3" }}}
+      - {'': { "_id": 7, 'v': { "$numberLong": "80" }, 'divisor': { "$numberLong": "7" }, 'n': { "$numberLong": "3" }}}
+      - {'': { "_id": 8, 'v': { "$numberLong": "80" }, 'divisor': { "$numberDouble": "7" }, 'n': { "$numberLong": "3" }}}
+      - {'': { "_id": 9, 'v': { "$numberLong": "80" }, 'divisor': { "$numberDecimal": "7" }, 'n': { "$numberDecimal": "3" }}}
+      - {'': { "_id": 10, 'v': { "$numberLong": "80" }, 'divisor': null, 'n': null }}
+      - {'': { "_id": 11, 'v': { "$numberLong": "80" }, 'n': null }}
+      - {'': { "_id": 12, 'v': { "$numberDouble": "80" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDouble": "3" }}}
+      - {'': { "_id": 13, 'v': { "$numberDouble": "80" }, 'divisor': { "$numberLong": "7" }, 'n': { "$numberDouble": "3" }}}
+      - {'': { "_id": 14, 'v': { "$numberDouble": "80" }, 'divisor': { "$numberDouble": "7" }, 'n': { "$numberDouble": "3" }}}
+      - {'': { "_id": 15, 'v': { "$numberDouble": "80" }, 'divisor': { "$numberDecimal": "7" }, 'n': { "$numberDecimal": "3.0000000000000e0" }}}
+      - {'': { "_id": 16, 'v': { "$numberDouble": "80" }, 'divisor': null, 'n': null }}
+      - {'': { "_id": 17, 'v': { "$numberDouble": "80" }, 'n': null }}
+      - {'': { "_id": 18, 'v': { "$numberDecimal": "80" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDecimal": "3" }}}
+      - {'': { "_id": 19, 'v': { "$numberDecimal": "80" }, 'divisor': { "$numberLong": "7" }, 'n': { "$numberDecimal": "3" }}}
+      - {'': { "_id": 20, 'v': { "$numberDecimal": "80" }, 'divisor': { "$numberDouble": "7" }, 'n': { "$numberDecimal": "3.00000000000000E0" }}}
+      - {'': { "_id": 21, 'v': { "$numberDecimal": "80" }, 'divisor': { "$numberDecimal": "7" }, 'n': { "$numberDecimal": "3" }}}
+      - {'': { "_id": 22, 'v': { "$numberDecimal": "80" }, 'divisor': null, 'n': null }}
+      - {'': { "_id": 23, 'v': { "$numberDecimal": "80" }, 'n': null }}
+      - {'': { "_id": 24, 'v': { "$numberDouble": "NaN" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDouble": "NaN" }}}
+      - {'': { "_id": 25, 'v': { "$numberInt": "80" }, 'divisor': { "$numberDouble": "NaN" }, 'n': { "$numberDouble": "NaN" }}}
+      - {'': { "_id": 26, 'v': { "$numberDouble": "Infinity" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDouble": "NaN" }}}
+      - {'': { "_id": 27, 'v': { "$numberInt": "80" }, 'divisor': { "$numberDouble": "Infinity" }, 'n': { "$numberDouble": "80" }}}
+      - {'': { "_id": 28, 'v': { "$numberDouble": "-Infinity" }, 'divisor': { "$numberInt": "7" }, 'n': { "$numberDouble": "NaN" }}}
+      - {'': { "_id": 29, 'v': { "$numberInt": "80" }, 'divisor': { "$numberDouble": "-Infinity" }, 'n': { "$numberDouble": "80" }}}
+      - {'': { "_id": 30, 'v': null, 'divisor': { "$numberInt": "7" }, 'n': null }}
+      - {'': { "_id": 31, 'v': null, 'divisor': null, 'n': null }}
+      - {'': { "_id": 32, 'v': null, 'n': null }}
+      - {'': { "_id": 33, 'n': null }}
 
   - description: POW correctness tests
     current_db: spec_query_scalar_functions


### PR DESCRIPTION
This PR addressees a bug in the e2e / spec/query result set comparison algorithm; see the jira ticket for full details. The short of it is that the old implementation allowed for the same "expected" row to be reused multiple times by different "actual" rows. This is now fixed so each expected row can only match at most one actual row.

As a result, I had to modify one spec test, `MOD correctness test` since it was only passing because of this bug. The fix was simple: we accidentally had the `Decimal128` values use `e1` (* 10) instead of `e0` (* 1). This wasn't failing before since we do cross-numeric-type comparisons and the same expected rows could be reused by actual rows. That is now fixed.

I wanted to get this one done to ensure our confidence in new spec tests added recently: not only for array functions, but also for the changes in #204 .